### PR TITLE
Add flake.nix for dev shell and package output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ scripts/
 .env
 .env.local
 *.local.toml
+
+# Nix build artifacts
+result
+result-*
+*.nix-tmp

--- a/README.md
+++ b/README.md
@@ -150,6 +150,24 @@ cargo install vm-curator
 
 Pre-built packages (DEB, RPM, AppImage, tarball) are available from [GitHub Releases](https://github.com/mroboff/vm-curator/releases).
 
+**Nix / NixOS**
+
+```bash
+# Run directly without installing
+nix run github:mroboff/vm-curator
+
+# Build the package
+nix build .#default
+```
+
+For NixOS, add to `/etc/nixos/configuration.nix`:
+```nix
+{ pkgs, ... }:
+{
+  environment.systemPackages = [ pkgs.vm-curator ];
+}
+```
+
 **From Source**
 
 ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,78 @@
+{
+  description = "vm-curator - A TUI application to manage QEMU VM library";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+
+      # Helper function to generate attributes for each system
+      forAllSystems =
+        function: nixpkgs.lib.genAttrs supportedSystems (system: function nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forAllSystems (
+        pkgs:
+        let
+          cargoToml = fromTOML (builtins.readFile ./Cargo.toml);
+          pname = cargoToml.package.name;
+          inherit (cargoToml.package) version;
+        in
+        {
+          default = pkgs.rustPlatform.buildRustPackage {
+            inherit pname version;
+            src = ./.;
+
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+            };
+
+            nativeBuildInputs = with pkgs; [
+              pkg-config
+            ];
+
+            buildInputs = with pkgs; [
+              udev
+            ];
+
+            meta = with pkgs.lib; {
+              inherit (cargoToml.package) description;
+              inherit (cargoToml.package) homepage;
+              license = licenses.mit;
+              mainProgram = "vm-curator";
+            };
+          };
+        }
+      );
+
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+          ];
+          buildInputs = with pkgs; [
+            udev
+            cargo
+            rustc
+            rustfmt
+            clippy
+            rust-analyzer
+          ];
+        };
+      });
+
+      apps = forAllSystems (pkgs: {
+        default = {
+          type = "app";
+          program = "${self.packages.${pkgs.system}.default}/bin/vm-curator";
+        };
+      });
+    };
+}


### PR DESCRIPTION
Adds Nix flake with packages.default, devShells.default, and apps.default for reproducible builds and development environment. 
Updates .gitignore to exclude Nix build artifacts (result, etc.). 
Update README.md with Nix/NixOS installation instructions.