### PR TITLE
fix: skip pflash disks in primary_disk() for snapshot operations

### DIFF
--- a/src/vm/qemu_config.rs
+++ b/src/vm/qemu_config.rs
@@ -291,8 +291,13 @@ impl QemuConfig {
     }
 
     /// Get the primary disk for snapshot operations
+    /// Returns the first disk that supports snapshots (qcow2), skipping
+    /// pflash/OVMF firmware files that are not snapshotable.
     pub fn primary_disk(&self) -> Option<&DiskConfig> {
-        self.disks.first()
+        self.disks
+            .iter()
+            .find(|d| d.format.supports_snapshots())
+            .or_else(|| self.disks.first())
     }
 
     /// Whether para-virtualized 3D acceleration is currently enabled.


### PR DESCRIPTION
## Problem

`primary_disk()` returns `self.disks.first()`, which is the OVMF pflash firmware file (e.g. `/usr/share/edk2/x64/OVMF_CODE.secboot.4m.fd`) rather than the actual qcow2 disk.

This causes `qemu-img snapshot -c` to fail with:

```
Error: Failed to create snapshot: qemu-img: Could not open '/usr/share/edk2/x64/OVMF_CODE.secboot.4m.fd': Permission denied
```

## Fix

Changed `primary_disk()` to return the first disk whose format supports snapshots (qcow2), falling back to `self.disks.first()` if none found.

## Testing

- Created snapshot via TUI on a Windows 11 VM with UEFI/pflash configuration
- Snapshot created successfully on the qcow2 disk instead of the OVMF pflash file