### PR TITLE
Add networking infrastructure: backends, port forwarding, and settings

### DIFF
--- a/src/commands/qemu_system.rs
+++ b/src/commands/qemu_system.rs
@@ -3,8 +3,8 @@
 //! Provides utilities for checking QEMU availability and capabilities.
 
 use anyhow::{Context, Result};
-use std::path::Path;
-use std::process::Command;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
 /// Get QEMU version information
 pub fn get_qemu_version(emulator: &str) -> Result<String> {
@@ -119,4 +119,108 @@ pub fn get_kvm_info() -> Option<String> {
     }
 
     Some("kvm".to_string())
+}
+
+/// Information about available network backends
+#[derive(Debug, Clone)]
+pub struct NetworkCapabilities {
+    pub passt_available: bool,
+    pub bridge_helper_path: Option<PathBuf>,
+    pub bridge_helper_configured: bool,
+    pub system_bridges: Vec<String>,
+}
+
+/// Detect all available networking capabilities
+pub fn detect_network_capabilities() -> NetworkCapabilities {
+    let passt_available = is_passt_available();
+    let bridge_helper_path = find_bridge_helper();
+    let bridge_helper_configured = bridge_helper_path
+        .as_ref()
+        .map(|p| is_bridge_helper_configured(p))
+        .unwrap_or(false);
+    let system_bridges = list_system_bridges();
+
+    NetworkCapabilities {
+        passt_available,
+        bridge_helper_path,
+        bridge_helper_configured,
+        system_bridges,
+    }
+}
+
+/// Check if passt binary is available
+fn is_passt_available() -> bool {
+    Command::new("passt")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Find qemu-bridge-helper binary
+fn find_bridge_helper() -> Option<PathBuf> {
+    let paths = [
+        "/usr/lib/qemu/qemu-bridge-helper",
+        "/usr/libexec/qemu-bridge-helper",
+        "/usr/libexec/qemu/qemu-bridge-helper",
+    ];
+
+    for path in paths {
+        let p = PathBuf::from(path);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// Check if bridge helper has setuid or CAP_NET_ADMIN
+fn is_bridge_helper_configured(path: &Path) -> bool {
+    // Check setuid bit
+    if let Ok(metadata) = std::fs::metadata(path) {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = metadata.permissions().mode();
+        if mode & 0o4000 != 0 {
+            return true;
+        }
+    }
+
+    // Check capabilities via getcap
+    if let Ok(output) = Command::new("getcap")
+        .arg(path)
+        .output()
+    {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if stdout.contains("cap_net_admin") {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// List bridges currently on the system
+fn list_system_bridges() -> Vec<String> {
+    let output = match Command::new("ip")
+        .args(["-o", "link", "show", "type", "bridge"])
+        .output()
+    {
+        Ok(o) => o,
+        Err(_) => return Vec::new(),
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut bridges = Vec::new();
+    for line in stdout.lines() {
+        // Format: "N: bridgename: <FLAGS> ..."
+        if let Some(name) = line.split(':').nth(1) {
+            let name = name.trim();
+            if !name.is_empty() {
+                bridges.push(name.to_string());
+            }
+        }
+    }
+    bridges
 }

--- a/src/ui/screens/help.rs
+++ b/src/ui/screens/help.rs
@@ -7,7 +7,7 @@ use ratatui::{
 pub fn render(frame: &mut Frame) {
     let area = frame.area();
     let dialog_width = 55.min(area.width.saturating_sub(4));
-    let dialog_height = 22.min(area.height.saturating_sub(4));
+    let dialog_height = 28.min(area.height.saturating_sub(4));
 
     let dialog_area = centered_rect(dialog_width, dialog_height, area);
     frame.render_widget(Clear, dialog_area);
@@ -41,6 +41,13 @@ pub fn render(frame: &mut Frame) {
         key_line("x", "Stop selected VM (graceful shutdown)"),
         key_line("c", "Create new VM"),
         key_line("/", "Search/filter VMs"),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Management Menu",
+            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        key_line("Network", "Backend, port forwarding"),
         Line::from(""),
         Line::from(Span::styled(
             "General",

--- a/src/ui/screens/management.rs
+++ b/src/ui/screens/management.rs
@@ -24,6 +24,7 @@ pub enum MenuAction {
     UsbPassthrough,
     PciPassthrough,
     SharedFolders,
+    NetworkSettings,
     MultiGpuPassthrough,
     SingleGpuPassthrough,
     ChangeDisplay,
@@ -36,11 +37,6 @@ pub enum MenuAction {
 /// Get menu items based on config and VM state
 pub fn get_menu_items(vm: &DiscoveredVm, config: &Config) -> Vec<MenuItem> {
     let mut items = vec![
-        MenuItem {
-            name: "Stop VM",
-            description: "Shut down the running VM (ACPI poweroff)",
-            action: MenuAction::StopVm,
-        },
         MenuItem {
             name: "Boot Options",
             description: "Normal, install, or custom ISO boot",
@@ -65,6 +61,11 @@ pub fn get_menu_items(vm: &DiscoveredVm, config: &Config) -> Vec<MenuItem> {
             name: "Shared Folders",
             description: "Share host directories with the VM (9p)",
             action: MenuAction::SharedFolders,
+        },
+        MenuItem {
+            name: "Network Settings",
+            description: "Configure networking backend and port forwarding",
+            action: MenuAction::NetworkSettings,
         },
     ];
 
@@ -98,6 +99,12 @@ pub fn get_menu_items(vm: &DiscoveredVm, config: &Config) -> Vec<MenuItem> {
             action: MenuAction::RenameVm,
         },
     ]);
+
+    items.push(MenuItem {
+        name: "Stop VM",
+        description: "Shut down the running VM (ACPI poweroff)",
+        action: MenuAction::StopVm,
+    });
 
     // Add dangerous operations at the end
     items.extend([

--- a/src/ui/screens/mod.rs
+++ b/src/ui/screens/mod.rs
@@ -4,6 +4,7 @@ pub mod help;
 pub mod main_menu;
 pub mod management;
 pub mod multi_gpu_setup;
+pub mod network_settings;
 pub mod pci_passthrough;
 pub mod settings;
 pub mod shared_folders;


### PR DESCRIPTION
## Summary
- Add `NetworkBackend` enum (user/passt/bridge/none), `PortForward` types, and `NetworkCapabilities` detection for passt, bridge-helper, and system bridges
- Parse network backends and port forwarding rules from launch.sh scripts with new tests
- Add Network Settings screen accessible from management menu for editing backend, adapter model, and port forwarding on existing VMs
- Update create wizard to generate correct network args for all backends
- Reorder management menu (Stop VM moved to bottom) and add help screen entry for networking

## Test plan
- [x] `cargo build` — clean, no warnings
- [x] `cargo test` — all 64 tests pass (includes new network arg generation and port forward parsing tests)
- [x] `cargo build --release` — clean
- [ ] Manual: open Network Settings on an existing VM, verify backend cycling and port forward editing
- [ ] Manual: create wizard step 4, verify network backend and port forward fields work
- [ ] Manual: verify bridge backend generates correct launch.sh args

🤖 Generated with [Claude Code](https://claude.com/claude-code)