### PR TITLE
Add USB passthrough feature with persistent configuration and udev rules

### DIFF
--- a/vm-curator/src/app.rs
+++ b/vm-curator/src/app.rs
@@ -131,6 +131,8 @@ pub struct App {
     pub error_scroll: u16,
     /// Right panel scroll position (for info panel)
     pub info_scroll: u16,
+    /// Raw script view scroll position
+    pub raw_script_scroll: u16,
 }
 
 /// Entry in file browser
@@ -205,6 +207,7 @@ impl App {
             error_detail: None,
             error_scroll: 0,
             info_scroll: 0,
+            raw_script_scroll: 0,
         })
     }
 
@@ -344,6 +347,22 @@ impl App {
             self.selected_usb_devices.remove(pos);
         } else {
             self.selected_usb_devices.push(index);
+        }
+    }
+
+    /// Reload the selected VM's raw script from disk
+    pub fn reload_selected_vm_script(&mut self) {
+        if self.visual_order.is_empty() {
+            return;
+        }
+        if let Some(filtered_idx) = self.visual_order.get(self.selected_vm) {
+            if let Some(actual_idx) = self.filtered_indices.get(*filtered_idx) {
+                if let Some(vm) = self.vms.get_mut(*actual_idx) {
+                    if let Ok(content) = std::fs::read_to_string(&vm.launch_script) {
+                        vm.config.raw_script = content;
+                    }
+                }
+            }
         }
     }
 

--- a/vm-curator/src/hardware/mod.rs
+++ b/vm-curator/src/hardware/mod.rs
@@ -2,4 +2,4 @@ pub mod passthrough;
 pub mod usb;
 
 pub use passthrough::PassthroughConfig;
-pub use usb::{enumerate_usb_devices, UsbDevice};
+pub use usb::{enumerate_usb_devices, install_udev_rules, UdevInstallResult, UsbDevice};

--- a/vm-curator/src/ui/screens/management.rs
+++ b/vm-curator/src/ui/screens/management.rs
@@ -9,6 +9,7 @@ use crate::app::App;
 pub const MENU_ITEMS: &[&str] = &[
     "Boot Options",
     "Snapshots",
+    "USB Passthrough",
     "Reset VM (recreate disk)",
     "Delete VM",
     "View Configuration",
@@ -20,7 +21,7 @@ pub fn render(app: &App, frame: &mut Frame) {
 
     // Calculate dialog size
     let dialog_width = 50.min(area.width.saturating_sub(4));
-    let dialog_height = 16.min(area.height.saturating_sub(4));
+    let dialog_height = 18.min(area.height.saturating_sub(4));
 
     let dialog_area = centered_rect(dialog_width, dialog_height, area);
 
@@ -68,9 +69,10 @@ pub fn render(app: &App, frame: &mut Frame) {
             let description = match i {
                 0 => "Normal, install, or custom ISO boot",
                 1 => "Create, restore, or delete snapshots",
-                2 => "Restore VM to fresh state",
-                3 => "Permanently remove this VM",
-                4 => "View QEMU settings and launch script",
+                2 => "Pass USB devices to the VM",
+                3 => "Restore VM to fresh state",
+                4 => "Permanently remove this VM",
+                5 => "View QEMU settings and launch script",
                 _ => "",
             };
 

--- a/vm-curator/src/vm/lifecycle.rs
+++ b/vm-curator/src/vm/lifecycle.rs
@@ -67,6 +67,17 @@ pub fn launch_vm_sync(vm: &DiscoveredVm, options: &LaunchOptions) -> Result<()> 
     }
 
     args.extend(options.extra_args.clone());
+
+    // Add USB passthrough arguments
+    // These are passed as extra args that the launch.sh script forwards to QEMU
+    if !options.usb_devices.is_empty() {
+        // Add USB controller if passing through devices
+        args.push("-usb".to_string());
+        for usb in &options.usb_devices {
+            args.extend(usb.to_qemu_args());
+        }
+    }
+
     cmd.args(&args);
 
     cmd.stdin(Stdio::null())
@@ -185,4 +196,244 @@ pub fn is_vm_running(vm: &DiscoveredVm) -> bool {
         }
     }
     false
+}
+
+// USB Passthrough configuration markers
+const USB_MARKER_START: &str = "# >>> USB Passthrough (managed by vm-curator) >>>";
+const USB_MARKER_END: &str = "# <<< USB Passthrough <<<";
+
+/// Save USB passthrough configuration to the VM's launch.sh
+pub fn save_usb_passthrough(vm: &DiscoveredVm, devices: &[UsbPassthrough]) -> Result<()> {
+    let script_path = &vm.launch_script;
+    let content = std::fs::read_to_string(script_path)
+        .context("Failed to read launch.sh")?;
+
+    // Remove existing USB passthrough section if present
+    let content = remove_usb_section(&content);
+
+    // Generate new USB passthrough section
+    let usb_section = generate_usb_section(devices);
+
+    // Find where to insert the USB section
+    // We want to add it before the final qemu-system command or at the end
+    let new_content = insert_usb_section(&content, &usb_section);
+
+    // Write back
+    std::fs::write(script_path, new_content)
+        .context("Failed to write launch.sh")?;
+
+    Ok(())
+}
+
+/// Load USB passthrough configuration from the VM's launch.sh
+pub fn load_usb_passthrough(vm: &DiscoveredVm) -> Vec<UsbPassthrough> {
+    let script_path = &vm.launch_script;
+    let content = match std::fs::read_to_string(script_path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+
+    parse_usb_section(&content)
+}
+
+fn remove_usb_section(content: &str) -> String {
+    let mut result = String::new();
+    let mut in_usb_section = false;
+
+    for line in content.lines() {
+        if line.trim() == USB_MARKER_START {
+            in_usb_section = true;
+            continue;
+        }
+        if line.trim() == USB_MARKER_END {
+            in_usb_section = false;
+            continue;
+        }
+        if !in_usb_section {
+            // Also remove any $USB_PASSTHROUGH_ARGS references from qemu command lines
+            let cleaned_line = remove_usb_args_from_line(line);
+            result.push_str(&cleaned_line);
+            result.push('\n');
+        }
+    }
+
+    // Remove trailing empty lines that may have accumulated
+    while result.ends_with("\n\n") {
+        result.pop();
+    }
+
+    result
+}
+
+fn remove_usb_args_from_line(line: &str) -> String {
+    // Remove $USB_PASSTHROUGH_ARGS from a line (with various formats)
+    line.replace(" $USB_PASSTHROUGH_ARGS", "")
+        .replace("$USB_PASSTHROUGH_ARGS ", "")
+        .replace("$USB_PASSTHROUGH_ARGS", "")
+}
+
+fn generate_usb_section(devices: &[UsbPassthrough]) -> String {
+    if devices.is_empty() {
+        return String::new();
+    }
+
+    let mut section = String::new();
+    section.push_str(USB_MARKER_START);
+    section.push('\n');
+    section.push_str("USB_PASSTHROUGH_ARGS=\"-usb");
+
+    for device in devices {
+        section.push_str(&format!(
+            " -device usb-host,vendorid=0x{:04x},productid=0x{:04x}",
+            device.vendor_id, device.product_id
+        ));
+    }
+
+    section.push_str("\"\n");
+    section.push_str(USB_MARKER_END);
+    section.push('\n');
+
+    section
+}
+
+fn insert_usb_section(content: &str, usb_section: &str) -> String {
+    if usb_section.is_empty() {
+        return content.to_string();
+    }
+
+    let lines: Vec<&str> = content.lines().collect();
+    let mut result = String::new();
+    let mut inserted_section = false;
+    let mut modified_qemu_cmd = false;
+
+    // First pass: find the qemu command start line index
+    let mut qemu_start_idx: Option<usize> = None;
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        let is_qemu_line = (trimmed.starts_with("qemu-system-")
+            || trimmed.starts_with("exec qemu-system-")
+            || trimmed.starts_with("\"$QEMU\"")
+            || trimmed.starts_with("$QEMU "))
+            && !trimmed.starts_with('#');
+
+        if is_qemu_line {
+            qemu_start_idx = Some(i);
+            break;
+        }
+    }
+
+    // Find the last line of the qemu command (the one without trailing \)
+    let mut qemu_end_idx: Option<usize> = None;
+    if let Some(start) = qemu_start_idx {
+        for i in start..lines.len() {
+            let trimmed = lines[i].trim();
+            if !trimmed.ends_with('\\') {
+                qemu_end_idx = Some(i);
+                break;
+            }
+        }
+        // If all lines end with \, use the last line
+        if qemu_end_idx.is_none() {
+            qemu_end_idx = Some(lines.len() - 1);
+        }
+    }
+
+    for (i, line) in lines.iter().enumerate() {
+        // Insert USB section before the qemu command
+        if Some(i) == qemu_start_idx && !inserted_section {
+            result.push_str(usb_section);
+            result.push('\n');
+            inserted_section = true;
+        }
+
+        // Modify the last line of the qemu command to include $USB_PASSTHROUGH_ARGS
+        if Some(i) == qemu_end_idx && !modified_qemu_cmd {
+            let trimmed = line.trim_end();
+            // Add $USB_PASSTHROUGH_ARGS before any trailing comment
+            if let Some(comment_pos) = trimmed.find(" #") {
+                let (cmd, comment) = trimmed.split_at(comment_pos);
+                result.push_str(cmd);
+                result.push_str(" $USB_PASSTHROUGH_ARGS");
+                result.push_str(comment);
+            } else {
+                result.push_str(trimmed);
+                result.push_str(" $USB_PASSTHROUGH_ARGS");
+            }
+            result.push('\n');
+            modified_qemu_cmd = true;
+            continue;
+        }
+
+        result.push_str(line);
+        if i < lines.len() - 1 {
+            result.push('\n');
+        }
+    }
+
+    // If we didn't find a qemu line, append at the end
+    if !inserted_section {
+        if !result.ends_with('\n') {
+            result.push('\n');
+        }
+        result.push('\n');
+        result.push_str(usb_section);
+    }
+
+    // Ensure file ends with newline
+    if !result.ends_with('\n') {
+        result.push('\n');
+    }
+
+    result
+}
+
+fn parse_usb_section(content: &str) -> Vec<UsbPassthrough> {
+    let mut devices = Vec::new();
+    let mut in_usb_section = false;
+
+    for line in content.lines() {
+        if line.trim() == USB_MARKER_START {
+            in_usb_section = true;
+            continue;
+        }
+        if line.trim() == USB_MARKER_END {
+            in_usb_section = false;
+            continue;
+        }
+        if in_usb_section && line.contains("USB_PASSTHROUGH_ARGS=") {
+            // Parse the USB args line
+            // Format: USB_PASSTHROUGH_ARGS="-usb -device usb-host,vendorid=0x1234,productid=0x5678 ..."
+            for part in line.split("-device usb-host,") {
+                if part.contains("vendorid=") && part.contains("productid=") {
+                    if let (Some(vid), Some(pid)) = (
+                        extract_hex_value(part, "vendorid="),
+                        extract_hex_value(part, "productid="),
+                    ) {
+                        devices.push(UsbPassthrough {
+                            vendor_id: vid,
+                            product_id: pid,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    devices
+}
+
+fn extract_hex_value(s: &str, prefix: &str) -> Option<u16> {
+    let start = s.find(prefix)? + prefix.len();
+    let rest = &s[start..];
+
+    // Find end of hex value (comma, space, quote, or end of string)
+    let end = rest.find(|c: char| c == ',' || c == ' ' || c == '"' || c == '\'')
+        .unwrap_or(rest.len());
+
+    let hex_str = &rest[..end];
+
+    // Handle 0x prefix
+    let hex_str = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+
+    u16::from_str_radix(hex_str, 16).ok()
 }

--- a/vm-curator/src/vm/mod.rs
+++ b/vm-curator/src/vm/mod.rs
@@ -5,6 +5,6 @@ pub mod qemu_config;
 pub mod snapshot;
 
 pub use discovery::{discover_vms, group_vms_by_category, DiscoveredVm};
-pub use lifecycle::{launch_vm_sync, LaunchOptions, UsbPassthrough};
+pub use lifecycle::{launch_vm_sync, load_usb_passthrough, save_usb_passthrough, LaunchOptions, UsbPassthrough};
 pub use qemu_config::{BootMode, QemuConfig, VgaType};
 pub use snapshot::{create_snapshot, delete_snapshot, list_snapshots, restore_snapshot, validate_snapshot_name, Snapshot};


### PR DESCRIPTION
- Add USB Passthrough option to management menu with save/load from launch.sh
- Implement udev rules generation and installation (pkexec/sudo) for USB permissions
- Add scrolling support to raw script viewer
- Improve USB devices screen with selection count, help text, and better styling
- Auto-reload VM script after USB config changes