### PR TITLE
Spring cleaning: MAC addresses, default ISO path, 3D acceleration toggle

### DIFF
--- a/assets/metadata/settings_help.toml
+++ b/assets/metadata/settings_help.toml
@@ -10,6 +10,13 @@ description = """
 The directory where your VMs are stored. Each VM lives in its own subdirectory \
 containing a launch.sh script and disk images. You can use ~ for your home directory."""
 
+[default_iso_path]
+title = "Default ISO Path"
+description = """
+The directory the ISO file browser opens to when creating VMs or changing media. \
+The path must exist; leave empty to fall back to your home directory. \
+You can also set or clear this from the Create VM wizard's ISO step."""
+
 [default_memory]
 title = "Default Memory"
 description = """

--- a/src/app.rs
+++ b/src/app.rs
@@ -226,6 +226,8 @@ pub struct WizardQemuConfig {
     pub port_forwards: Vec<PortForward>,
     /// Bridge name when backend is "bridge"
     pub bridge_name: Option<String>,
+    /// Custom MAC address for the NIC (canonical aa:bb:cc:dd:ee:ff form)
+    pub mac_address: Option<String>,
     /// Additional QEMU arguments
     pub extra_args: Vec<String>,
     /// BIOS/ROM file path (for classic Mac and other systems needing custom firmware)
@@ -254,6 +256,7 @@ impl Default for WizardQemuConfig {
             network_backend: "user".to_string(),
             port_forwards: Vec::new(),
             bridge_name: None,
+            mac_address: None,
             extra_args: Vec::new(),
             bios_path: None,
         }
@@ -288,6 +291,7 @@ impl WizardQemuConfig {
             network_backend: profile.network_backend.clone(),
             port_forwards: Vec::new(),
             bridge_name: None,
+            mac_address: None,
             extra_args: profile.extra_args.clone(),
             bios_path: None,
         }
@@ -392,6 +396,7 @@ pub enum WizardField {
     DiskSize,
     MemoryMb,
     CpuCores,
+    MacAddress,
     CustomOsId,
     CustomOsName,
     CustomOsPublisher,
@@ -574,6 +579,12 @@ pub struct NetworkSettingsState {
     pub backend: String,
     pub bridge_name: Option<String>,
     pub port_forwards: Vec<PortForward>,
+    /// Custom MAC address (canonical aa:bb:cc:dd:ee:ff form). `None` = QEMU default.
+    pub mac_address: Option<String>,
+    /// In-place editor buffer for the MAC field.
+    pub mac_edit_buffer: String,
+    /// Whether the MAC field is currently in edit mode.
+    pub editing_mac: bool,
     pub selected_field: usize,
     pub editing_port_forwards: bool,
     pub pf_selected: usize,
@@ -1443,6 +1454,20 @@ impl App {
     pub fn selected_vm_pid(&self) -> Option<u32> {
         let vm = self.selected_vm()?;
         self.running_vms.get(&vm.id).copied()
+    }
+
+    /// Seed `file_browser_dir` for ISO selection: prefer the configured
+    /// default ISO path if it still exists, else the user's home directory.
+    pub fn seed_iso_browser_dir(&mut self) {
+        let target = self
+            .config
+            .default_iso_path
+            .as_ref()
+            .filter(|p| p.is_dir())
+            .cloned()
+            .or_else(dirs::home_dir)
+            .unwrap_or_else(|| PathBuf::from("/"));
+        self.file_browser_dir = target;
     }
 
     /// Load file browser entries for current directory

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,6 +15,11 @@ pub struct Config {
     /// Default snapshot name prefix
     pub snapshot_prefix: String,
 
+    /// Default directory the ISO file browser should open to.
+    /// `None` = fall back to home directory.
+    #[serde(default)]
+    pub default_iso_path: Option<PathBuf>,
+
     // === VM Creation Defaults ===
     /// Default memory for new VMs (MB)
     pub default_memory_mb: u32,
@@ -64,6 +69,7 @@ impl Default for Config {
             metadata_path: config_dir.join("metadata"),
             ascii_art_path: config_dir.join("ascii"),
             snapshot_prefix: "snapshot".to_string(),
+            default_iso_path: None,
 
             // VM Creation Defaults
             default_memory_mb: 4096,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -691,12 +691,16 @@ fn handle_management(app: &mut App, key: KeyEvent) -> Result<()> {
                                     }
                                 }).unwrap_or_else(|| ("user".to_string(), None));
                                 let port_forwards = net.map(|n| n.port_forwards.clone()).unwrap_or_default();
+                                let mac_address = net.and_then(|n| n.mac_address.clone());
 
                                 app.network_settings_state = Some(crate::app::NetworkSettingsState {
                                     model,
                                     backend,
                                     bridge_name,
                                     port_forwards,
+                                    mac_address: mac_address.clone(),
+                                    mac_edit_buffer: mac_address.unwrap_or_default(),
+                                    editing_mac: false,
                                     selected_field: 0,
                                     editing_port_forwards: false,
                                     pf_selected: 0,
@@ -716,6 +720,25 @@ fn handle_management(app: &mut App, key: KeyEvent) -> Result<()> {
                             screens::single_gpu_setup::init_single_gpu_config(app);
                             app.single_gpu_selected_field = 0;
                             app.push_screen(Screen::SingleGpuSetup);
+                        }
+                        MenuAction::Toggle3dAccel => {
+                            if let Some(vm) = app.selected_vm() {
+                                let script_path = vm.launch_script.clone();
+                                let was_on = vm.config.has_gl_acceleration();
+                                match toggle_vm_gl_acceleration(&script_path) {
+                                    Ok(result) => {
+                                        let now = if !was_on { "enabled" } else { "disabled" };
+                                        let extra = if result.display_swapped_to_sdl {
+                                            " (display switched to SDL)"
+                                        } else {
+                                            ""
+                                        };
+                                        app.set_status(format!("3D acceleration {}{}", now, extra));
+                                        app.reload_selected_vm_script();
+                                    }
+                                    Err(e) => app.set_status(format!("Failed to toggle 3D: {}", e)),
+                                }
+                            }
                         }
                         MenuAction::ChangeDisplay => {
                             app.selected_menu_item = 0;
@@ -1212,6 +1235,7 @@ fn handle_boot_options(app: &mut App, key: KeyEvent) -> Result<()> {
                 }
                 2 => {
                     // Open file browser for ISO selection
+                    app.seed_iso_browser_dir();
                     app.load_file_browser(FileBrowserMode::Iso);
                     app.push_screen(Screen::FileBrowser);
                 }
@@ -1280,6 +1304,67 @@ fn handle_display_options(app: &mut App, key: KeyEvent) -> Result<()> {
         _ => {}
     }
     Ok(())
+}
+
+/// Result of toggling 3D acceleration on an existing VM.
+struct GlToggleResult {
+    /// Whether the toggle also auto-swapped the display backend from gtk to sdl
+    /// (sdl gives noticeably better 3D performance than gtk).
+    display_swapped_to_sdl: bool,
+}
+
+/// Toggle para-virtualized 3D acceleration in a VM's launch.sh.
+///
+/// Enable: replace `-vga <X>` with `-device virtio-vga-gl`, append `,gl=on`
+///   to the `-display <X>` line, and swap gtk → sdl if necessary.
+/// Disable: replace `-device virtio-vga-gl` with `-vga virtio`, strip
+///   `,gl=on` from the display line.
+fn toggle_vm_gl_acceleration(script_path: &std::path::Path) -> Result<GlToggleResult> {
+    let content = std::fs::read_to_string(script_path)?;
+
+    let currently_on = content.contains("virtio-vga-gl") || content.contains("gl=on");
+    let mut display_swapped_to_sdl = false;
+
+    let new_content = if currently_on {
+        // === Disable 3D ===
+        // Replace `-device virtio-vga-gl` with `-vga virtio` (best Linux default
+        // when we can't recover the original VGA choice).
+        let device_re = Regex::new(r"-device\s+virtio-vga-gl(?:[,\w=-]*)?")?;
+        let after_device = device_re.replace_all(&content, "-vga virtio").to_string();
+        // Strip `,gl=on` from `-display <X>,gl=on`.
+        let display_re = Regex::new(r"(-display\s+[\w-]+),gl=on")?;
+        display_re.replace_all(&after_device, "$1").to_string()
+    } else {
+        // === Enable 3D ===
+        // Replace `-vga <X>` with `-device virtio-vga-gl`.
+        let vga_re = Regex::new(r"-vga\s+[\w-]+")?;
+        let after_vga = if vga_re.is_match(&content) {
+            vga_re.replace_all(&content, "-device virtio-vga-gl").to_string()
+        } else {
+            content.clone()
+        };
+        // Add `,gl=on` to `-display <X>` if not already there. Swap gtk → sdl
+        // for noticeably better 3D performance.
+        let display_re = Regex::new(r"-display\s+([\w-]+)(,gl=on)?")?;
+        let mut swapped = false;
+        let after_display = display_re
+            .replace_all(&after_vga, |caps: &regex::Captures| {
+                let backend = caps.get(1).map(|m| m.as_str()).unwrap_or("sdl");
+                let new_backend = if backend == "gtk" {
+                    swapped = true;
+                    "sdl"
+                } else {
+                    backend
+                };
+                format!("-display {},gl=on", new_backend)
+            })
+            .to_string();
+        display_swapped_to_sdl = swapped;
+        after_display
+    };
+
+    std::fs::write(script_path, new_content)?;
+    Ok(GlToggleResult { display_swapped_to_sdl })
 }
 
 /// Update the display setting in a VM's launch script
@@ -1656,13 +1741,18 @@ fn render_search(app: &App, frame: &mut Frame) {
 }
 
 fn render_file_browser(app: &App, frame: &mut Frame) {
-    use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState};
+    use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph};
     use ratatui::layout::{Layout, Direction, Constraint};
     use crate::app::FileBrowserMode;
 
+    let show_default_iso_checkbox =
+        app.wizard_state.is_some() && app.file_browser_mode == FileBrowserMode::Iso;
+
     let area = frame.area();
     let dialog_width = 60.min(area.width.saturating_sub(4));
-    let dialog_height = 20.min(area.height.saturating_sub(4));
+    let base_height: u16 = 20;
+    let dialog_height = (base_height + if show_default_iso_checkbox { 2 } else { 0 })
+        .min(area.height.saturating_sub(4));
 
     let dialog_area = centered_rect(dialog_width, dialog_height, area);
     frame.render_widget(Clear, dialog_area);
@@ -1696,16 +1786,40 @@ fn render_file_browser(app: &App, frame: &mut Frame) {
         ])
         .split(inner);
 
-    // Add top padding
+    // Vertical layout: top padding, content, optional checkbox footer.
+    let v_constraints: Vec<Constraint> = if show_default_iso_checkbox {
+        vec![
+            Constraint::Length(1), // Top padding
+            Constraint::Min(1),    // Content
+            Constraint::Length(2), // Footer (checkbox + hint)
+        ]
+    } else {
+        vec![Constraint::Length(1), Constraint::Min(1)]
+    };
+
     let v_chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1),  // Top padding
-            Constraint::Min(1),     // Content
-        ])
+        .constraints(v_constraints)
         .split(h_chunks[1]);
 
     let content_area = v_chunks[1];
+
+    if show_default_iso_checkbox {
+        let footer_area = v_chunks[2];
+        let is_default = app
+            .config
+            .default_iso_path
+            .as_ref()
+            .map(|p| p == &app.file_browser_dir)
+            .unwrap_or(false);
+        let mark = if is_default { "[x]" } else { "[ ]" };
+        let line = Line::from(vec![
+            Span::styled(mark, Style::default().fg(Color::Yellow)),
+            Span::raw(" Set as Default ISO Path "),
+            Span::styled("[d] toggle", Style::default().fg(Color::DarkGray)),
+        ]);
+        frame.render_widget(Paragraph::new(line), footer_area);
+    }
 
     if app.file_browser_entries.is_empty() {
         let msg_text = match app.file_browser_mode {
@@ -1759,6 +1873,31 @@ fn handle_file_browser(app: &mut App, key: KeyEvent) -> Result<()> {
         KeyCode::Esc => app.pop_screen(),
         KeyCode::Char('j') | KeyCode::Down => app.file_browser_next(),
         KeyCode::Char('k') | KeyCode::Up => app.file_browser_prev(),
+        KeyCode::Char('d')
+            if app.wizard_state.is_some() && app.file_browser_mode == FileBrowserMode::Iso =>
+        {
+            let already_default = app
+                .config
+                .default_iso_path
+                .as_ref()
+                .map(|p| p == &app.file_browser_dir)
+                .unwrap_or(false);
+            if already_default {
+                app.config.default_iso_path = None;
+            } else {
+                app.config.default_iso_path = Some(app.file_browser_dir.clone());
+            }
+            match app.config.save() {
+                Ok(()) => {
+                    if app.config.default_iso_path.is_some() {
+                        app.set_status("Default ISO path updated");
+                    } else {
+                        app.set_status("Default ISO path cleared");
+                    }
+                }
+                Err(e) => app.set_status(format!("Failed to save config: {}", e)),
+            }
+        }
         KeyCode::Enter => {
             if let Some(selected_path) = app.file_browser_enter() {
                 match app.file_browser_mode {

--- a/src/ui/screens/create_wizard.rs
+++ b/src/ui/screens/create_wizard.rs
@@ -1184,6 +1184,7 @@ fn handle_step_select_iso(app: &mut App, key: KeyEvent) -> Result<()> {
                 app.push_screen(crate::app::Screen::FileBrowser);
             } else if focus == browse_idx {
                 // Browse for ISO - open file browser
+                app.seed_iso_browser_dir();
                 app.load_file_browser(crate::app::FileBrowserMode::Iso);
                 app.push_screen(crate::app::Screen::FileBrowser);
             } else if focus == recovery_browse_idx {
@@ -1653,6 +1654,7 @@ enum QemuField {
     NetBackend,
     BridgeName,
     PortForwards,
+    MacAddress,
     DiskInterface,
     Display,
     Kvm,
@@ -1674,19 +1676,20 @@ impl QemuField {
             5 => Self::NetBackend,
             6 => Self::BridgeName,
             7 => Self::PortForwards,
-            8 => Self::DiskInterface,
-            9 => Self::Display,
-            10 => Self::Kvm,
-            11 => Self::GlAccel,
-            12 => Self::Uefi,
-            13 => Self::Tpm,
-            14 => Self::UsbTablet,
+            8 => Self::MacAddress,
+            9 => Self::DiskInterface,
+            10 => Self::Display,
+            11 => Self::Kvm,
+            12 => Self::GlAccel,
+            13 => Self::Uefi,
+            14 => Self::Tpm,
+            15 => Self::UsbTablet,
             _ => Self::RtcLocal,
         }
     }
 
     fn count() -> usize {
-        16
+        17
     }
 }
 
@@ -1862,10 +1865,35 @@ fn render_step_configure_qemu(app: &App, frame: &mut Frame, area: Rect) {
                 "[Enter] edit",
             ));
         }
+
+        // MAC address (text input, hidden when network model is "none")
+        let mac_selected = focus == 8;
+        let mac_editing = matches!(state.editing_field, Some(WizardField::MacAddress));
+        let mac_value = if mac_editing {
+            format!("{}|", state.wizard_edit_buffer)
+        } else if let Some(mac) = config.mac_address.as_deref() {
+            mac.to_string()
+        } else {
+            "(auto)".to_string()
+        };
+        let mac_hint = if mac_editing {
+            "[Enter] Done  [Esc] Cancel"
+        } else if mac_selected {
+            "[Tab] Edit  [g] Generate  [c] Clear"
+        } else {
+            ""
+        };
+        lines.push(render_field_line(
+            "MAC:",
+            &mac_value,
+            mac_selected,
+            mac_editing,
+            mac_hint,
+        ));
     }
 
     // Disk Interface (cycle)
-    let disk_selected = focus == 8;
+    let disk_selected = focus == 9;
     lines.push(render_field_line(
         "Disk I/F:",
         &config.disk_interface,
@@ -1875,7 +1903,7 @@ fn render_step_configure_qemu(app: &App, frame: &mut Frame, area: Rect) {
     ));
 
     // Display (cycle)
-    let disp_selected = focus == 9;
+    let disp_selected = focus == 10;
     lines.push(render_field_line(
         "Display:",
         &config.display,
@@ -1888,27 +1916,27 @@ fn render_step_configure_qemu(app: &App, frame: &mut Frame, area: Rect) {
     lines.push(Line::styled("  Features (toggle with Space):", Style::default().fg(Color::DarkGray)));
 
     // KVM toggle
-    let kvm_selected = focus == 10;
+    let kvm_selected = focus == 11;
     lines.push(render_toggle_line("KVM Accel:", config.enable_kvm, kvm_selected));
 
     // 3D/GL acceleration toggle
-    let gl_selected = focus == 11;
+    let gl_selected = focus == 12;
     lines.push(render_toggle_line("3D Accel:", config.gl_acceleration, gl_selected));
 
     // UEFI toggle
-    let uefi_selected = focus == 12;
+    let uefi_selected = focus == 13;
     lines.push(render_toggle_line("UEFI Boot:", config.uefi, uefi_selected));
 
     // TPM toggle
-    let tpm_selected = focus == 13;
+    let tpm_selected = focus == 14;
     lines.push(render_toggle_line("TPM 2.0:", config.tpm, tpm_selected));
 
     // USB Tablet toggle
-    let usb_selected = focus == 14;
+    let usb_selected = focus == 15;
     lines.push(render_toggle_line("USB Tablet:", config.usb_tablet, usb_selected));
 
     // RTC Local toggle
-    let rtc_selected = focus == 15;
+    let rtc_selected = focus == 16;
     lines.push(render_toggle_line("RTC Local:", config.rtc_localtime, rtc_selected));
 
     let settings = Paragraph::new(lines);
@@ -2081,6 +2109,17 @@ fn get_field_notes(app: &App, focus: usize) -> String {
             Press Enter to edit forwarding rules.",
             os_name
         ),
+        QemuField::MacAddress => format!(
+            "MAC address for {}.\n\n\
+            Leave empty for QEMU to pick one. \
+            Set explicitly when you need a stable MAC \
+            (DHCP reservations, license-bound guests, \
+            host firewall rules).\n\n\
+            Format: aa:bb:cc:dd:ee:ff\n\
+            Press [g] to generate a random MAC \
+            with QEMU's safe 52:54:00 prefix.",
+            os_name
+        ),
         QemuField::DiskInterface => format!(
             "Disk interface for {}.\n\n\
             virtio: Best perf (needs driver)\n\
@@ -2151,6 +2190,48 @@ fn handle_step_configure_qemu(app: &mut App, key: KeyEvent) -> Result<()> {
     let editing_cpu = app.wizard_state.as_ref()
         .map(|s| matches!(s.editing_field, Some(WizardField::CpuCores)))
         .unwrap_or(false);
+    let editing_mac = app.wizard_state.as_ref()
+        .map(|s| matches!(s.editing_field, Some(WizardField::MacAddress)))
+        .unwrap_or(false);
+
+    if editing_mac {
+        let mut bad_mac: Option<String> = None;
+        if let Some(ref mut state) = app.wizard_state {
+            match key.code {
+                KeyCode::Esc => {
+                    state.editing_field = None;
+                    state.wizard_edit_buffer.clear();
+                }
+                KeyCode::Enter | KeyCode::Tab => {
+                    let trimmed = state.wizard_edit_buffer.trim().to_string();
+                    if trimmed.is_empty() {
+                        state.qemu_config.mac_address = None;
+                        state.editing_field = None;
+                        state.wizard_edit_buffer.clear();
+                    } else if crate::vm::mac::is_valid_mac(&trimmed) {
+                        state.qemu_config.mac_address = Some(trimmed.to_lowercase());
+                        state.editing_field = None;
+                        state.wizard_edit_buffer.clear();
+                    } else {
+                        bad_mac = Some(trimmed);
+                    }
+                }
+                KeyCode::Char(c) if c.is_ascii_hexdigit() || c == ':' => {
+                    if state.wizard_edit_buffer.len() < 17 {
+                        state.wizard_edit_buffer.push(c);
+                    }
+                }
+                KeyCode::Backspace => {
+                    state.wizard_edit_buffer.pop();
+                }
+                _ => {}
+            }
+        }
+        if let Some(bad) = bad_mac {
+            app.set_status(format!("Invalid MAC address: {}", bad));
+        }
+        return Ok(());
+    }
 
     if editing_memory || editing_cpu {
         // Text input mode for Memory or CPU
@@ -2227,7 +2308,7 @@ fn handle_step_configure_qemu(app: &mut App, key: KeyEvent) -> Result<()> {
             }
         }
         KeyCode::Tab => {
-            // Enter edit mode for Memory or CPU fields
+            // Enter edit mode for Memory, CPU, or MAC fields
             if let Some(ref mut state) = app.wizard_state {
                 let field = QemuField::from_index(state.field_focus);
                 match field {
@@ -2239,7 +2320,31 @@ fn handle_step_configure_qemu(app: &mut App, key: KeyEvent) -> Result<()> {
                         state.editing_field = Some(WizardField::CpuCores);
                         state.wizard_edit_buffer = state.qemu_config.cpu_cores.to_string();
                     }
+                    QemuField::MacAddress if state.qemu_config.network_model != "none" => {
+                        state.editing_field = Some(WizardField::MacAddress);
+                        state.wizard_edit_buffer = state
+                            .qemu_config
+                            .mac_address
+                            .clone()
+                            .unwrap_or_default();
+                    }
                     _ => {}
+                }
+            }
+        }
+        KeyCode::Char('g') => {
+            if let Some(ref mut state) = app.wizard_state {
+                let field = QemuField::from_index(state.field_focus);
+                if field == QemuField::MacAddress && state.qemu_config.network_model != "none" {
+                    state.qemu_config.mac_address = Some(crate::vm::mac::generate_random_mac());
+                }
+            }
+        }
+        KeyCode::Char('c') => {
+            if let Some(ref mut state) = app.wizard_state {
+                let field = QemuField::from_index(state.field_focus);
+                if field == QemuField::MacAddress {
+                    state.qemu_config.mac_address = None;
                 }
             }
         }

--- a/src/ui/screens/management.rs
+++ b/src/ui/screens/management.rs
@@ -28,6 +28,7 @@ pub enum MenuAction {
     MultiGpuPassthrough,
     SingleGpuPassthrough,
     ChangeDisplay,
+    Toggle3dAccel,
     EditNotes,
     RenameVm,
     ResetVm,
@@ -88,11 +89,24 @@ pub fn get_menu_items(vm: &DiscoveredVm, config: &Config) -> Vec<MenuItem> {
         });
     }
 
+    let gl_state = if vm.config.has_gl_acceleration() { "ON" } else { "OFF" };
+    let gl_desc: &'static str = if vm.config.has_gl_acceleration() {
+        "Disable para-virtualized 3D (currently ON)"
+    } else {
+        "Enable para-virtualized 3D (currently OFF)"
+    };
+    let _ = gl_state; // kept in case the description copy is updated to use it
+
     items.extend([
         MenuItem {
             name: "Change Display",
             description: "GTK, SDL, SPICE-app, or VNC output",
             action: MenuAction::ChangeDisplay,
+        },
+        MenuItem {
+            name: "3D Acceleration",
+            description: gl_desc,
+            action: MenuAction::Toggle3dAccel,
         },
         MenuItem {
             name: "Edit Notes",

--- a/src/ui/screens/management.rs
+++ b/src/ui/screens/management.rs
@@ -89,13 +89,11 @@ pub fn get_menu_items(vm: &DiscoveredVm, config: &Config) -> Vec<MenuItem> {
         });
     }
 
-    let gl_state = if vm.config.has_gl_acceleration() { "ON" } else { "OFF" };
     let gl_desc: &'static str = if vm.config.has_gl_acceleration() {
-        "Disable para-virtualized 3D (currently ON)"
+        "Currently ON - toggle off"
     } else {
-        "Enable para-virtualized 3D (currently OFF)"
+        "Currently OFF - toggle on"
     };
-    let _ = gl_state; // kept in case the description copy is updated to use it
 
     items.extend([
         MenuItem {
@@ -104,7 +102,7 @@ pub fn get_menu_items(vm: &DiscoveredVm, config: &Config) -> Vec<MenuItem> {
             action: MenuAction::ChangeDisplay,
         },
         MenuItem {
-            name: "3D Acceleration",
+            name: "3D Acceleration (non-pass-through)",
             description: gl_desc,
             action: MenuAction::Toggle3dAccel,
         },

--- a/src/ui/screens/network_settings.rs
+++ b/src/ui/screens/network_settings.rs
@@ -19,7 +19,7 @@ const NETWORK_OPTIONS: &[&str] = &["virtio", "e1000", "rtl8139", "ne2k_pci", "pc
 pub fn render(app: &App, frame: &mut Frame) {
     let area = frame.area();
     let dialog_width = 72.min(area.width.saturating_sub(4));
-    let dialog_height = 30.min(area.height.saturating_sub(4));
+    let dialog_height = 32.min(area.height.saturating_sub(4));
 
     let dialog_area = centered_rect(dialog_width, dialog_height, area);
     frame.render_widget(Clear, dialog_area);
@@ -44,6 +44,7 @@ pub fn render(app: &App, frame: &mut Frame) {
     }
 
     let is_bridge = ns.backend == "bridge";
+    let show_mac = ns.backend != "none";
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -53,9 +54,10 @@ pub fn render(app: &App, frame: &mut Frame) {
             Constraint::Length(1),   // Spacer
             Constraint::Length(1),   // Adapter field
             Constraint::Length(1),   // Backend field
+            Constraint::Length(1),   // MAC field
             Constraint::Length(1),   // Bridge name / Port forwards field
             Constraint::Length(1),   // Spacer
-            Constraint::Min(6),      // Info area (port forward list or bridge status)
+            Constraint::Min(6),      // Info area
             Constraint::Length(2),   // Help
         ])
         .split(inner);
@@ -82,24 +84,44 @@ pub fn render(app: &App, frame: &mut Frame) {
     let backend_line = render_field_line("Backend:", &backend_display, backend_selected, "[Left/Right] cycle");
     frame.render_widget(Paragraph::new(backend_line), chunks[3]);
 
-    // Field 2: Bridge name (when bridge backend) or Port forwards (when user/passt)
+    // MAC address (hidden when backend == "none")
+    if show_mac {
+        let mac_selected = ns.selected_field == 2;
+        let mac_display = if ns.editing_mac {
+            format!("{}_", ns.mac_edit_buffer)
+        } else if let Some(mac) = ns.mac_address.as_deref() {
+            mac.to_string()
+        } else {
+            "(auto)".to_string()
+        };
+        let mac_hint = if ns.editing_mac {
+            "[Enter] save  [Esc] cancel"
+        } else if mac_selected {
+            "[Enter] edit  [r] randomize  [c] clear"
+        } else {
+            ""
+        };
+        let mac_line = render_field_line("MAC:", &mac_display, mac_selected, mac_hint);
+        frame.render_widget(Paragraph::new(mac_line), chunks[4]);
+    }
+
+    // Bridge name (when bridge backend) or Port forwards (when user/passt)
     let show_pf = ns.backend == "user" || ns.backend == "passt";
+    let bridge_pf_selected = ns.selected_field == 3;
     if is_bridge {
-        let bridge_selected = ns.selected_field == 2;
         let bridge_display = ns.bridge_name.as_deref().unwrap_or("qemubr0");
-        let bridge_line = render_field_line("Bridge:", bridge_display, bridge_selected, "[Left/Right] cycle");
-        frame.render_widget(Paragraph::new(bridge_line), chunks[4]);
+        let bridge_line = render_field_line("Bridge:", bridge_display, bridge_pf_selected, "[Left/Right] cycle");
+        frame.render_widget(Paragraph::new(bridge_line), chunks[5]);
     } else if show_pf {
-        let pf_selected = ns.selected_field == 2;
         let pf_count = ns.port_forwards.len();
         let pf_display = if pf_count == 0 {
             "none".to_string()
         } else {
             format!("{} rule(s)", pf_count)
         };
-        let pf_hint = if pf_selected { "[Enter] edit" } else { "" };
-        let pf_line = render_field_line("Forwards:", &pf_display, pf_selected, pf_hint);
-        frame.render_widget(Paragraph::new(pf_line), chunks[4]);
+        let pf_hint = if bridge_pf_selected { "[Enter] edit" } else { "" };
+        let pf_line = render_field_line("Forwards:", &pf_display, bridge_pf_selected, pf_hint);
+        frame.render_widget(Paragraph::new(pf_line), chunks[5]);
     }
 
     // Info area: bridge status (when bridge) or port forward list (when user/passt)
@@ -159,7 +181,7 @@ pub fn render(app: &App, frame: &mut Frame) {
         }
 
         let info = Paragraph::new(lines);
-        frame.render_widget(info, chunks[6]);
+        frame.render_widget(info, chunks[7]);
     } else if show_pf && !ns.port_forwards.is_empty() {
         let mut lines = Vec::new();
         lines.push(Line::styled("  Current port forwarding rules:", Style::default().fg(Color::DarkGray)));
@@ -167,14 +189,14 @@ pub fn render(app: &App, frame: &mut Frame) {
             lines.push(Line::from(format!("    {} {} -> {}", pf.protocol, pf.host_port, pf.guest_port)));
         }
         let list = Paragraph::new(lines);
-        frame.render_widget(list, chunks[6]);
+        frame.render_widget(list, chunks[7]);
     }
 
     // Help
     let help = Paragraph::new("[Enter] Apply  [Esc] Cancel  [j/k] Navigate  [Left/Right] Change")
         .style(Style::default().fg(Color::DarkGray))
         .alignment(Alignment::Center);
-    frame.render_widget(help, chunks[7]);
+    frame.render_widget(help, chunks[8]);
 }
 
 /// Render the port forward editor overlay
@@ -394,6 +416,51 @@ pub fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> anyhow::Res
         return Ok(());
     }
 
+    // MAC edit mode: capture text input first.
+    let editing_mac = app
+        .network_settings_state
+        .as_ref()
+        .map(|ns| ns.editing_mac)
+        .unwrap_or(false);
+    if editing_mac {
+        let mut bad_mac: Option<String> = None;
+        if let Some(ref mut ns) = app.network_settings_state {
+            match key.code {
+                KeyCode::Esc => {
+                    ns.mac_edit_buffer = ns.mac_address.clone().unwrap_or_default();
+                    ns.editing_mac = false;
+                }
+                KeyCode::Enter => {
+                    let trimmed = ns.mac_edit_buffer.trim().to_string();
+                    if trimmed.is_empty() {
+                        ns.mac_address = None;
+                        ns.mac_edit_buffer.clear();
+                        ns.editing_mac = false;
+                    } else if crate::vm::mac::is_valid_mac(&trimmed) {
+                        ns.mac_address = Some(trimmed.to_lowercase());
+                        ns.mac_edit_buffer = ns.mac_address.clone().unwrap_or_default();
+                        ns.editing_mac = false;
+                    } else {
+                        bad_mac = Some(trimmed);
+                    }
+                }
+                KeyCode::Backspace => {
+                    ns.mac_edit_buffer.pop();
+                }
+                KeyCode::Char(c) if c.is_ascii_hexdigit() || c == ':' => {
+                    if ns.mac_edit_buffer.len() < 17 {
+                        ns.mac_edit_buffer.push(c);
+                    }
+                }
+                _ => {}
+            }
+        }
+        if let Some(bad) = bad_mac {
+            app.set_status(format!("Invalid MAC address: {}", bad));
+        }
+        return Ok(());
+    }
+
     // Normal settings mode
     let backend_options: Vec<String> = app.get_network_backend_options()
         .iter()
@@ -408,7 +475,18 @@ pub fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> anyhow::Res
         let ns = app.network_settings_state.as_ref().unwrap();
         ns.backend == "bridge"
     };
-    let max_field = if show_pf || is_bridge { 2 } else { 1 };
+    let show_mac = {
+        let ns = app.network_settings_state.as_ref().unwrap();
+        ns.backend != "none"
+    };
+    // Field indices: 0=adapter, 1=backend, 2=mac (when show_mac), 3=bridge/forwards
+    let max_field = if !show_mac {
+        1
+    } else if show_pf || is_bridge {
+        3
+    } else {
+        2
+    };
 
     match key.code {
         KeyCode::Esc => {
@@ -426,6 +504,23 @@ pub fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> anyhow::Res
             if let Some(ref mut ns) = app.network_settings_state {
                 if ns.selected_field > 0 {
                     ns.selected_field -= 1;
+                }
+            }
+        }
+        KeyCode::Char('r') => {
+            if let Some(ref mut ns) = app.network_settings_state {
+                if ns.selected_field == 2 && ns.backend != "none" {
+                    let mac = crate::vm::mac::generate_random_mac();
+                    ns.mac_address = Some(mac.clone());
+                    ns.mac_edit_buffer = mac;
+                }
+            }
+        }
+        KeyCode::Char('c') => {
+            if let Some(ref mut ns) = app.network_settings_state {
+                if ns.selected_field == 2 && ns.backend != "none" {
+                    ns.mac_address = None;
+                    ns.mac_edit_buffer.clear();
                 }
             }
         }
@@ -452,7 +547,7 @@ pub fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> anyhow::Res
                                 .or_else(|| Some("qemubr0".to_string()));
                         }
                     }
-                    2 if ns.backend == "bridge" => {
+                    3 if ns.backend == "bridge" => {
                         // Cycle bridge name
                         if !system_bridges.is_empty() {
                             let current_bridge = ns.bridge_name.as_deref().unwrap_or("");
@@ -469,8 +564,17 @@ pub fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> anyhow::Res
             }
         }
         KeyCode::Enter => {
-            let ns = app.network_settings_state.as_ref().unwrap();
-            if ns.selected_field == 2 && show_pf {
+            let (sel, backend) = {
+                let ns = app.network_settings_state.as_ref().unwrap();
+                (ns.selected_field, ns.backend.clone())
+            };
+            if sel == 2 && backend != "none" {
+                // Enter MAC edit mode
+                if let Some(ref mut ns) = app.network_settings_state {
+                    ns.mac_edit_buffer = ns.mac_address.clone().unwrap_or_default();
+                    ns.editing_mac = true;
+                }
+            } else if sel == 3 && show_pf {
                 // Enter port forward editor
                 if let Some(ref mut ns) = app.network_settings_state {
                     ns.editing_port_forwards = true;
@@ -578,6 +682,7 @@ fn apply_network_settings(app: &mut App) -> anyhow::Result<()> {
             &ns.backend,
             ns.bridge_name.as_deref(),
             &ns.port_forwards,
+            ns.mac_address.as_deref(),
         )?;
 
         app.reload_selected_vm_script();

--- a/src/ui/screens/settings.rs
+++ b/src/ui/screens/settings.rs
@@ -26,6 +26,7 @@ pub enum GpuValidationResult {
 pub enum SettingsItem {
     // General settings
     VmLibraryPath,
+    DefaultIsoPath,
     DefaultMemory,
     DefaultCpuCores,
     DefaultDiskSize,
@@ -65,6 +66,7 @@ impl SettingsItem {
     pub fn display_name(&self) -> &'static str {
         match self {
             SettingsItem::VmLibraryPath => "VM Library Path",
+            SettingsItem::DefaultIsoPath => "Default ISO Path",
             SettingsItem::DefaultMemory => "Default Memory (MB)",
             SettingsItem::DefaultCpuCores => "Default CPU Cores",
             SettingsItem::DefaultDiskSize => "Default Disk Size (GB)",
@@ -89,6 +91,11 @@ impl SettingsItem {
     pub fn get_value(&self, config: &Config) -> String {
         match self {
             SettingsItem::VmLibraryPath => config.vm_library_path.display().to_string(),
+            SettingsItem::DefaultIsoPath => config
+                .default_iso_path
+                .as_ref()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default(),
             SettingsItem::DefaultMemory => config.default_memory_mb.to_string(),
             SettingsItem::DefaultCpuCores => config.default_cpu_cores.to_string(),
             SettingsItem::DefaultDiskSize => config.default_disk_size_gb.to_string(),
@@ -159,6 +166,7 @@ impl SettingsItem {
     pub fn help_key(&self) -> &'static str {
         match self {
             SettingsItem::VmLibraryPath => "vm_library_path",
+            SettingsItem::DefaultIsoPath => "default_iso_path",
             SettingsItem::DefaultMemory => "default_memory",
             SettingsItem::DefaultCpuCores => "default_cpu_cores",
             SettingsItem::DefaultDiskSize => "default_disk_size",
@@ -197,6 +205,7 @@ fn make_visible(item: SettingsItem, indent: usize) -> VisibleItem {
 fn build_visible_items(config: &Config) -> Vec<VisibleItem> {
     let mut items = vec![
         make_visible(SettingsItem::VmLibraryPath, 0),
+        make_visible(SettingsItem::DefaultIsoPath, 0),
         make_visible(SettingsItem::DefaultMemory, 0),
         make_visible(SettingsItem::DefaultCpuCores, 0),
         make_visible(SettingsItem::DefaultDiskSize, 0),
@@ -838,6 +847,29 @@ fn apply_edit(app: &mut App, item: SettingsItem) -> anyhow::Result<()> {
             }
 
             app.config.vm_library_path = path;
+        }
+        SettingsItem::DefaultIsoPath => {
+            if value.is_empty() {
+                app.config.default_iso_path = None;
+            } else {
+                let path = std::path::PathBuf::from(value);
+                let path = if let Some(rest) = value.strip_prefix("~/") {
+                    if let Some(home) = dirs::home_dir() {
+                        home.join(rest)
+                    } else {
+                        path
+                    }
+                } else {
+                    path
+                };
+
+                if !path.is_dir() {
+                    app.set_status(format!("Path does not exist or is not a directory: {}", path.display()));
+                    return Ok(());
+                }
+
+                app.config.default_iso_path = Some(path);
+            }
         }
         SettingsItem::DefaultMemory => {
             if let Ok(mb) = value.parse::<u32>() {

--- a/src/vm/create.rs
+++ b/src/vm/create.rs
@@ -1002,18 +1002,25 @@ fn build_qemu_command_with_os(
             other => shell_escape(other),
         };
 
+        let mac_suffix = config
+            .mac_address
+            .as_deref()
+            .filter(|m| crate::vm::mac::is_valid_mac(m))
+            .map(|m| format!(",mac={}", m))
+            .unwrap_or_default();
+
         match config.network_backend.as_str() {
             "none" => {
                 // No networking backend (different from network_model "none")
             }
             "passt" => {
                 args.push("-netdev passt,id=net0".to_string());
-                args.push(format!("-device {},netdev=net0", net_device));
+                args.push(format!("-device {},netdev=net0{}", net_device, mac_suffix));
             }
             "bridge" => {
                 let br = config.bridge_name.as_deref().unwrap_or("qemubr0");
                 args.push(format!("-netdev bridge,id=net0,br={}", shell_escape(br)));
-                args.push(format!("-device {},netdev=net0", net_device));
+                args.push(format!("-device {},netdev=net0{}", net_device, mac_suffix));
             }
             _ => {
                 // User/SLIRP (default)
@@ -1026,7 +1033,7 @@ fn build_qemu_command_with_os(
                     netdev.push_str(&format!(",hostfwd={}::{}-:{}", proto, pf.host_port, pf.guest_port));
                 }
                 args.push(netdev);
-                args.push(format!("-device {},netdev=net0", net_device));
+                args.push(format!("-device {},netdev=net0{}", net_device, mac_suffix));
             }
         }
     }
@@ -1087,13 +1094,14 @@ pub fn update_network_in_script(
     backend: &str,
     bridge_name: Option<&str>,
     port_forwards: &[PortForward],
+    mac_address: Option<&str>,
 ) -> Result<()> {
     let script_path = vm_path.join("launch.sh");
     let content = std::fs::read_to_string(&script_path)
         .with_context(|| format!("Failed to read launch script: {}", script_path.display()))?;
 
     // Build new network arguments
-    let new_net_args = generate_network_args(model, backend, bridge_name, port_forwards);
+    let new_net_args = generate_network_args(model, backend, bridge_name, port_forwards, mac_address);
 
     // Remove existing network lines and replace
     let mut new_lines = Vec::new();
@@ -1166,6 +1174,7 @@ fn generate_network_args(
     backend: &str,
     bridge_name: Option<&str>,
     port_forwards: &[PortForward],
+    mac_address: Option<&str>,
 ) -> Vec<String> {
     if model == "none" {
         return Vec::new();
@@ -1176,6 +1185,11 @@ fn generate_network_args(
         other => shell_escape(other),
     };
 
+    let mac_suffix = mac_address
+        .filter(|m| crate::vm::mac::is_valid_mac(m))
+        .map(|m| format!(",mac={}", m))
+        .unwrap_or_default();
+
     let mut args = Vec::new();
 
     match backend {
@@ -1184,12 +1198,12 @@ fn generate_network_args(
         }
         "passt" => {
             args.push("        -netdev passt,id=net0 \\".to_string());
-            args.push(format!("        -device {},netdev=net0 \\", net_device));
+            args.push(format!("        -device {},netdev=net0{} \\", net_device, mac_suffix));
         }
         "bridge" => {
             let br = bridge_name.unwrap_or("qemubr0");
             args.push(format!("        -netdev bridge,id=net0,br={} \\", shell_escape(br)));
-            args.push(format!("        -device {},netdev=net0 \\", net_device));
+            args.push(format!("        -device {},netdev=net0{} \\", net_device, mac_suffix));
         }
         _ => {
             // User/SLIRP
@@ -1203,7 +1217,7 @@ fn generate_network_args(
             }
             netdev.push_str(" \\");
             args.push(netdev);
-            args.push(format!("        -device {},netdev=net0 \\", net_device));
+            args.push(format!("        -device {},netdev=net0{} \\", net_device, mac_suffix));
         }
     }
 

--- a/src/vm/import.rs
+++ b/src/vm/import.rs
@@ -366,6 +366,7 @@ fn parse_libvirt_xml_str(xml: &str, config_path: &Path) -> Result<ImportableVm> 
         network_backend,
         port_forwards: Vec::new(),
         bridge_name,
+        mac_address: None,
         extra_args: Vec::new(),
         bios_path: None,
     };
@@ -541,6 +542,7 @@ fn parse_quickemu_conf_str(content: &str, config_path: &Path) -> Result<Importab
         network_backend: "user".to_string(),
         port_forwards: Vec::new(),
         bridge_name: None,
+        mac_address: None,
         extra_args: Vec::new(),
         bios_path: None,
     };

--- a/src/vm/launch_parser.rs
+++ b/src/vm/launch_parser.rs
@@ -592,6 +592,24 @@ fn extract_network(content: &str) -> Option<NetworkConfig> {
                 config.bridge = Some(bridge);
             }
         }
+
+        // Extract MAC address. QEMU accepts `mac=...` on either the
+        // -device line (most common) or the -netdev line.
+        if (line.contains("-device") || line.contains("-netdev") || line.contains("-nic"))
+            && line.contains("mac=")
+        {
+            if let Some(idx) = line.find("mac=") {
+                let rest = &line[idx + 4..];
+                let mac: String = rest
+                    .chars()
+                    .take_while(|c| c.is_ascii_hexdigit() || *c == ':')
+                    .collect();
+                if crate::vm::mac::is_valid_mac(&mac) {
+                    config.mac_address = Some(mac.to_lowercase());
+                    has_network = true;
+                }
+            }
+        }
     }
 
     if has_network || content.contains("-net") || content.contains("-nic") {

--- a/src/vm/mac.rs
+++ b/src/vm/mac.rs
@@ -1,0 +1,81 @@
+//! MAC address utilities.
+
+use std::fs::File;
+use std::io::Read;
+
+/// Generate a random MAC address with QEMU's IANA-assigned OUI prefix
+/// (52:54:00). Three random low-order bytes give 16M unique addresses,
+/// which is plenty for any single host.
+pub fn generate_random_mac() -> String {
+    let mut bytes = [0u8; 3];
+    if File::open("/dev/urandom")
+        .and_then(|mut f| f.read_exact(&mut bytes))
+        .is_err()
+    {
+        // /dev/urandom should never fail on Linux, but fall back to a
+        // time-derived seed so we still produce *something* unique.
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+        bytes[0] = (nanos & 0xff) as u8;
+        bytes[1] = ((nanos >> 8) & 0xff) as u8;
+        bytes[2] = ((nanos >> 16) & 0xff) as u8;
+    }
+    format!("52:54:00:{:02x}:{:02x}:{:02x}", bytes[0], bytes[1], bytes[2])
+}
+
+/// Validate a MAC address in canonical colon-separated hex form
+/// (e.g., `52:54:00:12:34:56`). Accepts both upper and lower case.
+pub fn is_valid_mac(s: &str) -> bool {
+    let parts: Vec<&str> = s.split(':').collect();
+    if parts.len() != 6 {
+        return false;
+    }
+    parts.iter().all(|p| {
+        p.len() == 2 && p.chars().all(|c| c.is_ascii_hexdigit())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn random_mac_has_qemu_oui_and_correct_format() {
+        for _ in 0..100 {
+            let mac = generate_random_mac();
+            assert!(mac.starts_with("52:54:00:"), "wrong OUI: {}", mac);
+            assert!(is_valid_mac(&mac), "not valid MAC: {}", mac);
+            assert_eq!(mac.len(), 17);
+        }
+    }
+
+    #[test]
+    fn random_macs_are_distinct() {
+        let macs: HashSet<String> = (0..200).map(|_| generate_random_mac()).collect();
+        // 3 random bytes = 16M space; collisions in 200 draws are essentially impossible.
+        assert!(macs.len() > 195, "too many collisions: {}", macs.len());
+    }
+
+    #[test]
+    fn validator_accepts_canonical_macs() {
+        assert!(is_valid_mac("52:54:00:12:34:56"));
+        assert!(is_valid_mac("AA:BB:CC:DD:EE:FF"));
+        assert!(is_valid_mac("aa:bb:cc:dd:ee:ff"));
+        assert!(is_valid_mac("00:00:00:00:00:00"));
+    }
+
+    #[test]
+    fn validator_rejects_malformed_macs() {
+        assert!(!is_valid_mac(""));
+        assert!(!is_valid_mac("52-54-00-12-34-56"));
+        assert!(!is_valid_mac("52:54:00:12:34"));
+        assert!(!is_valid_mac("52:54:00:12:34:56:78"));
+        assert!(!is_valid_mac("ZZ:54:00:12:34:56"));
+        assert!(!is_valid_mac("525:54:00:12:34:56"));
+        assert!(!is_valid_mac("5:54:00:12:34:56"));
+    }
+}

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -3,6 +3,7 @@ pub mod discovery;
 pub mod import;
 pub mod launch_parser;
 pub mod lifecycle;
+pub mod mac;
 pub mod qemu_config;
 pub mod single_gpu_scripts;
 pub mod snapshot;

--- a/src/vm/qemu_config.rs
+++ b/src/vm/qemu_config.rs
@@ -169,6 +169,10 @@ pub struct NetworkConfig {
     #[serde(default = "default_true")]
     pub user_net: bool,
     pub bridge: Option<String>,
+    /// Custom MAC address for the NIC (canonical aa:bb:cc:dd:ee:ff form).
+    /// `None` lets QEMU pick its own.
+    #[serde(default)]
+    pub mac_address: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -183,6 +187,7 @@ impl Default for NetworkConfig {
             port_forwards: Vec::new(),
             user_net: true,
             bridge: None,
+            mac_address: None,
         }
     }
 }
@@ -288,5 +293,46 @@ impl QemuConfig {
     /// Get the primary disk for snapshot operations
     pub fn primary_disk(&self) -> Option<&DiskConfig> {
         self.disks.first()
+    }
+
+    /// Whether para-virtualized 3D acceleration is currently enabled.
+    /// Detected from the raw script (gl=on on display, virtio-vga-gl device,
+    /// or any extra_arg containing those tokens).
+    pub fn has_gl_acceleration(&self) -> bool {
+        if self
+            .extra_args
+            .iter()
+            .any(|arg| arg.contains("virtio-vga-gl") || arg.contains("gl=on"))
+        {
+            return true;
+        }
+        let s = &self.raw_script;
+        s.contains("virtio-vga-gl") || s.contains("gl=on")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn has_gl_acceleration_detects_device() {
+        let mut cfg = QemuConfig::default();
+        cfg.raw_script = "qemu-system-x86_64 \\\n  -device virtio-vga-gl \\\n  -display sdl,gl=on".to_string();
+        assert!(cfg.has_gl_acceleration());
+    }
+
+    #[test]
+    fn has_gl_acceleration_detects_extra_arg() {
+        let mut cfg = QemuConfig::default();
+        cfg.extra_args = vec!["-display gtk,gl=on".to_string()];
+        assert!(cfg.has_gl_acceleration());
+    }
+
+    #[test]
+    fn has_gl_acceleration_negative() {
+        let mut cfg = QemuConfig::default();
+        cfg.raw_script = "qemu-system-x86_64 \\\n  -vga std \\\n  -display gtk".to_string();
+        assert!(!cfg.has_gl_acceleration());
     }
 }

--- a/src/vm/tests/create.rs
+++ b/src/vm/tests/create.rs
@@ -74,6 +74,7 @@ fn test_build_qemu_command_basic() {
         network_backend: "user".to_string(),
         port_forwards: vec![],
         bridge_name: None,
+        mac_address: None,
         extra_args: vec![],
         bios_path: None,
     };
@@ -106,7 +107,7 @@ fn test_generate_network_args_user_with_portfwd() {
         PortForward { protocol: PortProtocol::Tcp, host_port: 2222, guest_port: 22 },
         PortForward { protocol: PortProtocol::Tcp, host_port: 8080, guest_port: 80 },
     ];
-    let args = generate_network_args("e1000", "user", None, &forwards);
+    let args = generate_network_args("e1000", "user", None, &forwards, None);
     assert_eq!(args.len(), 2);
     assert!(args[0].contains("hostfwd=tcp::2222-:22"));
     assert!(args[0].contains("hostfwd=tcp::8080-:80"));
@@ -115,7 +116,7 @@ fn test_generate_network_args_user_with_portfwd() {
 
 #[test]
 fn test_generate_network_args_passt() {
-    let args = generate_network_args("virtio", "passt", None, &[]);
+    let args = generate_network_args("virtio", "passt", None, &[], None);
     assert_eq!(args.len(), 2);
     assert!(args[0].contains("-netdev passt,id=net0"));
     assert!(args[1].contains("virtio-net-pci,netdev=net0"));
@@ -123,14 +124,40 @@ fn test_generate_network_args_passt() {
 
 #[test]
 fn test_generate_network_args_bridge() {
-    let args = generate_network_args("e1000", "bridge", Some("virbr0"), &[]);
+    let args = generate_network_args("e1000", "bridge", Some("virbr0"), &[], None);
     assert_eq!(args.len(), 2);
     assert!(args[0].contains("-netdev bridge,id=net0,br=virbr0"));
 }
 
 #[test]
+fn test_generate_network_args_with_mac_bridge() {
+    let args = generate_network_args(
+        "e1000",
+        "bridge",
+        Some("virbr0"),
+        &[],
+        Some("52:54:00:de:ad:be"),
+    );
+    assert_eq!(args.len(), 2);
+    assert!(args[1].contains("mac=52:54:00:de:ad:be"), "device line missing mac=: {}", args[1]);
+}
+
+#[test]
+fn test_generate_network_args_with_mac_user() {
+    let args = generate_network_args("virtio", "user", None, &[], Some("aa:bb:cc:dd:ee:ff"));
+    assert!(args[1].contains("virtio-net-pci,netdev=net0,mac=aa:bb:cc:dd:ee:ff"));
+}
+
+#[test]
+fn test_generate_network_args_invalid_mac_dropped() {
+    // Invalid MAC strings must not be written into the script.
+    let args = generate_network_args("e1000", "user", None, &[], Some("not-a-mac"));
+    assert!(!args.iter().any(|a| a.contains("mac=")));
+}
+
+#[test]
 fn test_generate_network_args_none() {
-    let args = generate_network_args("none", "user", None, &[]);
+    let args = generate_network_args("none", "user", None, &[], None);
     assert!(args.is_empty());
 }
 
@@ -170,6 +197,7 @@ fn test_build_qemu_command_with_bios() {
         network_backend: "user".to_string(),
         port_forwards: vec![],
         bridge_name: None,
+        mac_address: None,
         extra_args: vec![],
         bios_path: Some(PathBuf::from("MacROM.bin")),
     };
@@ -294,6 +322,7 @@ fn macos_uefi_config() -> WizardQemuConfig {
         network_backend: "passt".to_string(),
         port_forwards: vec![],
         bridge_name: None,
+        mac_address: None,
         extra_args: vec!["-device vmware-svga,vgamem_mb=256".to_string()],
         bios_path: Some(PathBuf::from("OpenCore.qcow2")),
     }
@@ -321,6 +350,7 @@ fn macos_non_uefi_config() -> WizardQemuConfig {
         network_backend: "passt".to_string(),
         port_forwards: vec![],
         bridge_name: None,
+        mac_address: None,
         extra_args: vec!["-device vmware-svga,vgamem_mb=256".to_string()],
         bios_path: None,
     }

--- a/src/vm/tests/launch_parser.rs
+++ b/src/vm/tests/launch_parser.rs
@@ -87,6 +87,27 @@ fn test_extract_network_user_with_portfwd() {
 }
 
 #[test]
+fn test_extract_network_mac_on_device() {
+    let content = "qemu-system-x86_64 \\\n  -netdev bridge,id=net0,br=virbr0 \\\n  -device virtio-net-pci,netdev=net0,mac=52:54:00:de:ad:be";
+    let config = extract_network(content).unwrap();
+    assert_eq!(config.mac_address, Some("52:54:00:de:ad:be".to_string()));
+}
+
+#[test]
+fn test_extract_network_mac_uppercase_normalized() {
+    let content = "qemu-system-x86_64 \\\n  -netdev user,id=net0 \\\n  -device e1000,netdev=net0,mac=AA:BB:CC:DD:EE:FF";
+    let config = extract_network(content).unwrap();
+    assert_eq!(config.mac_address, Some("aa:bb:cc:dd:ee:ff".to_string()));
+}
+
+#[test]
+fn test_extract_network_no_mac() {
+    let content = "qemu-system-x86_64 \\\n  -netdev user,id=net0 \\\n  -device e1000,netdev=net0";
+    let config = extract_network(content).unwrap();
+    assert_eq!(config.mac_address, None);
+}
+
+#[test]
 fn test_extract_bios_path_with_variable() {
     let vm_dir = Path::new("/home/user/vms/mac-system7");
     let content = r#"VM_DIR="$(dirname "$(readlink -f "$0")")"


### PR DESCRIPTION
## Summary
- **Custom MAC addresses**: New `vm::mac` module to generate (using QEMU's 52:54:00 OUI) and validate MAC addresses. Editable from the create wizard's QEMU step and from existing-VM Network Settings; parsed from `launch.sh` on import so changes round-trip.
- **Default ISO path**: New `default_iso_path` config field. The ISO file browser seeds to this directory; settable from Settings or via `[d]` in the browser itself.
- **3D acceleration toggle**: New management menu item "3D Acceleration (non-pass-through)" toggles `virtio-vga-gl` + `gl=on` in-place on existing VMs and auto-swaps `gtk` → `sdl` for better performance.

## Test plan
- [ ] Create a new VM, set a MAC in the wizard (try `[g]` to generate, `[c]` to clear, manual entry with validation)
- [ ] Edit MAC on an existing VM via Network Settings; verify it persists in `launch.sh` and is read back correctly
- [ ] Set Default ISO Path in Settings, then open the wizard ISO step — browser opens there
- [ ] Toggle `[d]` in the file browser and confirm the checkbox + status message
- [ ] Toggle 3D Acceleration on a VM with `-display gtk` and confirm it switches to `sdl,gl=on` with `-device virtio-vga-gl`
- [ ] Toggle it back off and confirm `-vga virtio` is restored, `gl=on` is stripped
- [ ] `cargo test` passes (new tests cover MAC parsing/validation, GL detection, network arg generation with MAC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)