### PR TITLE
Harden for v1.0.0: CI gates, tests, import-parser refactor, docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions: {}
+
+jobs:
+  check:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy (warnings denied)
+        run: cargo clippy --all-targets --locked -- -D warnings
+
+      - name: Test
+        run: cargo test --locked
+
+  audit:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+
+      # The dependency tree was clean (0 advisories) when this gate was added,
+      # so it blocks on any new RustSec advisory. Relax to continue-on-error
+      # only if a future advisory has no available fix.
+      - name: Audit dependencies
+        run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
+  # Run on pushes to main (post-merge) and on every PR. Branch pushes are covered
+  # by the pull_request trigger, avoiding duplicate runs on PR branches.
   push:
-    branches: ['**']
+    branches: [main]
   pull_request:
 
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+**v1.0.0**
+- **First stable release.** Focus of this release is release-engineering and code-hardening rather than new features; behavior is unchanged for existing users.
+- **CI quality gates** (`.github/workflows/ci.yml`): every push and pull request now runs `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --locked`, and `cargo audit`. Previously nothing ran tests or lints before a release tag was cut.
+- **Toolchain pin**: added `rust-toolchain.toml` (stable + clippy/rustfmt) so local, contributor, and CI builds agree; dropped the unenforced "Rust 1.70+" MSRV claim from the README.
+- **Lint clean-up**: added `#![warn(clippy::all)]` and fixed all clippy findings under `-D warnings`; the whole codebase is now `cargo fmt`-clean.
+- **Expanded test coverage**: new tests for `qemu-img` disk-format JSON parsing and for `Config` load/save (round-trip, partial/malformed TOML), via new path-parameterized `Config::load_from`/`save_to` helpers.
+- **Import parser refactor**: the ~360-line libvirt XML parser was split into a small state struct with focused per-event/element helpers; behavior-preserving, with added regression tests.
+- **Documentation**: crate-level public-API docs on the library root, module docs for the app state machine and UI dispatcher, and clarifying comments on intentional future-API `dead_code`; `cargo doc` is warning-free.
+
 **v0.4.10**
 - **First release with external contributions** — many thanks to [@Ibn-Hesham](https://github.com/Ibn-Hesham) and [@nextzard](https://github.com/nextzard) for the patches below!
 - **Nix Flake** (thanks @Ibn-Hesham, #32): Reproducible builds and dev shell. Adds `flake.nix` with `packages.default`, `devShells.default`, and `apps.default` outputs, plus a `flake.lock`. README updated with Nix/NixOS installation instructions. Build artifacts excluded via `.gitignore`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
 **v1.0.0**
-- **First stable release.** Focus of this release is release-engineering and code-hardening rather than new features; behavior is unchanged for existing users.
-- **CI quality gates** (`.github/workflows/ci.yml`): every push and pull request now runs `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --locked`, and `cargo audit`. Previously nothing ran tests or lints before a release tag was cut.
+- **First stable release.** Many thanks to [@indyfive11](https://github.com/indyfive11) for the library-API contributions below! Beyond those, this release focuses on release-engineering and code-hardening rather than new end-user features; existing TUI behavior is unchanged.
+- **Library target for GUI/external consumers** (thanks @indyfive11, #39): adds a `[lib]` target exposing the business-logic modules (`commands`, `config`, `fs`, `hardware`, `metadata`, `vm`, `wizard_types`) via `lib.rs`, with the `ui` (ratatui/crossterm) module intentionally excluded. Wizard/import state types were extracted into a front-end-agnostic `wizard_types` module. Also adds QMP-based VM control (pause/resume) and a D-Bus display launch path for GUI embedding.
+- **Detect immediate QEMU startup failures in D-Bus launch** (thanks @indyfive11, #40): `launch_vm_dbus` now polls `try_wait()` after 300ms (the same pattern as `launch_vm_with_error_check`) so a QEMU process that exits instantly — no session bus, an unrecognized flag, a missing shared library — surfaces an error with QEMU's stderr instead of returning a PID a GUI consumer would wait on forever.
+- **CI quality gates** (`.github/workflows/ci.yml`): every push to `main` and every pull request now runs `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --locked`, and `cargo audit`. Previously nothing ran tests or lints before a release tag was cut.
 - **Toolchain pin**: added `rust-toolchain.toml` (stable + clippy/rustfmt) so local, contributor, and CI builds agree; dropped the unenforced "Rust 1.70+" MSRV claim from the README.
 - **Lint clean-up**: added `#![warn(clippy::all)]` and fixed all clippy findings under `-D warnings`; the whole codebase is now `cargo fmt`-clean.
 - **Expanded test coverage**: new tests for `qemu-img` disk-format JSON parsing and for `Config` load/save (round-trip, partial/malformed TOML), via new path-parameterized `Config::load_from`/`save_to` helpers.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,6 +480,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1568,6 +1574,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "terminfo"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,6 +1839,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tempfile",
  "toml",
  "unicode-width",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ unicode-width = "0.2"
 once_cell = "1.19"
 quick-xml = "0.36"
 
+[dev-dependencies]
+tempfile = "3"
+
 [profile.release]
 lto = true
 strip = true

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The binary will be at `target/release/vm-curator`.
 
 **Prerequisites**
 - **Required**: QEMU (`qemu-system-*` binaries), qemu-img (for disk creation and snapshots), libudev
-- **Build**: Rust 1.70+, libudev-dev (Debian/Ubuntu) or systemd-libs (Arch/Fedora)
+- **Build**: a recent Rust stable toolchain (see `rust-toolchain.toml`), libudev-dev (Debian/Ubuntu) or systemd-libs (Arch/Fedora)
 - **Optional**:
   - OVMF/edk2 — UEFI boot support (`edk2-ovmf` on Arch, `ovmf` on Debian/Ubuntu)
   - virt-viewer — SPICE-app display backend
@@ -410,7 +410,7 @@ facts = ["Fact 1", "Fact 2"]
 ### Dependencies
 
 - **Runtime**: QEMU, qemu-img, libudev
-- **Build**: Rust 1.70+, libudev-dev (Debian/Ubuntu) or systemd-libs (Arch)
+- **Build**: a recent Rust stable toolchain (see `rust-toolchain.toml`), libudev-dev (Debian/Ubuntu) or systemd-libs (Arch)
 - **Optional**: OVMF/edk2 (UEFI), virt-viewer (SPICE-app), passt (networking), Looking Glass client (multi-GPU), polkit (bridge networking)
 
 ### Cross-Distribution Compatibility

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ A fast and friendly Rust TUI for managing desktop QEMU/KVM virtual machines — 
 
 ### Changelog
 
+**v1.0.0**
+- **First stable release** — many thanks to [@indyfive11](https://github.com/indyfive11) for the library-API contributions below! Otherwise this release focuses on release-engineering and code-hardening; existing TUI behavior is unchanged.
+- **Library target for GUI consumers** (thanks @indyfive11, #39): new `[lib]` target re-exporting the business-logic modules (`commands`, `config`, `fs`, `hardware`, `metadata`, `vm`, `wizard_types`) for external front-ends, plus QMP VM control (pause/resume) and a D-Bus display launch path
+- **Detect immediate QEMU startup failures** (thanks @indyfive11, #40): `launch_vm_dbus` now catches a QEMU process that exits within milliseconds and surfaces its stderr, instead of returning a PID a GUI would wait on forever
+- **CI quality gates**: every push to `main` and PR now runs fmt, clippy (`-D warnings`), tests, and `cargo audit`; added `rust-toolchain.toml`, expanded test coverage, refactored the libvirt import parser, and added public-API docs
+
 **v0.4.10**
 - **First release with external contributions** — many thanks to [@Ibn-Hesham](https://github.com/Ibn-Hesham) and [@nextzard](https://github.com/nextzard) for the patches below!
 - **Nix Flake** (thanks @Ibn-Hesham, #32): Reproducible builds and dev shell via `nix build` / `nix develop` — flake exposes `packages.default`, `devShells.default`, and `apps.default`

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+# Pin to stable so local builds, contributors, and CI all use one toolchain.
+# clippy + rustfmt are required by the CI quality gate (.github/workflows/ci.yml).
+channel = "stable"
+components = ["clippy", "rustfmt"]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,14 @@
+//! Application state machine.
+//!
+//! [`App`] owns all runtime state for the TUI, and the [`Screen`] enum enumerates
+//! the views the user can be on. Navigation is a stack (`push_screen`/`pop_screen`)
+//! so screens can return to wherever they were opened from. Long-running work (VM
+//! launch, snapshot operations) runs on background threads and reports back through
+//! `mpsc` channels that the main loop drains via `try_recv` each tick.
+//!
+//! This module is part of the binary only — it depends on the `ui` layer and is
+//! intentionally excluded from the public library API (see the crate root docs).
+
 use anyhow::Result;
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,9 +7,14 @@ use std::time::Instant;
 use crate::commands::qemu_system::NetworkCapabilities;
 use crate::config::Config;
 use crate::hardware::{MultiGpuPassthroughStatus, PciDevice, SingleGpuConfig, UsbDevice};
-use crate::metadata::{AsciiArtStore, HierarchyConfig, MetadataStore, OsInfo, QemuProfileStore, SettingsHelpStore, SharedFoldersHelpStore};
+use crate::metadata::{
+    AsciiArtStore, HierarchyConfig, MetadataStore, OsInfo, QemuProfileStore, SettingsHelpStore,
+    SharedFoldersHelpStore,
+};
 use crate::ui::widgets::build_visual_order;
-use crate::vm::{discover_vms, BootMode, DiscoveredVm, LaunchOptions, QemuProcess, SharedFolder, Snapshot};
+use crate::vm::{
+    discover_vms, BootMode, DiscoveredVm, LaunchOptions, QemuProcess, SharedFolder, Snapshot,
+};
 pub use crate::wizard_types::*;
 
 /// Application screens/views
@@ -266,12 +271,27 @@ pub struct FileBrowserEntry {
 
 /// Background operation result
 pub enum BackgroundResult {
-    SnapshotCreated { name: String, success: bool, error: Option<String> },
-    SnapshotRestored { name: String, success: bool, error: Option<String> },
-    SnapshotDeleted { name: String, success: bool, error: Option<String> },
+    SnapshotCreated {
+        name: String,
+        success: bool,
+        error: Option<String>,
+    },
+    SnapshotRestored {
+        name: String,
+        success: bool,
+        error: Option<String>,
+    },
+    SnapshotDeleted {
+        name: String,
+        success: bool,
+        error: Option<String>,
+    },
     /// Reserved for async snapshot loading
     #[allow(dead_code)]
-    SnapshotsLoaded { snapshots: Vec<Snapshot>, error: Option<String> },
+    SnapshotsLoaded {
+        snapshots: Vec<Snapshot>,
+        error: Option<String>,
+    },
 }
 
 impl App {
@@ -459,14 +479,14 @@ impl App {
 
     /// Get available network backend options based on detected capabilities
     pub fn get_network_backend_options(&self) -> Vec<(&str, &str)> {
-        let mut options = vec![
-            ("user", "User/SLIRP (NAT) - Default, works everywhere"),
-        ];
+        let mut options = vec![("user", "User/SLIRP (NAT) - Default, works everywhere")];
         if self.network_caps.passt_available {
             options.push(("passt", "passt - Fast NAT, ping works"));
         }
         if self.network_caps.bridge_helper_path.is_some() {
-            if !self.network_caps.system_bridges.is_empty() && self.network_caps.bridge_helper_configured {
+            if !self.network_caps.system_bridges.is_empty()
+                && self.network_caps.bridge_helper_configured
+            {
                 options.push(("bridge", "Bridge - Full network, own IP"));
             } else {
                 options.push(("bridge", "Bridge - Requires one-time setup"));
@@ -568,7 +588,12 @@ impl App {
         }
 
         // Rebuild visual order for hierarchy navigation
-        self.visual_order = build_visual_order(&self.vms, &self.filtered_indices, &self.hierarchy, &self.metadata);
+        self.visual_order = build_visual_order(
+            &self.vms,
+            &self.filtered_indices,
+            &self.hierarchy,
+            &self.metadata,
+        );
 
         // Reset selection if out of bounds
         if self.selected_vm >= self.visual_order.len() {
@@ -682,7 +707,8 @@ impl App {
 
     /// Remove the currently selected shared folder
     pub fn remove_shared_folder(&mut self) {
-        if !self.shared_folders.is_empty() && self.shared_folder_selected < self.shared_folders.len()
+        if !self.shared_folders.is_empty()
+            && self.shared_folder_selected < self.shared_folders.len()
         {
             self.shared_folders.remove(self.shared_folder_selected);
             if self.shared_folder_selected >= self.shared_folders.len()
@@ -724,7 +750,11 @@ impl App {
 
             // Try to find and select the paired audio device
             if let Some(audio) = crate::hardware::find_gpu_audio_pair(gpu, &self.pci_devices) {
-                if let Some(audio_idx) = self.pci_devices.iter().position(|d| d.address == audio.address) {
+                if let Some(audio_idx) = self
+                    .pci_devices
+                    .iter()
+                    .position(|d| d.address == audio.address)
+                {
                     self.selected_pci_devices.push(audio_idx);
                 }
             }
@@ -801,7 +831,11 @@ impl App {
         while let Ok(result) = self.background_rx.try_recv() {
             self.loading = false;
             match result {
-                BackgroundResult::SnapshotCreated { name, success, error } => {
+                BackgroundResult::SnapshotCreated {
+                    name,
+                    success,
+                    error,
+                } => {
                     if success {
                         self.set_status(format!("Created snapshot: {}", name));
                         // Reload snapshots
@@ -810,14 +844,22 @@ impl App {
                         self.set_status(format!("Error creating snapshot: {}", e));
                     }
                 }
-                BackgroundResult::SnapshotRestored { name, success, error } => {
+                BackgroundResult::SnapshotRestored {
+                    name,
+                    success,
+                    error,
+                } => {
                     if success {
                         self.set_status(format!("Restored snapshot: {}", name));
                     } else if let Some(e) = error {
                         self.set_status(format!("Error restoring snapshot: {}", e));
                     }
                 }
-                BackgroundResult::SnapshotDeleted { name, success, error } => {
+                BackgroundResult::SnapshotDeleted {
+                    name,
+                    success,
+                    error,
+                } => {
                     if success {
                         self.set_status(format!("Deleted snapshot: {}", name));
                         let _ = self.load_snapshots();
@@ -847,7 +889,8 @@ impl App {
         if let Some(processes) = latest {
             self.running_vms = self.match_running_vms(&processes);
             // Clean up stopping_vms for VMs that have actually stopped
-            self.stopping_vms.retain(|id, _| self.running_vms.contains_key(id));
+            self.stopping_vms
+                .retain(|id, _| self.running_vms.contains_key(id));
         }
     }
 
@@ -915,8 +958,12 @@ impl App {
             FileBrowserMode::Disk => &[".qcow2", ".QCOW2", ".qcow", ".QCOW"],
             FileBrowserMode::Directory => &[],
             FileBrowserMode::ImportConfig => &[".xml", ".XML", ".conf"],
-            FileBrowserMode::Bios => &[".bin", ".BIN", ".rom", ".ROM", ".qcow2", ".QCOW2", ".fd", ".FD"],
-            FileBrowserMode::Floppy => &[".img", ".IMG", ".ima", ".IMA", ".flp", ".FLP", ".vfd", ".VFD"],
+            FileBrowserMode::Bios => &[
+                ".bin", ".BIN", ".rom", ".ROM", ".qcow2", ".QCOW2", ".fd", ".FD",
+            ],
+            FileBrowserMode::Floppy => &[
+                ".img", ".IMG", ".ima", ".IMA", ".flp", ".FLP", ".vfd", ".VFD",
+            ],
         };
 
         // For Directory mode, add a [Select This Directory] sentinel entry first
@@ -965,8 +1012,8 @@ impl App {
             }
 
             // Sort alphabetically
-            dirs.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
-            files.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+            dirs.sort_by_key(|e| e.name.to_lowercase());
+            files.sort_by_key(|e| e.name.to_lowercase());
 
             self.file_browser_entries.extend(dirs);
             self.file_browser_entries.extend(files);
@@ -1023,7 +1070,8 @@ impl App {
     /// Save the editor content back to the launch.sh file
     pub fn save_script_from_editor(&mut self) -> Result<()> {
         // Get the launch script path before we need mutable access
-        let launch_script_path = self.selected_vm()
+        let launch_script_path = self
+            .selected_vm()
             .map(|vm| vm.launch_script.clone())
             .ok_or_else(|| anyhow::anyhow!("No VM selected"))?;
 
@@ -1084,7 +1132,8 @@ impl App {
 
     /// Save the editor content as notes to vm-curator.toml
     pub fn save_notes_from_editor(&mut self) -> Result<()> {
-        let vm = self.selected_vm()
+        let vm = self
+            .selected_vm()
             .ok_or_else(|| anyhow::anyhow!("No VM selected"))?;
 
         let vm_path = vm.path.clone();
@@ -1094,7 +1143,11 @@ impl App {
         let notes_text = self.script_editor_lines.join("\n");
         // Trim trailing whitespace/newlines
         let notes_text = notes_text.trim_end().to_string();
-        let notes = if notes_text.is_empty() { None } else { Some(notes_text.as_str()) };
+        let notes = if notes_text.is_empty() {
+            None
+        } else {
+            Some(notes_text.as_str())
+        };
 
         crate::vm::create::write_vm_metadata(
             &vm_path,
@@ -1187,18 +1240,31 @@ impl App {
 
         // Get full display name from metadata (e.g., "CachyOS (rolling)")
         // Fall back to profile's display_name if not in metadata
-        let new_display_name = self.metadata.get(os_id)
+        let new_display_name = self
+            .metadata
+            .get(os_id)
             .and_then(|info| info.display_name.clone())
-            .or_else(|| self.qemu_profiles.get(os_id).map(|p| p.display_name.clone()))
+            .or_else(|| {
+                self.qemu_profiles
+                    .get(os_id)
+                    .map(|p| p.display_name.clone())
+            })
             .unwrap_or_else(|| os_id.to_string());
 
         // Get the previous OS's display name (if any) to check if user customized the name
-        let previous_default_name = self.wizard_state.as_ref()
+        let previous_default_name = self
+            .wizard_state
+            .as_ref()
             .and_then(|s| s.selected_os.as_ref())
             .and_then(|prev_id| {
-                self.metadata.get(prev_id)
+                self.metadata
+                    .get(prev_id)
                     .and_then(|info| info.display_name.clone())
-                    .or_else(|| self.qemu_profiles.get(prev_id).map(|p| p.display_name.clone()))
+                    .or_else(|| {
+                        self.qemu_profiles
+                            .get(prev_id)
+                            .map(|p| p.display_name.clone())
+                    })
             });
 
         if let Some(ref mut state) = self.wizard_state {
@@ -1213,7 +1279,10 @@ impl App {
                 // 1. Name is empty, OR
                 // 2. Name matches the previous OS's default (user hasn't customized it)
                 let should_update_name = state.vm_name.is_empty()
-                    || previous_default_name.as_ref().map(|n| n == &state.vm_name).unwrap_or(false);
+                    || previous_default_name
+                        .as_ref()
+                        .map(|n| n == &state.vm_name)
+                        .unwrap_or(false);
 
                 if should_update_name {
                     state.vm_name = new_display_name;

--- a/src/commands/qemu_img.rs
+++ b/src/commands/qemu_img.rs
@@ -59,7 +59,67 @@ pub fn detect_disk_format(path: &Path) -> Option<String> {
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let json: serde_json::Value = serde_json::from_str(&stdout).ok()?;
+    parse_format_from_info_json(&stdout)
+}
 
+/// Extract the `format` field from the JSON emitted by `qemu-img info --output=json`.
+///
+/// Returns `None` if the JSON is malformed or has no string `format` field. Kept
+/// separate from [`detect_disk_format`] so the parsing logic is unit-testable
+/// without invoking `qemu-img`.
+fn parse_format_from_info_json(stdout: &str) -> Option<String> {
+    let json: serde_json::Value = serde_json::from_str(stdout).ok()?;
     json["format"].as_str().map(|s| s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn parse_format_qcow2() {
+        let json = r#"{"virtual-size":42949672960,"filename":"disk.qcow2","format":"qcow2","actual-size":200704}"#;
+        assert_eq!(parse_format_from_info_json(json), Some("qcow2".to_string()));
+    }
+
+    #[test]
+    fn parse_format_raw() {
+        let json = r#"{"format":"raw","virtual-size":1048576}"#;
+        assert_eq!(parse_format_from_info_json(json), Some("raw".to_string()));
+    }
+
+    #[test]
+    fn parse_format_missing_field() {
+        let json = r#"{"virtual-size":1048576,"filename":"disk.img"}"#;
+        assert_eq!(parse_format_from_info_json(json), None);
+    }
+
+    #[test]
+    fn parse_format_non_string_field() {
+        let json = r#"{"format":123}"#;
+        assert_eq!(parse_format_from_info_json(json), None);
+    }
+
+    #[test]
+    fn parse_format_malformed_json() {
+        assert_eq!(parse_format_from_info_json("not json at all"), None);
+        assert_eq!(parse_format_from_info_json(""), None);
+    }
+
+    #[test]
+    fn path_to_str_valid_utf8() {
+        let path = PathBuf::from("/tmp/disk.qcow2");
+        assert_eq!(path_to_str(&path).unwrap(), "/tmp/disk.qcow2");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn path_to_str_invalid_utf8_errors() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+        // 0xFF is not valid UTF-8.
+        let path = PathBuf::from(OsStr::from_bytes(b"/tmp/\xff.img"));
+        assert!(path_to_str(&path).is_err());
+    }
 }

--- a/src/commands/qemu_system.rs
+++ b/src/commands/qemu_system.rs
@@ -54,10 +54,7 @@ pub fn is_kvm_available() -> bool {
 /// Runs `<emulator> -display help` and parses the output to get
 /// the list of supported display backends (e.g., gtk, sdl, spice-app, vnc).
 pub fn get_supported_displays(emulator: &str) -> Vec<String> {
-    let output = match Command::new(emulator)
-        .args(["-display", "help"])
-        .output()
-    {
+    let output = match Command::new(emulator).args(["-display", "help"]).output() {
         Ok(o) => o,
         Err(_) => return Vec::new(),
     };
@@ -224,10 +221,7 @@ fn is_bridge_helper_configured(path: &Path) -> bool {
     }
 
     // Check capabilities via getcap
-    if let Ok(output) = Command::new("getcap")
-        .arg(path)
-        .output()
-    {
+    if let Ok(output) = Command::new("getcap").arg(path).output() {
         let stdout = String::from_utf8_lossy(&output.stdout);
         if stdout.contains("cap_net_admin") {
             return true;
@@ -287,7 +281,15 @@ For a short list of the suboptions for each display, see the top-level -help out
         let parsed = parse_display_help(raw);
         assert_eq!(
             parsed,
-            vec!["none", "gtk", "sdl", "egl-headless", "curses", "spice-app", "dbus"]
+            vec![
+                "none",
+                "gtk",
+                "sdl",
+                "egl-headless",
+                "curses",
+                "spice-app",
+                "dbus"
+            ]
         );
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -120,8 +120,7 @@ impl Config {
                 .with_context(|| format!("Failed to create config directory {:?}", parent))?;
         }
 
-        let content = toml::to_string_pretty(self)
-            .context("Failed to serialize config")?;
+        let content = toml::to_string_pretty(self).context("Failed to serialize config")?;
         std::fs::write(&config_path, content)
             .with_context(|| format!("Failed to write config to {:?}", config_path))?;
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Application configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -97,12 +97,18 @@ impl Default for Config {
 }
 
 impl Config {
-    /// Load configuration from file or create default
+    /// Load configuration from the default file path, or return defaults if absent.
     pub fn load() -> Result<Self> {
-        let config_path = Self::config_file_path();
+        Self::load_from(&Self::config_file_path())
+    }
 
+    /// Load configuration from a specific path, returning defaults if it does not exist.
+    ///
+    /// Path-parameterized so the load logic can be exercised in tests without
+    /// touching the real user config directory.
+    pub fn load_from(config_path: &Path) -> Result<Self> {
         if config_path.exists() {
-            let content = std::fs::read_to_string(&config_path)
+            let content = std::fs::read_to_string(config_path)
                 .with_context(|| format!("Failed to read config from {:?}", config_path))?;
             toml::from_str(&content)
                 .with_context(|| format!("Failed to parse config from {:?}", config_path))
@@ -111,17 +117,23 @@ impl Config {
         }
     }
 
-    /// Save configuration to file
+    /// Save configuration to the default file path.
     pub fn save(&self) -> Result<()> {
-        let config_path = Self::config_file_path();
+        self.save_to(&Self::config_file_path())
+    }
 
+    /// Save configuration to a specific path, creating parent directories as needed.
+    ///
+    /// Path-parameterized so the save logic can be exercised in tests without
+    /// touching the real user config directory.
+    pub fn save_to(&self, config_path: &Path) -> Result<()> {
         if let Some(parent) = config_path.parent() {
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("Failed to create config directory {:?}", parent))?;
         }
 
         let content = toml::to_string_pretty(self).context("Failed to serialize config")?;
-        std::fs::write(&config_path, content)
+        std::fs::write(config_path, content)
             .with_context(|| format!("Failed to write config to {:?}", config_path))?;
 
         Ok(())
@@ -133,5 +145,75 @@ impl Config {
             .unwrap_or_else(|| PathBuf::from(".config"))
             .join("vm-curator")
             .join("config.toml")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_from_missing_path_returns_default() {
+        let cfg = Config::load_from(Path::new("/nonexistent/vm-curator/config.toml")).unwrap();
+        let default = Config::default();
+        assert_eq!(cfg.snapshot_prefix, default.snapshot_prefix);
+        assert_eq!(cfg.default_memory_mb, default.default_memory_mb);
+        assert_eq!(cfg.vm_library_path, default.vm_library_path);
+    }
+
+    #[test]
+    fn save_then_load_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("config.toml");
+
+        let cfg = Config {
+            snapshot_prefix: "custom-prefix".to_string(),
+            default_memory_mb: 8192,
+            default_iso_path: Some(PathBuf::from("/tmp/isos")),
+            single_gpu_enabled: true,
+            ..Config::default()
+        };
+
+        // save_to should create the missing parent directory.
+        cfg.save_to(&path).unwrap();
+        assert!(path.exists());
+
+        let loaded = Config::load_from(&path).unwrap();
+        assert_eq!(loaded.snapshot_prefix, "custom-prefix");
+        assert_eq!(loaded.default_memory_mb, 8192);
+        assert_eq!(loaded.default_iso_path, Some(PathBuf::from("/tmp/isos")));
+        assert!(loaded.single_gpu_enabled);
+    }
+
+    #[test]
+    fn load_from_partial_toml_fills_defaults() {
+        // `#[serde(default)]` on the struct means a partial file is valid and
+        // missing fields fall back to defaults.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "snapshot_prefix = \"partial\"\n").unwrap();
+
+        let loaded = Config::load_from(&path).unwrap();
+        assert_eq!(loaded.snapshot_prefix, "partial");
+        // Untouched field uses the default.
+        assert_eq!(
+            loaded.default_cpu_cores,
+            Config::default().default_cpu_cores
+        );
+    }
+
+    #[test]
+    fn load_from_malformed_toml_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "this is = not valid = toml = [[[").unwrap();
+
+        assert!(Config::load_from(&path).is_err());
+    }
+
+    #[test]
+    fn config_file_path_ends_with_expected_segments() {
+        let path = Config::config_file_path();
+        assert!(path.ends_with("vm-curator/config.toml"));
     }
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -70,7 +70,7 @@ fn is_btrfs_from_mounts(path: &Path) -> bool {
         })
         .collect();
 
-    mount_entries.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+    mount_entries.sort_by_key(|e| std::cmp::Reverse(e.0.len()));
 
     for (mount_point, fs_type) in mount_entries {
         if path_str.starts_with(mount_point) || mount_point == "/" {
@@ -95,9 +95,7 @@ pub fn disable_cow(path: &Path) -> Result<()> {
         let stderr = String::from_utf8_lossy(&output.stderr);
         // Don't fail if chattr isn't available or permission denied
         // Just log and continue - this is an optimization, not critical
-        if !stderr.contains("Operation not supported")
-            && !stderr.contains("Inappropriate ioctl")
-        {
+        if !stderr.contains("Operation not supported") && !stderr.contains("Inappropriate ioctl") {
             anyhow::bail!("chattr +C failed: {}", stderr.trim());
         }
     }

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -18,4 +18,6 @@ pub use single_gpu::{
 pub use pci::find_iommu_group_devices;
 #[allow(unused_imports)]
 pub use single_gpu::{DisplayManager, GpuDriver};
-pub use usb::{enumerate_usb_devices, install_udev_rules, UdevInstallResult, UsbDevice, UsbVersion};
+pub use usb::{
+    enumerate_usb_devices, install_udev_rules, UdevInstallResult, UsbDevice, UsbVersion,
+};

--- a/src/hardware/pci.rs
+++ b/src/hardware/pci.rs
@@ -168,10 +168,7 @@ impl PciDevice {
                 self.device_name.clone()
             }
         } else {
-            format!(
-                "PCI Device {:04x}:{:04x}",
-                self.vendor_id, self.device_id
-            )
+            format!("PCI Device {:04x}:{:04x}", self.vendor_id, self.device_id)
         }
     }
 
@@ -286,7 +283,11 @@ impl MultiGpuPassthroughStatus {
             format!(
                 "Ready ({} GPU{} available)",
                 self.passthrough_gpus.len(),
-                if self.passthrough_gpus.len() == 1 { "" } else { "s" }
+                if self.passthrough_gpus.len() == 1 {
+                    ""
+                } else {
+                    "s"
+                }
             )
         } else {
             let mut issues = Vec::new();
@@ -367,16 +368,16 @@ fn read_pci_device(path: &Path, address: &str) -> Result<PciDevice> {
 
 /// Read hex value from sysfs as u16
 fn read_sysfs_hex_u16(path: &Path, attr: &str) -> Result<u16> {
-    let value = fs::read_to_string(path.join(attr))
-        .with_context(|| format!("Failed to read {}", attr))?;
+    let value =
+        fs::read_to_string(path.join(attr)).with_context(|| format!("Failed to read {}", attr))?;
     let value = value.trim().trim_start_matches("0x");
     u16::from_str_radix(value, 16).context("Failed to parse hex value")
 }
 
 /// Read hex value from sysfs as u32
 fn read_sysfs_hex_u32(path: &Path, attr: &str) -> Result<u32> {
-    let value = fs::read_to_string(path.join(attr))
-        .with_context(|| format!("Failed to read {}", attr))?;
+    let value =
+        fs::read_to_string(path.join(attr)).with_context(|| format!("Failed to read {}", attr))?;
     let value = value.trim().trim_start_matches("0x");
     u32::from_str_radix(value, 16).context("Failed to parse hex value")
 }
@@ -404,13 +405,11 @@ fn read_driver_binding(path: &Path) -> Option<String> {
 fn read_iommu_group(path: &Path) -> Option<u32> {
     let iommu_link = path.join("iommu_group");
     if iommu_link.exists() {
-        fs::read_link(&iommu_link)
-            .ok()
-            .and_then(|p| {
-                p.file_name()
-                    .and_then(|n| n.to_str())
-                    .and_then(|s| s.parse().ok())
-            })
+        fs::read_link(&iommu_link).ok().and_then(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .and_then(|s| s.parse().ok())
+        })
     } else {
         None
     }
@@ -568,13 +567,18 @@ pub fn check_multi_gpu_passthrough_status() -> MultiGpuPassthroughStatus {
     // Check IOMMU
     status.iommu_enabled = check_iommu_enabled();
     if !status.iommu_enabled {
-        status.errors.push("IOMMU is not enabled. Add intel_iommu=on or amd_iommu=on to kernel parameters.".to_string());
+        status.errors.push(
+            "IOMMU is not enabled. Add intel_iommu=on or amd_iommu=on to kernel parameters."
+                .to_string(),
+        );
     }
 
     // Check VFIO modules
     status.vfio_loaded = check_vfio_modules();
     if !status.vfio_loaded {
-        status.errors.push("VFIO modules not loaded. Run: sudo modprobe vfio-pci".to_string());
+        status
+            .errors
+            .push("VFIO modules not loaded. Run: sudo modprobe vfio-pci".to_string());
     }
 
     // Enumerate GPUs
@@ -598,7 +602,9 @@ pub fn check_multi_gpu_passthrough_status() -> MultiGpuPassthroughStatus {
     status.available_gpus = status.passthrough_gpus.len();
 
     if status.available_gpus == 0 && status.boot_vga.is_some() {
-        status.errors.push("Only one GPU found (boot VGA). Need a secondary GPU for passthrough.".to_string());
+        status.errors.push(
+            "Only one GPU found (boot VGA). Need a secondary GPU for passthrough.".to_string(),
+        );
     }
 
     status

--- a/src/hardware/single_gpu.rs
+++ b/src/hardware/single_gpu.rs
@@ -151,10 +151,7 @@ pub fn detect_display_manager() -> DisplayManager {
     }
 
     // Check systemctl get-default for graphical target
-    if let Ok(output) = Command::new("systemctl")
-        .args(["get-default"])
-        .output()
-    {
+    if let Ok(output) = Command::new("systemctl").args(["get-default"]).output() {
         let target = String::from_utf8_lossy(&output.stdout);
         if target.contains("graphical") {
             // Check which DM is set as display-manager
@@ -338,9 +335,18 @@ pub fn save_config(vm_path: &Path, config: &SingleGpuConfig) -> anyhow::Result<(
     content.push_str(&format!("address = \"{}\"\n", config.gpu.address));
     content.push_str(&format!("vendor_id = \"0x{:04x}\"\n", config.gpu.vendor_id));
     content.push_str(&format!("device_id = \"0x{:04x}\"\n", config.gpu.device_id));
-    content.push_str(&format!("vendor_name = \"{}\"\n", config.gpu.vendor_name.replace('"', "\\\"")));
-    content.push_str(&format!("device_name = \"{}\"\n", config.gpu.device_name.replace('"', "\\\"")));
-    content.push_str(&format!("class_code = \"0x{:06x}\"\n", config.gpu.class_code));
+    content.push_str(&format!(
+        "vendor_name = \"{}\"\n",
+        config.gpu.vendor_name.replace('"', "\\\"")
+    ));
+    content.push_str(&format!(
+        "device_name = \"{}\"\n",
+        config.gpu.device_name.replace('"', "\\\"")
+    ));
+    content.push_str(&format!(
+        "class_code = \"0x{:06x}\"\n",
+        config.gpu.class_code
+    ));
     if let Some(ref driver) = config.gpu.driver {
         content.push_str(&format!("driver = \"{}\"\n", driver));
     }
@@ -354,8 +360,14 @@ pub fn save_config(vm_path: &Path, config: &SingleGpuConfig) -> anyhow::Result<(
         content.push_str(&format!("address = \"{}\"\n", audio.address));
         content.push_str(&format!("vendor_id = \"0x{:04x}\"\n", audio.vendor_id));
         content.push_str(&format!("device_id = \"0x{:04x}\"\n", audio.device_id));
-        content.push_str(&format!("vendor_name = \"{}\"\n", audio.vendor_name.replace('"', "\\\"")));
-        content.push_str(&format!("device_name = \"{}\"\n", audio.device_name.replace('"', "\\\"")));
+        content.push_str(&format!(
+            "vendor_name = \"{}\"\n",
+            audio.vendor_name.replace('"', "\\\"")
+        ));
+        content.push_str(&format!(
+            "device_name = \"{}\"\n",
+            audio.device_name.replace('"', "\\\"")
+        ));
         content.push_str(&format!("class_code = \"0x{:06x}\"\n", audio.class_code));
         if let Some(ref driver) = audio.driver {
             content.push_str(&format!("driver = \"{}\"\n", driver));
@@ -366,8 +378,14 @@ pub fn save_config(vm_path: &Path, config: &SingleGpuConfig) -> anyhow::Result<(
     }
 
     content.push_str("\n[settings]\n");
-    content.push_str(&format!("original_driver = \"{}\"\n", config.original_driver.module_name()));
-    content.push_str(&format!("display_manager = \"{}\"\n", config.display_manager.service_name()));
+    content.push_str(&format!(
+        "original_driver = \"{}\"\n",
+        config.original_driver.module_name()
+    ));
+    content.push_str(&format!(
+        "display_manager = \"{}\"\n",
+        config.display_manager.service_name()
+    ));
 
     fs::write(&config_path, content)?;
     Ok(())
@@ -414,7 +432,7 @@ pub fn load_config(vm_path: &Path) -> Option<SingleGpuConfig> {
         }
 
         if line.starts_with('[') && line.ends_with(']') {
-            current_section = &line[1..line.len()-1];
+            current_section = &line[1..line.len() - 1];
             continue;
         }
 

--- a/src/hardware/usb.rs
+++ b/src/hardware/usb.rs
@@ -77,7 +77,6 @@ impl UsbDevice {
             format!("USB Device {:04x}:{:04x}", self.vendor_id, self.product_id)
         }
     }
-
 }
 
 /// Enumerate USB devices using libudev
@@ -87,7 +86,10 @@ pub fn enumerate_usb_devices() -> Result<Vec<UsbDevice>> {
         Ok(devs) => devs,
         Err(e) => {
             // Log the fallback for debugging purposes
-            eprintln!("vm-curator: libudev enumeration failed ({}), falling back to sysfs", e);
+            eprintln!(
+                "vm-curator: libudev enumeration failed ({}), falling back to sysfs",
+                e
+            );
             enumerate_via_sysfs().unwrap_or_default()
         }
     };
@@ -103,10 +105,11 @@ fn enumerate_via_udev() -> Result<Vec<UsbDevice>> {
     use libudev::Context;
 
     let context = Context::new().context("Failed to create udev context")?;
-    let mut enumerator = libudev::Enumerator::new(&context)
-        .context("Failed to create udev enumerator")?;
+    let mut enumerator =
+        libudev::Enumerator::new(&context).context("Failed to create udev enumerator")?;
 
-    enumerator.match_subsystem("usb")
+    enumerator
+        .match_subsystem("usb")
         .context("Failed to match USB subsystem")?;
 
     let mut devices = Vec::new();
@@ -286,7 +289,9 @@ pub enum UdevInstallResult {
 pub fn generate_udev_rules(devices: &[UsbDevice]) -> String {
     let mut rules = String::new();
     rules.push_str("# USB Passthrough rules for QEMU (managed by vm-curator)\n");
-    rules.push_str("# These rules allow non-root users to access USB devices for VM passthrough\n\n");
+    rules.push_str(
+        "# These rules allow non-root users to access USB devices for VM passthrough\n\n",
+    );
 
     // Collect unique vendor IDs to avoid duplicate rules
     let mut seen_vendors = std::collections::HashSet::new();
@@ -366,7 +371,9 @@ pub fn install_udev_rules(devices: &[UsbDevice]) -> UdevInstallResult {
             }
         }
         Some(false) => UdevInstallResult::PermissionDenied,
-        None => UdevInstallResult::Error("No suitable privilege escalation method found".to_string()),
+        None => {
+            UdevInstallResult::Error("No suitable privilege escalation method found".to_string())
+        }
     }
 }
 
@@ -374,7 +381,13 @@ fn try_pkexec_install(temp_path: &str, rules_path: &str) -> Option<bool> {
     use std::process::Command;
 
     // Check if pkexec is available
-    if Command::new("which").arg("pkexec").output().ok()?.status.success() {
+    if Command::new("which")
+        .arg("pkexec")
+        .output()
+        .ok()?
+        .status
+        .success()
+    {
         // Use pkexec to copy the file
         let status = Command::new("pkexec")
             .args(["cp", temp_path, rules_path])
@@ -391,7 +404,13 @@ fn try_sudo_install(temp_path: &str, rules_path: &str) -> Option<bool> {
     use std::process::{Command, Stdio};
 
     // Check if sudo is available
-    if !Command::new("which").arg("sudo").output().ok()?.status.success() {
+    if !Command::new("which")
+        .arg("sudo")
+        .output()
+        .ok()?
+        .status
+        .success()
+    {
         return None;
     }
 
@@ -425,10 +444,7 @@ fn reload_udev_rules() -> bool {
     }
 
     // Fall back to sudo
-    if let Ok(status) = Command::new("sudo")
-        .args(["sh", "-c", reload_cmd])
-        .status()
-    {
+    if let Ok(status) = Command::new("sudo").args(["sh", "-c", reload_cmd]).status() {
         return status.success();
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,29 @@
-// Library target for GUI and other external consumers.
-// The `ui` and `app` modules are intentionally excluded:
-// `ui` contains ratatui/crossterm TUI rendering code, and `app`
-// references `ui` types, so neither can be part of the public lib API.
+#![warn(clippy::all)]
+//! # vm-curator
+//!
+//! Core library for [vm-curator](https://github.com/mroboff/vm-curator), a TUI for
+//! managing QEMU/KVM virtual machines.
+//!
+//! This crate exposes the non-UI building blocks so that alternative front-ends
+//! (a GUI, a daemon, scripts) can reuse the same VM discovery, launch-script
+//! parsing/generation, snapshot, hardware-passthrough, import, and metadata
+//! logic that powers the terminal interface.
+//!
+//! ## Public modules
+//!
+//! - [`vm`] — VM discovery, launch-script parsing/generation, lifecycle, snapshots, import
+//! - [`commands`] — wrappers around `qemu-img` and QEMU system binaries
+//! - [`hardware`] — USB / PCI / GPU passthrough enumeration and configuration
+//! - [`metadata`] — OS profiles, QEMU profiles, family hierarchy, ASCII art
+//! - [`config`] — user settings persisted under `~/.config/vm-curator/`
+//! - [`wizard_types`] — front-end-agnostic state types for the creation/import flows
+//! - [`fs`] — small filesystem helpers
+//!
+//! ## Intentionally excluded
+//!
+//! The `ui` and `app` modules are **not** part of the public API: `ui` contains
+//! ratatui/crossterm TUI rendering code, and `app` references `ui` types, so
+//! neither can be consumed independently of the terminal front-end.
 pub mod commands;
 pub mod config;
 pub mod fs;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,10 @@
+#![warn(clippy::all)]
+// The TUI event handlers deliberately keep an `if <guard> { ... }` inside each
+// `match` arm rather than folding the condition into a match guard. Collapsing
+// these (often into compound `&&` guards) hurts readability in the key/mouse
+// dispatch code, so this stylistic lint is allowed crate-wide.
+#![allow(clippy::collapsible_match)]
+
 mod app;
 mod commands;
 mod config;
@@ -112,7 +119,11 @@ fn main() -> Result<()> {
     // Handle subcommands
     match cli.command {
         Some(Commands::List) => cmd_list(&config),
-        Some(Commands::Launch { name, install, cdrom }) => cmd_launch(&config, &name, install, cdrom),
+        Some(Commands::Launch {
+            name,
+            install,
+            cdrom,
+        }) => cmd_launch(&config, &name, install, cdrom),
         Some(Commands::Info { name }) => cmd_info(&config, &name),
         Some(Commands::Snapshot { name, action }) => cmd_snapshot(&config, &name, action),
         Some(Commands::Emulators) => cmd_emulators(),
@@ -171,8 +182,12 @@ fn prompt_vm_library_setup(mut config: Config) -> Result<Config> {
     print!("Creating directory {:?}... ", config.vm_library_path);
     io::stdout().flush()?;
 
-    let cow_disabled = fs::setup_vm_directory(&config.vm_library_path)
-        .with_context(|| format!("Failed to create VM library directory {:?}", config.vm_library_path))?;
+    let cow_disabled = fs::setup_vm_directory(&config.vm_library_path).with_context(|| {
+        format!(
+            "Failed to create VM library directory {:?}",
+            config.vm_library_path
+        )
+    })?;
 
     println!("\x1b[32m✓\x1b[0m");
 
@@ -199,11 +214,7 @@ impl Drop for TerminalGuard {
     fn drop(&mut self) {
         // Best effort restoration - ignore errors since we may be panicking
         let _ = disable_raw_mode();
-        let _ = execute!(
-            io::stdout(),
-            LeaveAlternateScreen,
-            DisableMouseCapture
-        );
+        let _ = execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture);
         let _ = crossterm::cursor::Show;
     }
 }
@@ -257,7 +268,10 @@ fn print_loading_progress(step: usize, total: usize, message: &str) {
     let percent = (step * 100) / total;
 
     print!("\r\x1b[K"); // Clear line
-    print!("\x1b[90m[\x1b[36m{}\x1b[90m]\x1b[0m {:>3}% {}", bar, percent, message);
+    print!(
+        "\x1b[90m[\x1b[36m{}\x1b[90m]\x1b[0m {:>3}% {}",
+        bar, percent, message
+    );
     let _ = io::stdout().flush();
 }
 
@@ -360,10 +374,7 @@ fn cmd_info(config: &Config, name: &str) -> Result<()> {
     println!();
     println!("Disks:");
     for disk in &vm.config.disks {
-        println!(
-            "  {:?} ({:?}, {})",
-            disk.path, disk.format, disk.interface
-        );
+        println!("  {:?} ({:?}, {})", disk.path, disk.format, disk.interface);
     }
 
     println!();

--- a/src/metadata/ascii_art.rs
+++ b/src/metadata/ascii_art.rs
@@ -19,9 +19,14 @@ impl AsciiArtStore {
         if let Ok(entries) = std::fs::read_dir(dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                if path.extension().map(|e| e == "txt" || e == "ascii").unwrap_or(false) {
+                if path
+                    .extension()
+                    .map(|e| e == "txt" || e == "ascii")
+                    .unwrap_or(false)
+                {
                     if let Ok(content) = std::fs::read_to_string(&path) {
-                        let id = path.file_stem()
+                        let id = path
+                            .file_stem()
                             .and_then(|s| s.to_str())
                             .unwrap_or("")
                             .to_string();
@@ -39,62 +44,176 @@ impl AsciiArtStore {
         let mut store = Self::default();
 
         // Windows logos
-        store.art.insert("windows-31".to_string(), include_str!("../../assets/ascii/windows-31.txt").to_string());
-        store.art.insert("windows-95".to_string(), include_str!("../../assets/ascii/windows-95.txt").to_string());
-        store.art.insert("windows-98".to_string(), include_str!("../../assets/ascii/windows-98.txt").to_string());
-        store.art.insert("windows-98se".to_string(), include_str!("../../assets/ascii/windows-98se.txt").to_string());
-        store.art.insert("windows-me".to_string(), include_str!("../../assets/ascii/windows-me.txt").to_string());
-        store.art.insert("windows-2000".to_string(), include_str!("../../assets/ascii/windows-2000.txt").to_string());
-        store.art.insert("windows-xp".to_string(), include_str!("../../assets/ascii/windows-xp.txt").to_string());
-        store.art.insert("windows-vista".to_string(), include_str!("../../assets/ascii/windows-vista.txt").to_string());
-        store.art.insert("windows-7".to_string(), include_str!("../../assets/ascii/windows-7.txt").to_string());
-        store.art.insert("windows-10".to_string(), include_str!("../../assets/ascii/windows-10.txt").to_string());
-        store.art.insert("windows-11".to_string(), include_str!("../../assets/ascii/windows-11.txt").to_string());
+        store.art.insert(
+            "windows-31".to_string(),
+            include_str!("../../assets/ascii/windows-31.txt").to_string(),
+        );
+        store.art.insert(
+            "windows-95".to_string(),
+            include_str!("../../assets/ascii/windows-95.txt").to_string(),
+        );
+        store.art.insert(
+            "windows-98".to_string(),
+            include_str!("../../assets/ascii/windows-98.txt").to_string(),
+        );
+        store.art.insert(
+            "windows-98se".to_string(),
+            include_str!("../../assets/ascii/windows-98se.txt").to_string(),
+        );
+        store.art.insert(
+            "windows-me".to_string(),
+            include_str!("../../assets/ascii/windows-me.txt").to_string(),
+        );
+        store.art.insert(
+            "windows-2000".to_string(),
+            include_str!("../../assets/ascii/windows-2000.txt").to_string(),
+        );
+        store.art.insert(
+            "windows-xp".to_string(),
+            include_str!("../../assets/ascii/windows-xp.txt").to_string(),
+        );
+        store.art.insert(
+            "windows-vista".to_string(),
+            include_str!("../../assets/ascii/windows-vista.txt").to_string(),
+        );
+        store.art.insert(
+            "windows-7".to_string(),
+            include_str!("../../assets/ascii/windows-7.txt").to_string(),
+        );
+        store.art.insert(
+            "windows-10".to_string(),
+            include_str!("../../assets/ascii/windows-10.txt").to_string(),
+        );
+        store.art.insert(
+            "windows-11".to_string(),
+            include_str!("../../assets/ascii/windows-11.txt").to_string(),
+        );
 
         // DOS logos
-        store.art.insert("ms-dos".to_string(), include_str!("../../assets/ascii/ms-dos.txt").to_string());
-        store.art.insert("dos".to_string(), include_str!("../../assets/ascii/ms-dos.txt").to_string());
-        store.art.insert("my-first-pc".to_string(), include_str!("../../assets/ascii/ms-dos.txt").to_string());
+        store.art.insert(
+            "ms-dos".to_string(),
+            include_str!("../../assets/ascii/ms-dos.txt").to_string(),
+        );
+        store.art.insert(
+            "dos".to_string(),
+            include_str!("../../assets/ascii/ms-dos.txt").to_string(),
+        );
+        store.art.insert(
+            "my-first-pc".to_string(),
+            include_str!("../../assets/ascii/ms-dos.txt").to_string(),
+        );
 
         // Mac logos
-        store.art.insert("mac-system7".to_string(), include_str!("../../assets/ascii/mac-system7.txt").to_string());
-        store.art.insert("mac-os9".to_string(), include_str!("../../assets/ascii/mac-os9.txt").to_string());
-        store.art.insert("mac-osx".to_string(), include_str!("../../assets/ascii/mac-osx.txt").to_string());
-        store.art.insert("mac-osx-tiger".to_string(), include_str!("../../assets/ascii/mac-osx-tiger.txt").to_string());
-        store.art.insert("mac-osx-leopard".to_string(), include_str!("../../assets/ascii/mac-osx-leopard.txt").to_string());
+        store.art.insert(
+            "mac-system7".to_string(),
+            include_str!("../../assets/ascii/mac-system7.txt").to_string(),
+        );
+        store.art.insert(
+            "mac-os9".to_string(),
+            include_str!("../../assets/ascii/mac-os9.txt").to_string(),
+        );
+        store.art.insert(
+            "mac-osx".to_string(),
+            include_str!("../../assets/ascii/mac-osx.txt").to_string(),
+        );
+        store.art.insert(
+            "mac-osx-tiger".to_string(),
+            include_str!("../../assets/ascii/mac-osx-tiger.txt").to_string(),
+        );
+        store.art.insert(
+            "mac-osx-leopard".to_string(),
+            include_str!("../../assets/ascii/mac-osx-leopard.txt").to_string(),
+        );
 
         // Linux logos
-        store.art.insert("linux".to_string(), include_str!("../../assets/ascii/linux.txt").to_string());
-        store.art.insert("linux-fedora".to_string(), include_str!("../../assets/ascii/linux-fedora.txt").to_string());
-        store.art.insert("linux-debian".to_string(), include_str!("../../assets/ascii/linux-debian.txt").to_string());
-        store.art.insert("linux-ubuntu".to_string(), include_str!("../../assets/ascii/linux-ubuntu.txt").to_string());
-        store.art.insert("linux-mint".to_string(), include_str!("../../assets/ascii/linux-mint.txt").to_string());
-        store.art.insert("linux-pop".to_string(), include_str!("../../assets/ascii/linux-pop.txt").to_string());
-        store.art.insert("linux-zorin".to_string(), include_str!("../../assets/ascii/linux-zorin.txt").to_string());
-        store.art.insert("linux-cachyos".to_string(), include_str!("../../assets/ascii/linux-cachyos.txt").to_string());
-        store.art.insert("linux-garuda".to_string(), include_str!("../../assets/ascii/linux-garuda.txt").to_string());
-        store.art.insert("linux-bazzite".to_string(), include_str!("../../assets/ascii/linux-bazzite.txt").to_string());
-        store.art.insert("nix-os".to_string(), include_str!("../../assets/ascii/nix-os.txt").to_string());
+        store.art.insert(
+            "linux".to_string(),
+            include_str!("../../assets/ascii/linux.txt").to_string(),
+        );
+        store.art.insert(
+            "linux-fedora".to_string(),
+            include_str!("../../assets/ascii/linux-fedora.txt").to_string(),
+        );
+        store.art.insert(
+            "linux-debian".to_string(),
+            include_str!("../../assets/ascii/linux-debian.txt").to_string(),
+        );
+        store.art.insert(
+            "linux-ubuntu".to_string(),
+            include_str!("../../assets/ascii/linux-ubuntu.txt").to_string(),
+        );
+        store.art.insert(
+            "linux-mint".to_string(),
+            include_str!("../../assets/ascii/linux-mint.txt").to_string(),
+        );
+        store.art.insert(
+            "linux-pop".to_string(),
+            include_str!("../../assets/ascii/linux-pop.txt").to_string(),
+        );
+        store.art.insert(
+            "linux-zorin".to_string(),
+            include_str!("../../assets/ascii/linux-zorin.txt").to_string(),
+        );
+        store.art.insert(
+            "linux-cachyos".to_string(),
+            include_str!("../../assets/ascii/linux-cachyos.txt").to_string(),
+        );
+        store.art.insert(
+            "linux-garuda".to_string(),
+            include_str!("../../assets/ascii/linux-garuda.txt").to_string(),
+        );
+        store.art.insert(
+            "linux-bazzite".to_string(),
+            include_str!("../../assets/ascii/linux-bazzite.txt").to_string(),
+        );
+        store.art.insert(
+            "nix-os".to_string(),
+            include_str!("../../assets/ascii/nix-os.txt").to_string(),
+        );
 
         // BSD logos
-        store.art.insert("freebsd".to_string(), include_str!("../../assets/ascii/freebsd.txt").to_string());
+        store.art.insert(
+            "freebsd".to_string(),
+            include_str!("../../assets/ascii/freebsd.txt").to_string(),
+        );
 
         // Unix logos
-        store.art.insert("solaris".to_string(), include_str!("../../assets/ascii/solaris.txt").to_string());
+        store.art.insert(
+            "solaris".to_string(),
+            include_str!("../../assets/ascii/solaris.txt").to_string(),
+        );
 
         // IBM / OS2 logos
-        store.art.insert("os2-warp3".to_string(), include_str!("../../assets/ascii/os2-warp3.txt").to_string());
-        store.art.insert("os2-warp4".to_string(), include_str!("../../assets/ascii/os2-warp4.txt").to_string());
+        store.art.insert(
+            "os2-warp3".to_string(),
+            include_str!("../../assets/ascii/os2-warp3.txt").to_string(),
+        );
+        store.art.insert(
+            "os2-warp4".to_string(),
+            include_str!("../../assets/ascii/os2-warp4.txt").to_string(),
+        );
 
         // Be / Haiku logos
-        store.art.insert("beos".to_string(), include_str!("../../assets/ascii/beos.txt").to_string());
-        store.art.insert("haiku".to_string(), include_str!("../../assets/ascii/haiku.txt").to_string());
+        store.art.insert(
+            "beos".to_string(),
+            include_str!("../../assets/ascii/beos.txt").to_string(),
+        );
+        store.art.insert(
+            "haiku".to_string(),
+            include_str!("../../assets/ascii/haiku.txt").to_string(),
+        );
 
         // NeXT logos
-        store.art.insert("nextstep".to_string(), include_str!("../../assets/ascii/nextstep.txt").to_string());
+        store.art.insert(
+            "nextstep".to_string(),
+            include_str!("../../assets/ascii/nextstep.txt").to_string(),
+        );
 
         // Research OS logos
-        store.art.insert("plan9".to_string(), include_str!("../../assets/ascii/plan9.txt").to_string());
+        store.art.insert(
+            "plan9".to_string(),
+            include_str!("../../assets/ascii/plan9.txt").to_string(),
+        );
 
         store
     }

--- a/src/metadata/hierarchy.rs
+++ b/src/metadata/hierarchy.rs
@@ -104,7 +104,8 @@ impl HierarchyConfig {
         let raw: HierarchyToml = toml::from_str(content)?;
 
         // Convert families
-        let mut families: Vec<Family> = raw.families
+        let mut families: Vec<Family> = raw
+            .families
             .into_iter()
             .map(|(id, f)| Family {
                 id,
@@ -116,7 +117,8 @@ impl HierarchyConfig {
         families.sort_by_key(|f| f.order);
 
         // Convert subcategories
-        let mut subcategories: Vec<Subcategory> = raw.subcategories
+        let mut subcategories: Vec<Subcategory> = raw
+            .subcategories
             .into_iter()
             .map(|(id, s)| {
                 let sort_by = match s.sort_by.as_deref() {

--- a/src/metadata/os_info.rs
+++ b/src/metadata/os_info.rs
@@ -77,7 +77,8 @@ impl MetadataStore {
             if path.extension().map(|e| e == "toml").unwrap_or(false) {
                 if let Ok(content) = std::fs::read_to_string(&path) {
                     if let Ok(info) = toml::from_str::<OsInfo>(&content) {
-                        let id = path.file_stem()
+                        let id = path
+                            .file_stem()
                             .and_then(|s| s.to_str())
                             .unwrap_or("")
                             .to_string();
@@ -174,7 +175,8 @@ fn guess_os_details(vm_id: &str) -> (String, String) {
     let id = vm_id.to_lowercase();
 
     if id.contains("windows") {
-        let arch = if id.contains("11") || id.contains("10") || id.contains("8") || id.contains("7") {
+        let arch = if id.contains("11") || id.contains("10") || id.contains("8") || id.contains("7")
+        {
             "x86_64"
         } else {
             "i386"

--- a/src/metadata/qemu_profiles.rs
+++ b/src/metadata/qemu_profiles.rs
@@ -290,11 +290,8 @@ impl QemuProfileStore {
     /// Get all unique categories
     #[allow(dead_code)]
     pub fn categories(&self) -> Vec<String> {
-        let mut categories: Vec<String> = self
-            .profiles
-            .values()
-            .map(|p| p.category.clone())
-            .collect();
+        let mut categories: Vec<String> =
+            self.profiles.values().map(|p| p.category.clone()).collect();
         categories.sort();
         categories.dedup();
         categories

--- a/src/metadata/tests/qemu_profiles.rs
+++ b/src/metadata/tests/qemu_profiles.rs
@@ -56,21 +56,45 @@ fn test_classic_mac_bios_rom_config() {
 
     // m68k Mac profiles should have required bios_rom
     let system6 = store.get("mac-system6").expect("Should have mac-system6");
-    assert!(system6.bios_rom.is_some(), "mac-system6 should have bios_rom config");
-    assert!(system6.bios_rom.as_ref().unwrap().required, "mac-system6 bios_rom should be required");
+    assert!(
+        system6.bios_rom.is_some(),
+        "mac-system6 should have bios_rom config"
+    );
+    assert!(
+        system6.bios_rom.as_ref().unwrap().required,
+        "mac-system6 bios_rom should be required"
+    );
 
     let system7 = store.get("mac-system7").expect("Should have mac-system7");
-    assert!(system7.bios_rom.is_some(), "mac-system7 should have bios_rom config");
-    assert!(system7.bios_rom.as_ref().unwrap().required, "mac-system7 bios_rom should be required");
+    assert!(
+        system7.bios_rom.is_some(),
+        "mac-system7 should have bios_rom config"
+    );
+    assert!(
+        system7.bios_rom.as_ref().unwrap().required,
+        "mac-system7 bios_rom should be required"
+    );
 
     // PPC Mac profiles should have optional bios_rom
     let os8 = store.get("mac-os8").expect("Should have mac-os8");
-    assert!(os8.bios_rom.is_some(), "mac-os8 should have bios_rom config");
-    assert!(!os8.bios_rom.as_ref().unwrap().required, "mac-os8 bios_rom should be optional");
+    assert!(
+        os8.bios_rom.is_some(),
+        "mac-os8 should have bios_rom config"
+    );
+    assert!(
+        !os8.bios_rom.as_ref().unwrap().required,
+        "mac-os8 bios_rom should be optional"
+    );
 
     let os9 = store.get("mac-os9").expect("Should have mac-os9");
-    assert!(os9.bios_rom.is_some(), "mac-os9 should have bios_rom config");
-    assert!(!os9.bios_rom.as_ref().unwrap().required, "mac-os9 bios_rom should be optional");
+    assert!(
+        os9.bios_rom.is_some(),
+        "mac-os9 should have bios_rom config"
+    );
+    assert!(
+        !os9.bios_rom.as_ref().unwrap().required,
+        "mac-os9 bios_rom should be optional"
+    );
 }
 
 #[test]
@@ -78,10 +102,16 @@ fn test_non_mac_profiles_no_bios_rom() {
     let store = QemuProfileStore::load_embedded();
 
     let win10 = store.get("windows-10").expect("Should have windows-10");
-    assert!(win10.bios_rom.is_none(), "windows-10 should not have bios_rom");
+    assert!(
+        win10.bios_rom.is_none(),
+        "windows-10 should not have bios_rom"
+    );
 
     let debian = store.get("linux-debian").expect("Should have linux-debian");
-    assert!(debian.bios_rom.is_none(), "linux-debian should not have bios_rom");
+    assert!(
+        debian.bios_rom.is_none(),
+        "linux-debian should not have bios_rom"
+    );
 }
 
 #[test]

--- a/src/tests/fs.rs
+++ b/src/tests/fs.rs
@@ -3,10 +3,9 @@ use std::path::PathBuf;
 
 #[test]
 fn test_is_btrfs_nonexistent() {
-    // Should not panic on non-existent path
-    let result = is_btrfs(&PathBuf::from("/nonexistent/path/12345"));
-    // Result depends on root filesystem type
-    assert!(result == true || result == false);
+    // Should not panic on non-existent path; the bool value depends on the
+    // root filesystem type, so we only assert that the call returns cleanly.
+    let _result = is_btrfs(&PathBuf::from("/nonexistent/path/12345"));
 }
 
 #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,12 @@
+//! Terminal rendering and input dispatch.
+//!
+//! This module is the front-end event loop: [`run`] drives the draw/poll cycle,
+//! the render path matches on [`crate::app::Screen`] and delegates to the
+//! per-screen modules in [`screens`], and the key/mouse handlers route input the
+//! same way. Reusable rendering pieces live in [`widgets`]. Screen-specific layout
+//! and input logic stays in the individual `screens::*` modules; this file is the
+//! dispatcher that ties them to the [`crate::app::App`] state.
+
 pub mod screens;
 pub mod widgets;
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,8 +3,8 @@ pub mod widgets;
 
 use anyhow::Result;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
-use ratatui::prelude::*;
 use ratatui::backend::CrosstermBackend;
+use ratatui::prelude::*;
 use regex::Regex;
 use std::io::Stdout;
 use std::time::{Duration, Instant};
@@ -66,17 +66,15 @@ fn handle_mouse(app: &mut App, mouse: MouseEvent) -> Result<()> {
                 app.select_next();
             }
         }
-        MouseEventKind::Down(crossterm::event::MouseButton::Left) => {
-            match &app.screen {
-                Screen::MainMenu => {
-                    handle_main_menu_click(app, mouse.column, mouse.row)?;
-                }
-                Screen::Confirm(action) => {
-                    handle_confirm_click(app, action.clone(), mouse.column, mouse.row)?;
-                }
-                _ => {}
+        MouseEventKind::Down(crossterm::event::MouseButton::Left) => match &app.screen {
+            Screen::MainMenu => {
+                handle_main_menu_click(app, mouse.column, mouse.row)?;
             }
-        }
+            Screen::Confirm(action) => {
+                handle_confirm_click(app, action.clone(), mouse.column, mouse.row)?;
+            }
+            _ => {}
+        },
         _ => {}
     }
     Ok(())
@@ -133,7 +131,12 @@ fn handle_main_menu_click(app: &mut App, click_x: u16, click_y: u16) -> Result<(
 }
 
 /// Handle mouse click in the confirmation dialog
-fn handle_confirm_click(app: &mut App, action: ConfirmAction, click_x: u16, click_y: u16) -> Result<()> {
+fn handle_confirm_click(
+    app: &mut App,
+    action: ConfirmAction,
+    click_x: u16,
+    click_y: u16,
+) -> Result<()> {
     if let Ok((term_width, term_height)) = crossterm::terminal::size() {
         let area = Rect::new(0, 0, term_width, term_height);
 
@@ -170,8 +173,10 @@ fn handle_confirm_click(app: &mut App, action: ConfirmAction, click_x: u16, clic
         }
 
         // Allow clicking outside the dialog to cancel
-        if click_x < dialog_x || click_x >= dialog_x + dialog_width
-            || click_y < dialog_y || click_y >= dialog_y + dialog_height
+        if click_x < dialog_x
+            || click_x >= dialog_x + dialog_width
+            || click_y < dialog_y
+            || click_y >= dialog_y + dialog_height
         {
             app.pop_screen();
         }
@@ -321,7 +326,11 @@ fn execute_confirm_action(app: &mut App, action: ConfirmAction) -> Result<()> {
                             app.set_status(format!("Force stopped {}", vm.display_name()));
                         }
                         Err(e) => {
-                            app.set_status(format!("Failed to force stop {}: {}", vm.display_name(), e));
+                            app.set_status(format!(
+                                "Failed to force stop {}: {}",
+                                vm.display_name(),
+                                e
+                            ));
                         }
                     }
                 }
@@ -485,7 +494,17 @@ fn handle_key(app: &mut App, key: KeyEvent) -> Result<()> {
 
     // Global quit with q/Q (except in text input modes where q might be typed)
     if (key.code == KeyCode::Char('q') || key.code == KeyCode::Char('Q'))
-        && !matches!(app.screen, Screen::Search | Screen::TextInput(_) | Screen::RawScript | Screen::EditNotes | Screen::CreateWizard | Screen::CreateWizardCustomOs | Screen::NetworkSettings | Screen::ImportWizard)
+        && !matches!(
+            app.screen,
+            Screen::Search
+                | Screen::TextInput(_)
+                | Screen::RawScript
+                | Screen::EditNotes
+                | Screen::CreateWizard
+                | Screen::CreateWizardCustomOs
+                | Screen::NetworkSettings
+                | Screen::ImportWizard
+        )
     {
         app.should_quit = true;
         return Ok(());
@@ -517,7 +536,9 @@ fn handle_key(app: &mut App, key: KeyEvent) -> Result<()> {
         Screen::CreateWizardCustomOs => screens::create_wizard::handle_custom_os_key(app, key)?,
         Screen::CreateWizardDownload => screens::create_wizard::handle_download_key(app, key)?,
         Screen::NetworkSettings => screens::network_settings::handle_key(app, key)?,
-        Screen::Settings => { screens::settings::handle_input(app, key)?; }
+        Screen::Settings => {
+            screens::settings::handle_input(app, key)?;
+        }
         Screen::ImportWizard => screens::import_wizard::handle_key(app, key)?,
     }
 
@@ -597,7 +618,16 @@ fn handle_management(app: &mut App, key: KeyEvent) -> Result<()> {
         KeyCode::Esc => app.pop_screen(),
         KeyCode::Char('j') | KeyCode::Down => app.menu_next(item_count),
         KeyCode::Char('k') | KeyCode::Up => app.menu_prev(),
-        KeyCode::Enter | KeyCode::Char('1') | KeyCode::Char('2') | KeyCode::Char('3') | KeyCode::Char('4') | KeyCode::Char('5') | KeyCode::Char('6') | KeyCode::Char('7') | KeyCode::Char('8') | KeyCode::Char('9') => {
+        KeyCode::Enter
+        | KeyCode::Char('1')
+        | KeyCode::Char('2')
+        | KeyCode::Char('3')
+        | KeyCode::Char('4')
+        | KeyCode::Char('5')
+        | KeyCode::Char('6')
+        | KeyCode::Char('7')
+        | KeyCode::Char('8')
+        | KeyCode::Char('9') => {
             // Map number keys to menu index
             let selected_idx = match key.code {
                 KeyCode::Char('1') => 0,
@@ -622,7 +652,9 @@ fn handle_management(app: &mut App, key: KeyEvent) -> Result<()> {
                                 if app.selected_vm_pid().is_some() {
                                     if let Some(sent_at) = app.stopping_vms.get(&vm.id) {
                                         if sent_at.elapsed() > Duration::from_secs(10) {
-                                            app.push_screen(Screen::Confirm(ConfirmAction::ForceStopVm));
+                                            app.push_screen(Screen::Confirm(
+                                                ConfirmAction::ForceStopVm,
+                                            ));
                                         } else {
                                             app.set_status(format!(
                                                 "Waiting for {} to shut down...",
@@ -681,31 +713,43 @@ fn handle_management(app: &mut App, key: KeyEvent) -> Result<()> {
                             // Initialize network settings state from current VM config
                             if let Some(vm) = app.selected_vm() {
                                 let net = vm.config.network.as_ref();
-                                let model = net.map(|n| n.model.clone()).unwrap_or_else(|| "e1000".to_string());
-                                let (backend, bridge_name) = net.map(|n| {
-                                    match &n.backend {
-                                        crate::vm::qemu_config::NetworkBackend::User => ("user".to_string(), None),
-                                        crate::vm::qemu_config::NetworkBackend::Passt => ("passt".to_string(), None),
-                                        crate::vm::qemu_config::NetworkBackend::Bridge(name) => ("bridge".to_string(), Some(name.clone())),
-                                        crate::vm::qemu_config::NetworkBackend::None => ("none".to_string(), None),
-                                    }
-                                }).unwrap_or_else(|| ("user".to_string(), None));
-                                let port_forwards = net.map(|n| n.port_forwards.clone()).unwrap_or_default();
+                                let model = net
+                                    .map(|n| n.model.clone())
+                                    .unwrap_or_else(|| "e1000".to_string());
+                                let (backend, bridge_name) = net
+                                    .map(|n| match &n.backend {
+                                        crate::vm::qemu_config::NetworkBackend::User => {
+                                            ("user".to_string(), None)
+                                        }
+                                        crate::vm::qemu_config::NetworkBackend::Passt => {
+                                            ("passt".to_string(), None)
+                                        }
+                                        crate::vm::qemu_config::NetworkBackend::Bridge(name) => {
+                                            ("bridge".to_string(), Some(name.clone()))
+                                        }
+                                        crate::vm::qemu_config::NetworkBackend::None => {
+                                            ("none".to_string(), None)
+                                        }
+                                    })
+                                    .unwrap_or_else(|| ("user".to_string(), None));
+                                let port_forwards =
+                                    net.map(|n| n.port_forwards.clone()).unwrap_or_default();
                                 let mac_address = net.and_then(|n| n.mac_address.clone());
 
-                                app.network_settings_state = Some(crate::app::NetworkSettingsState {
-                                    model,
-                                    backend,
-                                    bridge_name,
-                                    port_forwards,
-                                    mac_address: mac_address.clone(),
-                                    mac_edit_buffer: mac_address.unwrap_or_default(),
-                                    editing_mac: false,
-                                    selected_field: 0,
-                                    editing_port_forwards: false,
-                                    pf_selected: 0,
-                                    adding_pf: None,
-                                });
+                                app.network_settings_state =
+                                    Some(crate::app::NetworkSettingsState {
+                                        model,
+                                        backend,
+                                        bridge_name,
+                                        port_forwards,
+                                        mac_address: mac_address.clone(),
+                                        mac_edit_buffer: mac_address.unwrap_or_default(),
+                                        editing_mac: false,
+                                        selected_field: 0,
+                                        editing_port_forwards: false,
+                                        pf_selected: 0,
+                                        adding_pf: None,
+                                    });
                                 app.push_screen(Screen::NetworkSettings);
                             }
                         }
@@ -813,8 +857,11 @@ fn handle_raw_script(app: &mut App, key: KeyEvent) -> Result<()> {
             if app.script_editor_cursor.0 > 0 {
                 app.script_editor_cursor.0 -= 1;
                 // Adjust column if new line is shorter
-                let line_len = app.script_editor_lines.get(app.script_editor_cursor.0)
-                    .map(|l| l.len()).unwrap_or(0);
+                let line_len = app
+                    .script_editor_lines
+                    .get(app.script_editor_cursor.0)
+                    .map(|l| l.len())
+                    .unwrap_or(0);
                 if app.script_editor_cursor.1 > line_len {
                     app.script_editor_cursor.1 = line_len;
                 }
@@ -828,15 +875,19 @@ fn handle_raw_script(app: &mut App, key: KeyEvent) -> Result<()> {
             if app.script_editor_cursor.0 < total_lines.saturating_sub(1) {
                 app.script_editor_cursor.0 += 1;
                 // Adjust column if new line is shorter
-                let line_len = app.script_editor_lines.get(app.script_editor_cursor.0)
-                    .map(|l| l.len()).unwrap_or(0);
+                let line_len = app
+                    .script_editor_lines
+                    .get(app.script_editor_cursor.0)
+                    .map(|l| l.len())
+                    .unwrap_or(0);
                 if app.script_editor_cursor.1 > line_len {
                     app.script_editor_cursor.1 = line_len;
                 }
                 // Scroll down if needed (assuming ~35 visible lines)
                 let visible_height = 35usize;
                 if app.script_editor_cursor.0 >= app.raw_script_scroll as usize + visible_height {
-                    app.raw_script_scroll = (app.script_editor_cursor.0 - visible_height + 1) as u16;
+                    app.raw_script_scroll =
+                        (app.script_editor_cursor.0 - visible_height + 1) as u16;
                 }
             }
         }
@@ -846,8 +897,11 @@ fn handle_raw_script(app: &mut App, key: KeyEvent) -> Result<()> {
             } else if app.script_editor_cursor.0 > 0 {
                 // Move to end of previous line
                 app.script_editor_cursor.0 -= 1;
-                app.script_editor_cursor.1 = app.script_editor_lines.get(app.script_editor_cursor.0)
-                    .map(|l| l.len()).unwrap_or(0);
+                app.script_editor_cursor.1 = app
+                    .script_editor_lines
+                    .get(app.script_editor_cursor.0)
+                    .map(|l| l.len())
+                    .unwrap_or(0);
             }
             // Adjust horizontal scroll
             if app.script_editor_cursor.1 < app.script_editor_h_scroll {
@@ -855,8 +909,11 @@ fn handle_raw_script(app: &mut App, key: KeyEvent) -> Result<()> {
             }
         }
         (KeyCode::Right, _) => {
-            let line_len = app.script_editor_lines.get(app.script_editor_cursor.0)
-                .map(|l| l.len()).unwrap_or(0);
+            let line_len = app
+                .script_editor_lines
+                .get(app.script_editor_cursor.0)
+                .map(|l| l.len())
+                .unwrap_or(0);
             if app.script_editor_cursor.1 < line_len {
                 app.script_editor_cursor.1 += 1;
             } else if app.script_editor_cursor.0 < total_lines.saturating_sub(1) {
@@ -875,8 +932,11 @@ fn handle_raw_script(app: &mut App, key: KeyEvent) -> Result<()> {
             app.script_editor_h_scroll = 0;
         }
         (KeyCode::End, _) => {
-            let line_len = app.script_editor_lines.get(app.script_editor_cursor.0)
-                .map(|l| l.len()).unwrap_or(0);
+            let line_len = app
+                .script_editor_lines
+                .get(app.script_editor_cursor.0)
+                .map(|l| l.len())
+                .unwrap_or(0);
             app.script_editor_cursor.1 = line_len;
         }
         (KeyCode::PageUp, _) => {
@@ -884,19 +944,27 @@ fn handle_raw_script(app: &mut App, key: KeyEvent) -> Result<()> {
             app.script_editor_cursor.0 = app.script_editor_cursor.0.saturating_sub(jump);
             app.raw_script_scroll = app.raw_script_scroll.saturating_sub(jump as u16);
             // Adjust column
-            let line_len = app.script_editor_lines.get(app.script_editor_cursor.0)
-                .map(|l| l.len()).unwrap_or(0);
+            let line_len = app
+                .script_editor_lines
+                .get(app.script_editor_cursor.0)
+                .map(|l| l.len())
+                .unwrap_or(0);
             if app.script_editor_cursor.1 > line_len {
                 app.script_editor_cursor.1 = line_len;
             }
         }
         (KeyCode::PageDown, _) => {
             let jump = 20;
-            app.script_editor_cursor.0 = (app.script_editor_cursor.0 + jump).min(total_lines.saturating_sub(1));
-            app.raw_script_scroll = (app.raw_script_scroll + jump as u16).min(total_lines.saturating_sub(1) as u16);
+            app.script_editor_cursor.0 =
+                (app.script_editor_cursor.0 + jump).min(total_lines.saturating_sub(1));
+            app.raw_script_scroll =
+                (app.raw_script_scroll + jump as u16).min(total_lines.saturating_sub(1) as u16);
             // Adjust column
-            let line_len = app.script_editor_lines.get(app.script_editor_cursor.0)
-                .map(|l| l.len()).unwrap_or(0);
+            let line_len = app
+                .script_editor_lines
+                .get(app.script_editor_cursor.0)
+                .map(|l| l.len())
+                .unwrap_or(0);
             if app.script_editor_cursor.1 > line_len {
                 app.script_editor_cursor.1 = line_len;
             }
@@ -945,7 +1013,10 @@ fn handle_raw_script(app: &mut App, key: KeyEvent) -> Result<()> {
                 } else if line_idx < total_lines - 1 {
                     // Join with next line
                     let next_line = app.script_editor_lines.remove(line_idx + 1);
-                    app.script_editor_lines.get_mut(line_idx).unwrap().push_str(&next_line);
+                    app.script_editor_lines
+                        .get_mut(line_idx)
+                        .unwrap()
+                        .push_str(&next_line);
                     app.script_editor_modified = true;
                 }
             }
@@ -1003,8 +1074,11 @@ fn handle_edit_notes(app: &mut App, key: KeyEvent) -> Result<()> {
         (KeyCode::Up, _) => {
             if app.script_editor_cursor.0 > 0 {
                 app.script_editor_cursor.0 -= 1;
-                let line_len = app.script_editor_lines.get(app.script_editor_cursor.0)
-                    .map(|l| l.len()).unwrap_or(0);
+                let line_len = app
+                    .script_editor_lines
+                    .get(app.script_editor_cursor.0)
+                    .map(|l| l.len())
+                    .unwrap_or(0);
                 if app.script_editor_cursor.1 > line_len {
                     app.script_editor_cursor.1 = line_len;
                 }
@@ -1016,14 +1090,18 @@ fn handle_edit_notes(app: &mut App, key: KeyEvent) -> Result<()> {
         (KeyCode::Down, _) => {
             if app.script_editor_cursor.0 < total_lines.saturating_sub(1) {
                 app.script_editor_cursor.0 += 1;
-                let line_len = app.script_editor_lines.get(app.script_editor_cursor.0)
-                    .map(|l| l.len()).unwrap_or(0);
+                let line_len = app
+                    .script_editor_lines
+                    .get(app.script_editor_cursor.0)
+                    .map(|l| l.len())
+                    .unwrap_or(0);
                 if app.script_editor_cursor.1 > line_len {
                     app.script_editor_cursor.1 = line_len;
                 }
                 let visible_height = 35usize;
                 if app.script_editor_cursor.0 >= app.raw_script_scroll as usize + visible_height {
-                    app.raw_script_scroll = (app.script_editor_cursor.0 - visible_height + 1) as u16;
+                    app.raw_script_scroll =
+                        (app.script_editor_cursor.0 - visible_height + 1) as u16;
                 }
             }
         }
@@ -1032,16 +1110,22 @@ fn handle_edit_notes(app: &mut App, key: KeyEvent) -> Result<()> {
                 app.script_editor_cursor.1 -= 1;
             } else if app.script_editor_cursor.0 > 0 {
                 app.script_editor_cursor.0 -= 1;
-                app.script_editor_cursor.1 = app.script_editor_lines.get(app.script_editor_cursor.0)
-                    .map(|l| l.len()).unwrap_or(0);
+                app.script_editor_cursor.1 = app
+                    .script_editor_lines
+                    .get(app.script_editor_cursor.0)
+                    .map(|l| l.len())
+                    .unwrap_or(0);
             }
             if app.script_editor_cursor.1 < app.script_editor_h_scroll {
                 app.script_editor_h_scroll = app.script_editor_cursor.1;
             }
         }
         (KeyCode::Right, _) => {
-            let line_len = app.script_editor_lines.get(app.script_editor_cursor.0)
-                .map(|l| l.len()).unwrap_or(0);
+            let line_len = app
+                .script_editor_lines
+                .get(app.script_editor_cursor.0)
+                .map(|l| l.len())
+                .unwrap_or(0);
             if app.script_editor_cursor.1 < line_len {
                 app.script_editor_cursor.1 += 1;
             } else if app.script_editor_cursor.0 < total_lines.saturating_sub(1) {
@@ -1058,26 +1142,37 @@ fn handle_edit_notes(app: &mut App, key: KeyEvent) -> Result<()> {
             app.script_editor_h_scroll = 0;
         }
         (KeyCode::End, _) => {
-            let line_len = app.script_editor_lines.get(app.script_editor_cursor.0)
-                .map(|l| l.len()).unwrap_or(0);
+            let line_len = app
+                .script_editor_lines
+                .get(app.script_editor_cursor.0)
+                .map(|l| l.len())
+                .unwrap_or(0);
             app.script_editor_cursor.1 = line_len;
         }
         (KeyCode::PageUp, _) => {
             let jump = 20;
             app.script_editor_cursor.0 = app.script_editor_cursor.0.saturating_sub(jump);
             app.raw_script_scroll = app.raw_script_scroll.saturating_sub(jump as u16);
-            let line_len = app.script_editor_lines.get(app.script_editor_cursor.0)
-                .map(|l| l.len()).unwrap_or(0);
+            let line_len = app
+                .script_editor_lines
+                .get(app.script_editor_cursor.0)
+                .map(|l| l.len())
+                .unwrap_or(0);
             if app.script_editor_cursor.1 > line_len {
                 app.script_editor_cursor.1 = line_len;
             }
         }
         (KeyCode::PageDown, _) => {
             let jump = 20;
-            app.script_editor_cursor.0 = (app.script_editor_cursor.0 + jump).min(total_lines.saturating_sub(1));
-            app.raw_script_scroll = (app.raw_script_scroll + jump as u16).min(total_lines.saturating_sub(1) as u16);
-            let line_len = app.script_editor_lines.get(app.script_editor_cursor.0)
-                .map(|l| l.len()).unwrap_or(0);
+            app.script_editor_cursor.0 =
+                (app.script_editor_cursor.0 + jump).min(total_lines.saturating_sub(1));
+            app.raw_script_scroll =
+                (app.raw_script_scroll + jump as u16).min(total_lines.saturating_sub(1) as u16);
+            let line_len = app
+                .script_editor_lines
+                .get(app.script_editor_cursor.0)
+                .map(|l| l.len())
+                .unwrap_or(0);
             if app.script_editor_cursor.1 > line_len {
                 app.script_editor_cursor.1 = line_len;
             }
@@ -1124,7 +1219,10 @@ fn handle_edit_notes(app: &mut App, key: KeyEvent) -> Result<()> {
                     app.script_editor_modified = true;
                 } else if line_idx < total_lines - 1 {
                     let next_line = app.script_editor_lines.remove(line_idx + 1);
-                    app.script_editor_lines.get_mut(line_idx).unwrap().push_str(&next_line);
+                    app.script_editor_lines
+                        .get_mut(line_idx)
+                        .unwrap()
+                        .push_str(&next_line);
                     app.script_editor_modified = true;
                 }
             }
@@ -1186,18 +1284,23 @@ fn handle_snapshots(app: &mut App, key: KeyEvent) -> Result<()> {
                     app.set_status("Warning: VM is running. Snapshot may be inconsistent.");
                 }
                 // Pre-fill with timestamp-based suggestion
-                app.text_input_buffer = format!("snapshot-{}", chrono::Local::now().format("%Y%m%d-%H%M%S"));
+                app.text_input_buffer =
+                    format!("snapshot-{}", chrono::Local::now().format("%Y%m%d-%H%M%S"));
                 app.push_screen(Screen::TextInput(TextInputContext::SnapshotName));
             }
         }
         KeyCode::Char('r') => {
             if let Some(snap) = app.snapshots.get(app.selected_snapshot) {
-                app.push_screen(Screen::Confirm(ConfirmAction::RestoreSnapshot(snap.name.clone())));
+                app.push_screen(Screen::Confirm(ConfirmAction::RestoreSnapshot(
+                    snap.name.clone(),
+                )));
             }
         }
         KeyCode::Char('d') => {
             if let Some(snap) = app.snapshots.get(app.selected_snapshot) {
-                app.push_screen(Screen::Confirm(ConfirmAction::DeleteSnapshot(snap.name.clone())));
+                app.push_screen(Screen::Confirm(ConfirmAction::DeleteSnapshot(
+                    snap.name.clone(),
+                )));
             }
         }
         _ => {}
@@ -1212,7 +1315,12 @@ fn handle_boot_options(app: &mut App, key: KeyEvent) -> Result<()> {
         KeyCode::Esc => app.pop_screen(),
         KeyCode::Char('j') | KeyCode::Down => app.menu_next(5),
         KeyCode::Char('k') | KeyCode::Up => app.menu_prev(),
-        KeyCode::Enter | KeyCode::Char('1') | KeyCode::Char('2') | KeyCode::Char('3') | KeyCode::Char('4') | KeyCode::Char('5') => {
+        KeyCode::Enter
+        | KeyCode::Char('1')
+        | KeyCode::Char('2')
+        | KeyCode::Char('3')
+        | KeyCode::Char('4')
+        | KeyCode::Char('5') => {
             let item = match key.code {
                 KeyCode::Char('1') => 0,
                 KeyCode::Char('2') => 1,
@@ -1268,7 +1376,11 @@ fn handle_display_options(app: &mut App, key: KeyEvent) -> Result<()> {
         }
         KeyCode::Char('j') | KeyCode::Down => app.menu_next(option_count),
         KeyCode::Char('k') | KeyCode::Up => app.menu_prev(),
-        KeyCode::Enter | KeyCode::Char('1') | KeyCode::Char('2') | KeyCode::Char('3') | KeyCode::Char('4') => {
+        KeyCode::Enter
+        | KeyCode::Char('1')
+        | KeyCode::Char('2')
+        | KeyCode::Char('3')
+        | KeyCode::Char('4') => {
             let item = match key.code {
                 KeyCode::Char('1') => 0,
                 KeyCode::Char('2') => 1,
@@ -1284,7 +1396,9 @@ fn handle_display_options(app: &mut App, key: KeyEvent) -> Result<()> {
                     match update_vm_display(&vm.launch_script, &display_name) {
                         Ok(()) => {
                             // Show spice-app warning if viewer not installed
-                            if display_name.contains("spice") && !crate::commands::qemu_system::is_spice_viewer_available() {
+                            if display_name.contains("spice")
+                                && !crate::commands::qemu_system::is_spice_viewer_available()
+                            {
                                 app.set_status(format!("Display changed to {}. Warning: virt-viewer/remote-viewer not found!", display_name));
                             } else {
                                 app.set_status(format!("Display changed to {}", display_name));
@@ -1339,7 +1453,9 @@ fn toggle_vm_gl_acceleration(script_path: &std::path::Path) -> Result<GlToggleRe
         // Replace `-vga <X>` with `-device virtio-vga-gl`.
         let vga_re = Regex::new(r"-vga\s+[\w-]+")?;
         let after_vga = if vga_re.is_match(&content) {
-            vga_re.replace_all(&content, "-device virtio-vga-gl").to_string()
+            vga_re
+                .replace_all(&content, "-device virtio-vga-gl")
+                .to_string()
         } else {
             content.clone()
         };
@@ -1364,7 +1480,9 @@ fn toggle_vm_gl_acceleration(script_path: &std::path::Path) -> Result<GlToggleRe
     };
 
     std::fs::write(script_path, new_content)?;
-    Ok(GlToggleResult { display_swapped_to_sdl })
+    Ok(GlToggleResult {
+        display_swapped_to_sdl,
+    })
 }
 
 /// Update the display setting in a VM's launch script
@@ -1377,13 +1495,15 @@ fn update_vm_display(script_path: &std::path::Path, new_display: &str) -> Result
 
     let new_content = if display_re.is_match(&content) {
         // Replace existing -display setting, preserving gl=on if present
-        display_re.replace_all(&content, |caps: &regex::Captures| {
-            if caps.get(2).is_some() {
-                format!("-display {},gl=on", new_display)
-            } else {
-                format!("-display {}", new_display)
-            }
-        }).to_string()
+        display_re
+            .replace_all(&content, |caps: &regex::Captures| {
+                if caps.get(2).is_some() {
+                    format!("-display {},gl=on", new_display)
+                } else {
+                    format!("-display {}", new_display)
+                }
+            })
+            .to_string()
     } else {
         // No -display found, this shouldn't happen for wizard-generated scripts
         // but handle gracefully
@@ -1401,7 +1521,8 @@ fn handle_usb_devices(app: &mut App, key: KeyEvent) -> Result<()> {
             app.pop_screen();
         }
         KeyCode::Char('j') | KeyCode::Down => {
-            app.selected_menu_item = (app.selected_menu_item + 1).min(app.usb_devices.len().saturating_sub(1));
+            app.selected_menu_item =
+                (app.selected_menu_item + 1).min(app.usb_devices.len().saturating_sub(1));
         }
         KeyCode::Char('k') | KeyCode::Up => {
             if app.selected_menu_item > 0 {
@@ -1448,7 +1569,9 @@ fn handle_usb_devices(app: &mut App, key: KeyEvent) -> Result<()> {
                         if let Some(vm) = app.selected_vm() {
                             if crate::hardware::scripts_exist(&vm.path) {
                                 // Try with in-memory config first, fall back to saved config
-                                let regen_result = if let Some(config) = app.single_gpu_config.as_ref() {
+                                let regen_result = if let Some(config) =
+                                    app.single_gpu_config.as_ref()
+                                {
                                     crate::vm::single_gpu_scripts::regenerate_if_exists(vm, config)
                                 } else {
                                     crate::vm::single_gpu_scripts::regenerate_from_saved_config(vm)
@@ -1491,7 +1614,9 @@ fn handle_usb_devices(app: &mut App, key: KeyEvent) -> Result<()> {
                 // The install function will handle elevation
                 match crate::hardware::install_udev_rules(&selected_devices) {
                     crate::hardware::UdevInstallResult::Success => {
-                        app.set_status("USB permissions installed! Devices should now work without sudo.");
+                        app.set_status(
+                            "USB permissions installed! Devices should now work without sudo.",
+                        );
                     }
                     crate::hardware::UdevInstallResult::NeedsReboot => {
                         app.set_status("Rules installed. Please unplug/replug devices or reboot.");
@@ -1562,7 +1687,8 @@ fn render_detailed_info(app: &App, frame: &mut Frame) {
     let dialog_area = centered_rect(dialog_width, dialog_height, area);
     frame.render_widget(ratatui::widgets::Clear, dialog_area);
 
-    let vm_name = app.selected_vm()
+    let vm_name = app
+        .selected_vm()
         .map(|vm| vm.display_name())
         .unwrap_or_else(|| "Unknown".to_string());
 
@@ -1580,40 +1706,55 @@ fn render_confirm(app: &App, action: &ConfirmAction, frame: &mut Frame) {
 
     let (title, message) = match action {
         ConfirmAction::LaunchVm => {
-            let name = app.selected_vm()
+            let name = app
+                .selected_vm()
                 .map(|vm| vm.display_name())
                 .unwrap_or_else(|| "VM".to_string());
             ("Launch VM", format!("Launch {}?", name))
         }
-        ConfirmAction::ResetVm => {
-            ("Reset VM", "This will reset the VM to its initial state. All changes will be lost. Continue?".to_string())
-        }
+        ConfirmAction::ResetVm => (
+            "Reset VM",
+            "This will reset the VM to its initial state. All changes will be lost. Continue?"
+                .to_string(),
+        ),
         ConfirmAction::DeleteVm => {
-            let name = app.selected_vm()
+            let name = app
+                .selected_vm()
                 .map(|vm| vm.display_name())
                 .unwrap_or_else(|| "VM".to_string());
-            ("Delete VM", format!("Delete {}? This will move the VM to trash.", name))
+            (
+                "Delete VM",
+                format!("Delete {}? This will move the VM to trash.", name),
+            )
         }
-        ConfirmAction::RestoreSnapshot(name) => {
-            ("Restore Snapshot", format!("Restore snapshot '{}'? Current state will be lost.", name))
-        }
-        ConfirmAction::DeleteSnapshot(name) => {
-            ("Delete Snapshot", format!("Delete snapshot '{}'? This cannot be undone.", name))
-        }
-        ConfirmAction::DiscardScriptChanges | ConfirmAction::DiscardNotesChanges => {
-            ("Discard Changes", "You have unsaved changes. Discard them?".to_string())
-        }
+        ConfirmAction::RestoreSnapshot(name) => (
+            "Restore Snapshot",
+            format!("Restore snapshot '{}'? Current state will be lost.", name),
+        ),
+        ConfirmAction::DeleteSnapshot(name) => (
+            "Delete Snapshot",
+            format!("Delete snapshot '{}'? This cannot be undone.", name),
+        ),
+        ConfirmAction::DiscardScriptChanges | ConfirmAction::DiscardNotesChanges => (
+            "Discard Changes",
+            "You have unsaved changes. Discard them?".to_string(),
+        ),
         ConfirmAction::StopVm => {
-            let name = app.selected_vm()
+            let name = app
+                .selected_vm()
                 .map(|vm| vm.display_name())
                 .unwrap_or_else(|| "VM".to_string());
             ("Stop VM", format!("Stop {}?", name))
         }
         ConfirmAction::ForceStopVm => {
-            let name = app.selected_vm()
+            let name = app
+                .selected_vm()
                 .map(|vm| vm.display_name())
                 .unwrap_or_else(|| "VM".to_string());
-            ("Force Stop VM", format!("Force stop {}? This may cause data loss.", name))
+            (
+                "Force Stop VM",
+                format!("Force stop {}? This may cause data loss.", name),
+            )
         }
     };
 
@@ -1621,8 +1762,8 @@ fn render_confirm(app: &App, action: &ConfirmAction, frame: &mut Frame) {
 }
 
 fn render_usb_devices(app: &App, frame: &mut Frame) {
+    use ratatui::layout::{Constraint, Direction, Layout};
     use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph};
-    use ratatui::layout::{Layout, Direction, Constraint};
 
     let area = frame.area();
     let dialog_width = 80.min(area.width.saturating_sub(4));
@@ -1651,9 +1792,9 @@ fn render_usb_devices(app: &App, frame: &mut Frame) {
     let h_chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
-            Constraint::Length(2),  // Left margin
-            Constraint::Min(1),     // Content
-            Constraint::Length(2),  // Right margin
+            Constraint::Length(2), // Left margin
+            Constraint::Min(1),    // Content
+            Constraint::Length(2), // Right margin
         ])
         .split(inner);
 
@@ -1661,9 +1802,9 @@ fn render_usb_devices(app: &App, frame: &mut Frame) {
     let v_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1),  // Top padding
-            Constraint::Min(4),     // Device list
-            Constraint::Length(2),  // Help text
+            Constraint::Length(1), // Top padding
+            Constraint::Min(4),    // Device list
+            Constraint::Length(2), // Help text
         ])
         .split(h_chunks[1]);
 
@@ -1671,19 +1812,23 @@ fn render_usb_devices(app: &App, frame: &mut Frame) {
     let help_area = v_chunks[2];
 
     if app.usb_devices.is_empty() {
-        let msg = Paragraph::new("No USB devices found.\n\nConnect a USB device and reopen this screen.")
-            .style(Style::default().fg(Color::DarkGray))
-            .alignment(Alignment::Center);
+        let msg =
+            Paragraph::new("No USB devices found.\n\nConnect a USB device and reopen this screen.")
+                .style(Style::default().fg(Color::DarkGray))
+                .alignment(Alignment::Center);
         frame.render_widget(msg, content_area);
     } else {
-        let items: Vec<ListItem> = app.usb_devices
+        let items: Vec<ListItem> = app
+            .usb_devices
             .iter()
             .enumerate()
             .map(|(i, device)| {
                 let selected = app.selected_usb_devices.contains(&i);
                 let checkbox = if selected { "[✓]" } else { "[ ]" };
                 let style = if i == app.selected_menu_item {
-                    Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD)
                 } else if selected {
                     Style::default().fg(Color::Green)
                 } else {
@@ -1704,8 +1849,7 @@ fn render_usb_devices(app: &App, frame: &mut Frame) {
         let mut state = ListState::default();
         state.select(Some(app.selected_menu_item));
 
-        let list = List::new(items)
-            .highlight_symbol("> ");
+        let list = List::new(items).highlight_symbol("> ");
         frame.render_stateful_widget(list, content_area, &mut state);
     }
 
@@ -1735,15 +1879,15 @@ fn render_search(app: &App, frame: &mut Frame) {
     let inner = block.inner(dialog_area);
     frame.render_widget(block, dialog_area);
 
-    let input = Paragraph::new(format!("/{}", app.search_query))
-        .style(Style::default().fg(Color::White));
+    let input =
+        Paragraph::new(format!("/{}", app.search_query)).style(Style::default().fg(Color::White));
     frame.render_widget(input, inner);
 }
 
 fn render_file_browser(app: &App, frame: &mut Frame) {
-    use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph};
-    use ratatui::layout::{Layout, Direction, Constraint};
     use crate::app::FileBrowserMode;
+    use ratatui::layout::{Constraint, Direction, Layout};
+    use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph};
 
     let show_default_iso_checkbox =
         app.wizard_state.is_some() && app.file_browser_mode == FileBrowserMode::Iso;
@@ -1780,9 +1924,9 @@ fn render_file_browser(app: &App, frame: &mut Frame) {
     let h_chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
-            Constraint::Length(2),  // Left margin
-            Constraint::Min(1),     // Content
-            Constraint::Length(2),  // Right margin
+            Constraint::Length(2), // Left margin
+            Constraint::Min(1),    // Content
+            Constraint::Length(2), // Right margin
         ])
         .split(inner);
 
@@ -1824,12 +1968,20 @@ fn render_file_browser(app: &App, frame: &mut Frame) {
     if app.file_browser_entries.is_empty() {
         let msg_text = match app.file_browser_mode {
             FileBrowserMode::Iso => "No ISO files found in this directory.",
-            FileBrowserMode::RecoveryImage => "No recovery images (.dmg, .qcow2) found in this directory.",
+            FileBrowserMode::RecoveryImage => {
+                "No recovery images (.dmg, .qcow2) found in this directory."
+            }
             FileBrowserMode::Disk => "No disk images found in this directory.",
             FileBrowserMode::Directory => "No subdirectories in this directory.",
-            FileBrowserMode::ImportConfig => "No config files (.xml, .conf) found in this directory.",
-            FileBrowserMode::Bios => "No firmware files (.bin, .rom, .qcow2, .fd) found in this directory.",
-            FileBrowserMode::Floppy => "No floppy images (.img, .ima, .flp, .vfd) found in this directory.",
+            FileBrowserMode::ImportConfig => {
+                "No config files (.xml, .conf) found in this directory."
+            }
+            FileBrowserMode::Bios => {
+                "No firmware files (.bin, .rom, .qcow2, .fd) found in this directory."
+            }
+            FileBrowserMode::Floppy => {
+                "No floppy images (.img, .ima, .flp, .vfd) found in this directory."
+            }
         };
         let msg = ratatui::widgets::Paragraph::new(msg_text)
             .style(Style::default().fg(Color::DarkGray))
@@ -1838,7 +1990,8 @@ fn render_file_browser(app: &App, frame: &mut Frame) {
         return;
     }
 
-    let items: Vec<ListItem> = app.file_browser_entries
+    let items: Vec<ListItem> = app
+        .file_browser_entries
         .iter()
         .map(|entry| {
             let prefix = if entry.name == "[Select This Directory]" {
@@ -1983,7 +2136,9 @@ fn handle_file_browser(app: &mut App, key: KeyEvent) -> Result<()> {
                                     state.folder_name =
                                         crate::app::CreateWizardState::find_available_folder_name(
                                             &library_path,
-                                            &crate::app::CreateWizardState::generate_folder_name(&vm.name),
+                                            &crate::app::CreateWizardState::generate_folder_name(
+                                                &vm.name,
+                                            ),
                                         );
                                     let has_notes = !vm.import_notes.is_empty();
                                     state.selected_vm = Some(vm);
@@ -2004,7 +2159,9 @@ fn handle_file_browser(app: &mut App, key: KeyEvent) -> Result<()> {
                                     let folder_name =
                                         crate::app::CreateWizardState::find_available_folder_name(
                                             &library_path,
-                                            &crate::app::CreateWizardState::generate_folder_name(&vm.name),
+                                            &crate::app::CreateWizardState::generate_folder_name(
+                                                &vm.name,
+                                            ),
                                         );
                                     let vm_name = vm.name.clone();
                                     let (step, warnings_acknowledged) = if has_notes {
@@ -2136,7 +2293,13 @@ fn handle_text_input(app: &mut App, context: TextInputContext, key: KeyEvent) ->
                 }
                 TextInputContext::RenameVm => {
                     // Allow more characters for VM display names
-                    c.is_alphanumeric() || c == '-' || c == '_' || c == '.' || c == ' ' || c == '(' || c == ')'
+                    c.is_alphanumeric()
+                        || c == '-'
+                        || c == '_'
+                        || c == '.'
+                        || c == ' '
+                        || c == '('
+                        || c == ')'
                 }
             };
             if allowed {

--- a/src/ui/screens/configuration.rs
+++ b/src/ui/screens/configuration.rs
@@ -16,7 +16,8 @@ pub fn render(app: &App, frame: &mut Frame) {
     let dialog_area = centered_rect(dialog_width, dialog_height, area);
     frame.render_widget(Clear, dialog_area);
 
-    let vm_name = app.selected_vm()
+    let vm_name = app
+        .selected_vm()
         .map(|vm| vm.display_name())
         .unwrap_or_else(|| "Unknown".to_string());
 
@@ -33,9 +34,9 @@ pub fn render(app: &App, frame: &mut Frame) {
     let h_chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
-            Constraint::Length(2),  // Left margin
-            Constraint::Min(1),     // Content
-            Constraint::Length(2),  // Right margin
+            Constraint::Length(2), // Left margin
+            Constraint::Min(1),    // Content
+            Constraint::Length(2), // Right margin
         ])
         .split(inner);
 
@@ -43,10 +44,10 @@ pub fn render(app: &App, frame: &mut Frame) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1),   // Top padding
-            Constraint::Min(10),     // Config content
-            Constraint::Length(1),   // Bottom padding
-            Constraint::Length(2),   // Help text
+            Constraint::Length(1), // Top padding
+            Constraint::Min(10),   // Config content
+            Constraint::Length(1), // Bottom padding
+            Constraint::Length(2), // Help text
         ])
         .split(h_chunks[1]);
 
@@ -118,7 +119,8 @@ fn render_config(config: &QemuConfig, area: Rect, frame: &mut Frame) {
 
     // Audio
     if !config.audio_devices.is_empty() {
-        let audio_str = config.audio_devices
+        let audio_str = config
+            .audio_devices
             .iter()
             .map(|a| format!("{:?}", a))
             .collect::<Vec<_>>()
@@ -147,7 +149,10 @@ fn render_config(config: &QemuConfig, area: Rect, frame: &mut Frame) {
                 Style::default().fg(Color::DarkGray),
             )));
             for pf in &net.port_forwards {
-                lines.push(Line::from(format!("    {} {} -> {}", pf.protocol, pf.host_port, pf.guest_port)));
+                lines.push(Line::from(format!(
+                    "    {} {} -> {}",
+                    pf.protocol, pf.host_port, pf.guest_port
+                )));
             }
         }
     }
@@ -157,11 +162,15 @@ fn render_config(config: &QemuConfig, area: Rect, frame: &mut Frame) {
     // Disks
     lines.push(Line::from(Span::styled(
         "Disks:",
-        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
     )));
 
     for disk in &config.disks {
-        let path = disk.path.file_name()
+        let path = disk
+            .path
+            .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("unknown");
         lines.push(Line::from(format!(
@@ -202,8 +211,7 @@ fn render_config(config: &QemuConfig, area: Rect, frame: &mut Frame) {
         snapshot_support,
     ]));
 
-    let para = Paragraph::new(lines)
-        .wrap(Wrap { trim: false });
+    let para = Paragraph::new(lines).wrap(Wrap { trim: false });
     frame.render_widget(para, area);
 }
 
@@ -216,11 +224,16 @@ pub fn render_raw_script(app: &App, frame: &mut Frame) {
     let dialog_area = centered_rect(dialog_width, dialog_height, area);
     frame.render_widget(Clear, dialog_area);
 
-    let vm_name = app.selected_vm()
+    let vm_name = app
+        .selected_vm()
         .map(|vm| vm.display_name())
         .unwrap_or_else(|| "Unknown".to_string());
 
-    let modified_indicator = if app.script_editor_modified { " [modified]" } else { "" };
+    let modified_indicator = if app.script_editor_modified {
+        " [modified]"
+    } else {
+        ""
+    };
 
     let block = Block::default()
         .title(format!(" {} - launch.sh{} ", vm_name, modified_indicator))
@@ -239,8 +252,8 @@ pub fn render_raw_script(app: &App, frame: &mut Frame) {
     let v_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Min(1),     // Editor content
-            Constraint::Length(1),  // Help text
+            Constraint::Min(1),    // Editor content
+            Constraint::Length(1), // Help text
         ])
         .split(inner);
 
@@ -251,8 +264,8 @@ pub fn render_raw_script(app: &App, frame: &mut Frame) {
     let h_chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
-            Constraint::Length(5),  // Line numbers
-            Constraint::Min(1),     // Text content
+            Constraint::Length(5), // Line numbers
+            Constraint::Min(1),    // Text content
         ])
         .split(editor_area);
 
@@ -287,7 +300,11 @@ pub fn render_raw_script(app: &App, frame: &mut Frame) {
 
     let text_lines: Vec<Line> = (start_line..end_line)
         .map(|i| {
-            let line = app.script_editor_lines.get(i).map(|s| s.as_str()).unwrap_or("");
+            let line = app
+                .script_editor_lines
+                .get(i)
+                .map(|s| s.as_str())
+                .unwrap_or("");
 
             // Apply horizontal scroll
             let visible_line = if h_scroll < line.len() {
@@ -353,11 +370,16 @@ pub fn render_edit_notes(app: &App, frame: &mut Frame) {
     let dialog_area = centered_rect(dialog_width, dialog_height, area);
     frame.render_widget(Clear, dialog_area);
 
-    let vm_name = app.selected_vm()
+    let vm_name = app
+        .selected_vm()
         .map(|vm| vm.display_name())
         .unwrap_or_else(|| "Unknown".to_string());
 
-    let modified_indicator = if app.script_editor_modified { " [modified]" } else { "" };
+    let modified_indicator = if app.script_editor_modified {
+        " [modified]"
+    } else {
+        ""
+    };
 
     let block = Block::default()
         .title(format!(" {} - Notes{} ", vm_name, modified_indicator))
@@ -376,8 +398,8 @@ pub fn render_edit_notes(app: &App, frame: &mut Frame) {
     let v_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Min(1),     // Editor content
-            Constraint::Length(1),  // Help text
+            Constraint::Min(1),    // Editor content
+            Constraint::Length(1), // Help text
         ])
         .split(inner);
 
@@ -388,8 +410,8 @@ pub fn render_edit_notes(app: &App, frame: &mut Frame) {
     let h_chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
-            Constraint::Length(5),  // Line numbers
-            Constraint::Min(1),     // Text content
+            Constraint::Length(5), // Line numbers
+            Constraint::Min(1),    // Text content
         ])
         .split(editor_area);
 
@@ -423,7 +445,11 @@ pub fn render_edit_notes(app: &App, frame: &mut Frame) {
 
     let text_lines: Vec<Line> = (start_line..end_line)
         .map(|i| {
-            let line = app.script_editor_lines.get(i).map(|s| s.as_str()).unwrap_or("");
+            let line = app
+                .script_editor_lines
+                .get(i)
+                .map(|s| s.as_str())
+                .unwrap_or("");
 
             let visible_line = if h_scroll < line.len() {
                 &line[h_scroll..]

--- a/src/ui/screens/create_wizard.rs
+++ b/src/ui/screens/create_wizard.rs
@@ -10,7 +10,7 @@ use ratatui::{
     widgets::{Block, Borders, Clear, Paragraph, Wrap},
 };
 
-use crate::app::{App, WizardStep, WizardField, WizardQemuConfig};
+use crate::app::{App, WizardField, WizardQemuConfig, WizardStep};
 use crate::metadata::QemuProfileStore;
 use crate::vm::create_vm;
 
@@ -26,11 +26,11 @@ fn parse_size_with_suffix(input: &str, target_unit: &str) -> Option<u32> {
     }
 
     let (num_str, suffix) = if input.ends_with("GB") {
-        (&input[..input.len()-2], "GB")
+        (&input[..input.len() - 2], "GB")
     } else if input.ends_with("MB") {
-        (&input[..input.len()-2], "MB")
+        (&input[..input.len() - 2], "MB")
     } else if input.ends_with("KB") {
-        (&input[..input.len()-2], "KB")
+        (&input[..input.len() - 2], "KB")
     } else {
         (input.as_str(), target_unit)
     };
@@ -115,16 +115,16 @@ pub fn render_custom_os(app: &App, frame: &mut Frame) {
         .direction(Direction::Vertical)
         .margin(1)
         .constraints([
-            Constraint::Length(1),   // Intro text
-            Constraint::Length(1),   // Spacer
-            Constraint::Length(3),   // OS Name
-            Constraint::Length(3),   // Publisher
-            Constraint::Length(3),   // Architecture
-            Constraint::Length(1),   // Spacer
-            Constraint::Length(5),   // Base profile selection
-            Constraint::Length(1),   // Spacer
-            Constraint::Min(3),      // Tips
-            Constraint::Length(2),   // Help
+            Constraint::Length(1), // Intro text
+            Constraint::Length(1), // Spacer
+            Constraint::Length(3), // OS Name
+            Constraint::Length(3), // Publisher
+            Constraint::Length(3), // Architecture
+            Constraint::Length(1), // Spacer
+            Constraint::Length(5), // Base profile selection
+            Constraint::Length(1), // Spacer
+            Constraint::Min(3),    // Tips
+            Constraint::Length(2), // Help
         ])
         .split(inner);
 
@@ -139,9 +139,14 @@ pub fn render_custom_os(app: &App, frame: &mut Frame) {
     let name_editing = matches!(state.editing_field, Some(WizardField::CustomOsName));
 
     render_input_field(
-        frame, chunks[2],
+        frame,
+        chunks[2],
         "OS Name",
-        if os_name.is_empty() { "e.g., My Custom Linux" } else { os_name },
+        if os_name.is_empty() {
+            "e.g., My Custom Linux"
+        } else {
+            os_name
+        },
         os_name.is_empty(),
         name_focus,
         name_editing,
@@ -159,9 +164,14 @@ pub fn render_custom_os(app: &App, frame: &mut Frame) {
     let pub_editing = matches!(state.editing_field, Some(WizardField::CustomOsPublisher));
 
     render_input_field(
-        frame, chunks[3],
+        frame,
+        chunks[3],
         "Publisher",
-        if publisher.is_empty() { "e.g., Open Source Community" } else { publisher },
+        if publisher.is_empty() {
+            "e.g., Open Source Community"
+        } else {
+            publisher
+        },
         publisher.is_empty(),
         pub_focus,
         pub_editing,
@@ -174,10 +184,13 @@ pub fn render_custom_os(app: &App, frame: &mut Frame) {
     }
 
     // Architecture selection (cycle)
-    let arch = custom_os.map(|c| c.architecture.as_str()).unwrap_or("x86_64");
+    let arch = custom_os
+        .map(|c| c.architecture.as_str())
+        .unwrap_or("x86_64");
     let arch_focus = state.field_focus == 2;
     render_select_field(
-        frame, chunks[4],
+        frame,
+        chunks[4],
         "Architecture",
         arch,
         arch_focus,
@@ -185,7 +198,9 @@ pub fn render_custom_os(app: &App, frame: &mut Frame) {
     );
 
     // Base profile selection
-    let base_profile = custom_os.map(|c| c.base_profile.as_str()).unwrap_or("generic-other");
+    let base_profile = custom_os
+        .map(|c| c.base_profile.as_str())
+        .unwrap_or("generic-other");
     let base_focus = state.field_focus == 3;
 
     let base_block = Block::default()
@@ -204,10 +219,23 @@ pub fn render_custom_os(app: &App, frame: &mut Frame) {
     let mut base_lines = Vec::new();
     base_lines.push(Line::from(vec![
         Span::styled("Profile: ", Style::default().fg(Color::Yellow)),
-        Span::styled(base_display, if base_focus { Style::default().fg(Color::White).add_modifier(Modifier::BOLD) } else { Style::default().fg(Color::White) }),
+        Span::styled(
+            base_display,
+            if base_focus {
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            },
+        ),
     ]));
     base_lines.push(Line::from(Span::styled(
-        if base_focus { "[←/→] Change profile" } else { "" },
+        if base_focus {
+            "[←/→] Change profile"
+        } else {
+            ""
+        },
         Style::default().fg(Color::DarkGray),
     )));
 
@@ -225,7 +253,7 @@ pub fn render_custom_os(app: &App, frame: &mut Frame) {
 
     let tips_text = Paragraph::new(
         "You can adjust QEMU settings in step 4.\n\
-         Consider contributing new OS profiles to the project!"
+         Consider contributing new OS profiles to the project!",
     )
     .style(Style::default().fg(Color::DarkGray))
     .wrap(Wrap { trim: false });
@@ -266,7 +294,9 @@ fn render_input_field(
     let text_style = if is_placeholder {
         Style::default().fg(Color::DarkGray)
     } else if is_editing {
-        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(Color::White)
     };
@@ -297,13 +327,16 @@ fn render_select_field(
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    let mut spans = vec![
-        Span::styled(value, if is_focused {
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD)
+    let mut spans = vec![Span::styled(
+        value,
+        if is_focused {
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(Color::White)
-        }),
-    ];
+        },
+    )];
 
     if is_focused {
         spans.push(Span::raw("  "));
@@ -355,13 +388,18 @@ pub fn render_download(app: &App, frame: &mut Frame) {
     let inner = block.inner(dialog_area);
     frame.render_widget(block, dialog_area);
 
-    let progress = app.wizard_state.as_ref()
+    let progress = app
+        .wizard_state
+        .as_ref()
         .map(|s| s.iso_download_progress)
         .unwrap_or(0.0);
 
-    let text = Paragraph::new(format!("Downloading... {:.0}%\n\n[Esc] Cancel", progress * 100.0))
-        .style(Style::default().fg(Color::White))
-        .alignment(Alignment::Center);
+    let text = Paragraph::new(format!(
+        "Downloading... {:.0}%\n\n[Esc] Cancel",
+        progress * 100.0
+    ))
+    .style(Style::default().fg(Color::White))
+    .alignment(Alignment::Center);
     frame.render_widget(text, inner);
 }
 
@@ -383,7 +421,9 @@ pub fn handle_key(app: &mut App, key: KeyEvent) -> Result<()> {
 
 /// Handle key input for custom OS form
 pub fn handle_custom_os_key(app: &mut App, key: KeyEvent) -> Result<()> {
-    let editing = app.wizard_state.as_ref()
+    let editing = app
+        .wizard_state
+        .as_ref()
         .map(|s| s.editing_field.is_some())
         .unwrap_or(false);
 
@@ -414,8 +454,12 @@ pub fn handle_custom_os_key(app: &mut App, key: KeyEvent) -> Result<()> {
                 if let Some(ref mut state) = app.wizard_state {
                     if let Some(ref mut custom) = state.custom_os {
                         match state.editing_field {
-                            Some(WizardField::CustomOsName) => { custom.name.pop(); }
-                            Some(WizardField::CustomOsPublisher) => { custom.publisher.pop(); }
+                            Some(WizardField::CustomOsName) => {
+                                custom.name.pop();
+                            }
+                            Some(WizardField::CustomOsPublisher) => {
+                                custom.publisher.pop();
+                            }
                             _ => {}
                         }
                     }
@@ -440,30 +484,42 @@ pub fn handle_custom_os_key(app: &mut App, key: KeyEvent) -> Result<()> {
             }
             KeyCode::BackTab | KeyCode::Char('k') | KeyCode::Up => {
                 if let Some(ref mut state) = app.wizard_state {
-                    state.field_focus = if state.field_focus == 0 { 3 } else { state.field_focus - 1 };
+                    state.field_focus = if state.field_focus == 0 {
+                        3
+                    } else {
+                        state.field_focus - 1
+                    };
                 }
             }
             KeyCode::Left | KeyCode::Right => {
-                let delta = if key.code == KeyCode::Right { 1i32 } else { -1i32 };
+                let delta = if key.code == KeyCode::Right {
+                    1i32
+                } else {
+                    -1i32
+                };
                 if let Some(ref mut state) = app.wizard_state {
                     if let Some(ref mut custom) = state.custom_os {
                         match state.field_focus {
                             2 => {
                                 // Architecture
-                                let current_idx = ARCH_OPTIONS.iter()
+                                let current_idx = ARCH_OPTIONS
+                                    .iter()
                                     .position(|&a| a == custom.architecture)
                                     .unwrap_or(0);
                                 let new_idx = (current_idx as i32 + delta)
-                                    .rem_euclid(ARCH_OPTIONS.len() as i32) as usize;
+                                    .rem_euclid(ARCH_OPTIONS.len() as i32)
+                                    as usize;
                                 custom.architecture = ARCH_OPTIONS[new_idx].to_string();
                             }
                             3 => {
                                 // Base profile
-                                let current_idx = BASE_PROFILE_OPTIONS.iter()
+                                let current_idx = BASE_PROFILE_OPTIONS
+                                    .iter()
                                     .position(|&p| p == custom.base_profile)
                                     .unwrap_or(0);
                                 let new_idx = (current_idx as i32 + delta)
-                                    .rem_euclid(BASE_PROFILE_OPTIONS.len() as i32) as usize;
+                                    .rem_euclid(BASE_PROFILE_OPTIONS.len() as i32)
+                                    as usize;
                                 custom.base_profile = BASE_PROFILE_OPTIONS[new_idx].to_string();
                             }
                             _ => {}
@@ -483,7 +539,9 @@ pub fn handle_custom_os_key(app: &mut App, key: KeyEvent) -> Result<()> {
             }
             KeyCode::Enter => {
                 // Validate and continue
-                let valid = app.wizard_state.as_ref()
+                let valid = app
+                    .wizard_state
+                    .as_ref()
                     .and_then(|s| s.custom_os.as_ref())
                     .map(|c| !c.name.trim().is_empty())
                     .unwrap_or(false);
@@ -518,7 +576,8 @@ pub fn handle_custom_os_key(app: &mut App, key: KeyEvent) -> Result<()> {
                         }
 
                         // Generate ID from name
-                        let id = custom_name.to_lowercase()
+                        let id = custom_name
+                            .to_lowercase()
                             .chars()
                             .map(|c| if c.is_alphanumeric() { c } else { '-' })
                             .collect::<String>()
@@ -564,7 +623,11 @@ fn render_step_select_os(app: &App, frame: &mut Frame, area: Rect) {
     let state = app.wizard_state.as_ref().unwrap();
 
     let block = Block::default()
-        .title(format!(" Create New VM ({}/5) - {} ", state.step.number(), state.step.title()))
+        .title(format!(
+            " Create New VM ({}/5) - {} ",
+            state.step.number(),
+            state.step.title()
+        ))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Cyan))
         .style(Style::default().bg(Color::Black));
@@ -577,18 +640,21 @@ fn render_step_select_os(app: &App, frame: &mut Frame, area: Rect) {
         .direction(Direction::Vertical)
         .margin(1)
         .constraints([
-            Constraint::Length(1),   // OS list header
-            Constraint::Min(10),     // OS list
-            Constraint::Length(1),   // Spacer
-            Constraint::Length(3),   // VM Name field
-            Constraint::Length(1),   // Error message
-            Constraint::Length(2),   // Help text
+            Constraint::Length(1), // OS list header
+            Constraint::Min(10),   // OS list
+            Constraint::Length(1), // Spacer
+            Constraint::Length(3), // VM Name field
+            Constraint::Length(1), // Error message
+            Constraint::Length(2), // Help text
         ])
         .split(inner);
 
     // OS list header
-    let header = Paragraph::new("Select Operating System:")
-        .style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD));
+    let header = Paragraph::new("Select Operating System:").style(
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    );
     frame.render_widget(header, chunks[0]);
 
     // OS list (grouped by category)
@@ -632,8 +698,7 @@ fn render_step_select_os(app: &App, frame: &mut Frame, area: Rect) {
 
     // Error message
     if let Some(ref error) = state.error_message {
-        let error_text = Paragraph::new(error.as_str())
-            .style(Style::default().fg(Color::Red));
+        let error_text = Paragraph::new(error.as_str()).style(Style::default().fg(Color::Red));
         frame.render_widget(error_text, chunks[4]);
     }
 
@@ -664,7 +729,19 @@ fn render_os_list(app: &App, frame: &mut Frame, area: Rect) {
     let mut item_index = 0;
 
     // Get categories in display order
-    let category_order = ["windows", "linux", "bsd", "unix", "macos", "mobile", "infrastructure", "utilities", "alternative", "retro", "classic-mac"];
+    let category_order = [
+        "windows",
+        "linux",
+        "bsd",
+        "unix",
+        "macos",
+        "mobile",
+        "infrastructure",
+        "utilities",
+        "alternative",
+        "retro",
+        "classic-mac",
+    ];
 
     for category in &category_order {
         let profiles = app.qemu_profiles.list_by_category(category);
@@ -679,9 +756,13 @@ fn render_os_list(app: &App, frame: &mut Frame, area: Rect) {
         let expand_icon = if is_expanded { "v" } else { ">" };
         let category_name = QemuProfileStore::category_display_name(category);
         let category_style = if is_selected {
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD)
         } else {
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD)
         };
 
         let prefix = if is_selected { "> " } else { "  " };
@@ -725,7 +806,10 @@ fn render_os_list(app: &App, frame: &mut Frame, area: Rect) {
                     Span::styled(prefix, os_style),
                     Span::styled(format!("   {}", chosen_marker), os_style),
                     Span::styled(profile.display_name.to_string(), os_style),
-                    Span::styled(format!("  ({})", summary), Style::default().fg(Color::DarkGray)),
+                    Span::styled(
+                        format!("  ({})", summary),
+                        Style::default().fg(Color::DarkGray),
+                    ),
                 ]));
 
                 item_index += 1;
@@ -767,7 +851,9 @@ fn render_os_list(app: &App, frame: &mut Frame, area: Rect) {
 }
 
 fn handle_step_select_os(app: &mut App, key: KeyEvent) -> Result<()> {
-    let editing_name = app.wizard_state.as_ref()
+    let editing_name = app
+        .wizard_state
+        .as_ref()
         .map(|s| matches!(s.editing_field, Some(WizardField::VmName)))
         .unwrap_or(false);
 
@@ -838,7 +924,19 @@ fn handle_step_select_os(app: &mut App, key: KeyEvent) -> Result<()> {
 /// Count total items in the OS list (categories + visible OSes + custom)
 fn count_os_list_items(app: &App) -> usize {
     let state = app.wizard_state.as_ref().unwrap();
-    let category_order = ["windows", "linux", "bsd", "unix", "macos", "mobile", "infrastructure", "utilities", "alternative", "retro", "classic-mac"];
+    let category_order = [
+        "windows",
+        "linux",
+        "bsd",
+        "unix",
+        "macos",
+        "mobile",
+        "infrastructure",
+        "utilities",
+        "alternative",
+        "retro",
+        "classic-mac",
+    ];
 
     let mut count = 0;
     for category in &category_order {
@@ -876,7 +974,19 @@ fn handle_os_list_action(app: &mut App, proceed: bool) {
     let os_filter = state.os_filter.clone();
     let expanded_categories: Vec<String> = state.expanded_categories.clone();
 
-    let category_order = ["windows", "linux", "bsd", "unix", "macos", "mobile", "infrastructure", "utilities", "alternative", "retro", "classic-mac"];
+    let category_order = [
+        "windows",
+        "linux",
+        "bsd",
+        "unix",
+        "macos",
+        "mobile",
+        "infrastructure",
+        "utilities",
+        "alternative",
+        "retro",
+        "classic-mac",
+    ];
 
     let mut item_index = 0;
     let mut action: Option<OsListAction> = None;
@@ -964,7 +1074,11 @@ fn render_step_select_iso(app: &App, frame: &mut Frame, area: Rect) {
     let state = app.wizard_state.as_ref().unwrap();
 
     let block = Block::default()
-        .title(format!(" Create New VM ({}/5) - {} ", state.step.number(), state.step.title()))
+        .title(format!(
+            " Create New VM ({}/5) - {} ",
+            state.step.number(),
+            state.step.title()
+        ))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Cyan))
         .style(Style::default().bg(Color::Black));
@@ -976,17 +1090,19 @@ fn render_step_select_iso(app: &App, frame: &mut Frame, area: Rect) {
         .direction(Direction::Vertical)
         .margin(1)
         .constraints([
-            Constraint::Length(2),   // OS info
-            Constraint::Length(1),   // Spacer
-            Constraint::Length(1),   // Header
-            Constraint::Min(10),     // Options
-            Constraint::Length(1),   // Selected path
-            Constraint::Length(2),   // Help
+            Constraint::Length(2), // OS info
+            Constraint::Length(1), // Spacer
+            Constraint::Length(1), // Header
+            Constraint::Min(10),   // Options
+            Constraint::Length(1), // Selected path
+            Constraint::Length(2), // Help
         ])
         .split(inner);
 
     // OS info
-    let os_name = state.selected_os.as_ref()
+    let os_name = state
+        .selected_os
+        .as_ref()
         .and_then(|id| app.qemu_profiles.get(id))
         .map(|p| p.display_name.as_str())
         .unwrap_or("Custom OS");
@@ -996,8 +1112,11 @@ fn render_step_select_iso(app: &App, frame: &mut Frame, area: Rect) {
     frame.render_widget(os_info, chunks[0]);
 
     // Header
-    let header = Paragraph::new("Install Media:")
-        .style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD));
+    let header = Paragraph::new("Install Media:").style(
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    );
     frame.render_widget(header, chunks[2]);
 
     // Options
@@ -1005,12 +1124,18 @@ fn render_step_select_iso(app: &App, frame: &mut Frame, area: Rect) {
     let mut option_idx = 0;
 
     // BIOS/ROM option first (if the selected profile has bios_rom config)
-    let bios_rom_config = state.selected_os.as_ref()
+    let bios_rom_config = state
+        .selected_os
+        .as_ref()
         .and_then(|id| app.qemu_profiles.get(id))
         .and_then(|p| p.bios_rom.as_ref());
 
     if let Some(bios_config) = bios_rom_config {
-        let req_label = if bios_config.required { " (REQUIRED)" } else { " (optional)" };
+        let req_label = if bios_config.required {
+            " (REQUIRED)"
+        } else {
+            " (optional)"
+        };
         let is_rom_selected = state.field_focus == option_idx;
         let rom_style = if is_rom_selected {
             Style::default().fg(Color::Yellow)
@@ -1019,12 +1144,18 @@ fn render_step_select_iso(app: &App, frame: &mut Frame, area: Rect) {
         };
         let rom_prefix = if is_rom_selected { "> " } else { "  " };
         lines.push(Line::styled(
-            format!("{}( ) Browse for {} file...{}", rom_prefix, bios_config.label, req_label),
+            format!(
+                "{}( ) Browse for {} file...{}",
+                rom_prefix, bios_config.label, req_label
+            ),
             rom_style,
         ));
 
         if let Some(ref hint) = bios_config.hint {
-            lines.push(Line::styled(format!("       {}", hint), Style::default().fg(Color::DarkGray)));
+            lines.push(Line::styled(
+                format!("       {}", hint),
+                Style::default().fg(Color::DarkGray),
+            ));
         }
 
         if let Some(ref rom_path) = state.bios_rom_path {
@@ -1039,7 +1170,9 @@ fn render_step_select_iso(app: &App, frame: &mut Frame, area: Rect) {
     }
 
     // Check if this OS has a free ISO URL
-    let has_download = state.selected_os.as_ref()
+    let has_download = state
+        .selected_os
+        .as_ref()
         .and_then(|id| app.qemu_profiles.get(id))
         .and_then(|p| p.iso_url.as_ref())
         .is_some();
@@ -1052,7 +1185,10 @@ fn render_step_select_iso(app: &App, frame: &mut Frame, area: Rect) {
             Style::default().fg(Color::White)
         };
         let prefix = if is_selected { "> " } else { "  " };
-        lines.push(Line::styled(format!("{}( ) Open download page in browser", prefix), style));
+        lines.push(Line::styled(
+            format!("{}( ) Open download page in browser", prefix),
+            style,
+        ));
         option_idx += 1;
     }
 
@@ -1064,7 +1200,10 @@ fn render_step_select_iso(app: &App, frame: &mut Frame, area: Rect) {
         Style::default().fg(Color::White)
     };
     let floppy_prefix = if is_floppy_selected { "> " } else { "  " };
-    lines.push(Line::styled(format!("{}( ) Browse for boot floppy image...", floppy_prefix), floppy_style));
+    lines.push(Line::styled(
+        format!("{}( ) Browse for boot floppy image...", floppy_prefix),
+        floppy_style,
+    ));
     if let Some(ref floppy_path) = state.floppy_path {
         lines.push(Line::styled(
             format!("       Floppy: {}", floppy_path.display()),
@@ -1080,7 +1219,10 @@ fn render_step_select_iso(app: &App, frame: &mut Frame, area: Rect) {
         Style::default().fg(Color::White)
     };
     let browse_prefix = if is_browse_selected { "> " } else { "  " };
-    lines.push(Line::styled(format!("{}( ) Browse for local ISO file...", browse_prefix), browse_style));
+    lines.push(Line::styled(
+        format!("{}( ) Browse for local ISO file...", browse_prefix),
+        browse_style,
+    ));
     option_idx += 1;
 
     let is_recovery_selected = state.field_focus == option_idx;
@@ -1090,7 +1232,10 @@ fn render_step_select_iso(app: &App, frame: &mut Frame, area: Rect) {
         Style::default().fg(Color::White)
     };
     let recovery_prefix = if is_recovery_selected { "> " } else { "  " };
-    lines.push(Line::styled(format!("{}( ) Browse for recovery image (DMG)...", recovery_prefix), recovery_style));
+    lines.push(Line::styled(
+        format!("{}( ) Browse for recovery image (DMG)...", recovery_prefix),
+        recovery_style,
+    ));
     option_idx += 1;
 
     let is_none_selected = state.field_focus == option_idx;
@@ -1100,15 +1245,21 @@ fn render_step_select_iso(app: &App, frame: &mut Frame, area: Rect) {
         Style::default().fg(Color::White)
     };
     let none_prefix = if is_none_selected { "> " } else { "  " };
-    lines.push(Line::styled(format!("{}( ) Skip (configure later)", none_prefix), none_style));
+    lines.push(Line::styled(
+        format!("{}( ) Skip (configure later)", none_prefix),
+        none_style,
+    ));
 
-    let options = Paragraph::new(lines)
-        .wrap(Wrap { trim: false });
+    let options = Paragraph::new(lines).wrap(Wrap { trim: false });
     frame.render_widget(options, chunks[3]);
 
     // Selected path
     if let Some(ref path) = state.iso_path {
-        let label = if state.is_recovery_image { "Selected recovery image" } else { "Selected ISO" };
+        let label = if state.is_recovery_image {
+            "Selected recovery image"
+        } else {
+            "Selected ISO"
+        };
         let path_text = Paragraph::new(format!("{}: {}", label, path.display()))
             .style(Style::default().fg(Color::Green));
         frame.render_widget(path_text, chunks[4]);
@@ -1122,13 +1273,17 @@ fn render_step_select_iso(app: &App, frame: &mut Frame, area: Rect) {
 }
 
 fn handle_step_select_iso(app: &mut App, key: KeyEvent) -> Result<()> {
-    let has_download = app.wizard_state.as_ref()
+    let has_download = app
+        .wizard_state
+        .as_ref()
         .and_then(|s| s.selected_os.as_ref())
         .and_then(|id| app.qemu_profiles.get(id))
         .and_then(|p| p.iso_url.as_ref())
         .is_some();
 
-    let has_bios_rom = app.wizard_state.as_ref()
+    let has_bios_rom = app
+        .wizard_state
+        .as_ref()
         .and_then(|s| s.selected_os.as_ref())
         .and_then(|id| app.qemu_profiles.get(id))
         .and_then(|p| p.bios_rom.as_ref())
@@ -1136,12 +1291,28 @@ fn handle_step_select_iso(app: &mut App, key: KeyEvent) -> Result<()> {
 
     // Compute option indices matching the render order: ROM, download, floppy, browse, recovery, skip
     let mut idx = 0;
-    let rom_idx = if has_bios_rom { let i = idx; idx += 1; Some(i) } else { None };
-    let download_idx = if has_download { let i = idx; idx += 1; Some(i) } else { None };
-    let floppy_idx = idx; idx += 1;
-    let browse_idx = idx; idx += 1;
-    let recovery_browse_idx = idx; idx += 1;
-    let no_iso_idx = idx; idx += 1;
+    let rom_idx = if has_bios_rom {
+        let i = idx;
+        idx += 1;
+        Some(i)
+    } else {
+        None
+    };
+    let download_idx = if has_download {
+        let i = idx;
+        idx += 1;
+        Some(i)
+    } else {
+        None
+    };
+    let floppy_idx = idx;
+    idx += 1;
+    let browse_idx = idx;
+    idx += 1;
+    let recovery_browse_idx = idx;
+    idx += 1;
+    let no_iso_idx = idx;
+    idx += 1;
     let max_options = idx;
 
     match key.code {
@@ -1163,7 +1334,11 @@ fn handle_step_select_iso(app: &mut App, key: KeyEvent) -> Result<()> {
             }
         }
         KeyCode::Enter => {
-            let focus = app.wizard_state.as_ref().map(|s| s.field_focus).unwrap_or(0);
+            let focus = app
+                .wizard_state
+                .as_ref()
+                .map(|s| s.field_focus)
+                .unwrap_or(0);
 
             if Some(focus) == rom_idx {
                 // Browse for ROM/BIOS file
@@ -1171,7 +1346,9 @@ fn handle_step_select_iso(app: &mut App, key: KeyEvent) -> Result<()> {
                 app.push_screen(crate::app::Screen::FileBrowser);
             } else if Some(focus) == download_idx {
                 // Open download page in browser
-                if let Some(url) = app.wizard_state.as_ref()
+                if let Some(url) = app
+                    .wizard_state
+                    .as_ref()
                     .and_then(|s| s.selected_os.as_ref())
                     .and_then(|id| app.qemu_profiles.get(id))
                     .and_then(|p| p.iso_url.as_ref())
@@ -1198,13 +1375,17 @@ fn handle_step_select_iso(app: &mut App, key: KeyEvent) -> Result<()> {
                 app.push_screen(crate::app::Screen::FileBrowser);
             } else if focus == no_iso_idx {
                 // Skip - check if ROM is required but missing
-                let rom_required_but_missing = app.wizard_state.as_ref()
+                let rom_required_but_missing = app
+                    .wizard_state
+                    .as_ref()
                     .and_then(|s| s.selected_os.as_ref())
                     .and_then(|id| app.qemu_profiles.get(id))
                     .and_then(|p| p.bios_rom.as_ref())
                     .map(|b| b.required)
                     .unwrap_or(false)
-                    && app.wizard_state.as_ref()
+                    && app
+                        .wizard_state
+                        .as_ref()
                         .map(|s| s.bios_rom_path.is_none())
                         .unwrap_or(false);
 
@@ -1234,7 +1415,11 @@ fn render_step_configure_disk(app: &App, frame: &mut Frame, area: Rect) {
     let state = app.wizard_state.as_ref().unwrap();
 
     let block = Block::default()
-        .title(format!(" Create New VM ({}/5) - {} ", state.step.number(), state.step.title()))
+        .title(format!(
+            " Create New VM ({}/5) - {} ",
+            state.step.number(),
+            state.step.title()
+        ))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Cyan))
         .style(Style::default().bg(Color::Black));
@@ -1246,36 +1431,50 @@ fn render_step_configure_disk(app: &App, frame: &mut Frame, area: Rect) {
         .direction(Direction::Vertical)
         .margin(1)
         .constraints([
-            Constraint::Length(1),   // Header
-            Constraint::Length(1),   // Spacer
-            Constraint::Length(1),   // Disk source toggle
-            Constraint::Length(1),   // Spacer
-            Constraint::Min(10),     // Mode-specific content
-            Constraint::Length(2),   // Help
+            Constraint::Length(1), // Header
+            Constraint::Length(1), // Spacer
+            Constraint::Length(1), // Disk source toggle
+            Constraint::Length(1), // Spacer
+            Constraint::Min(10),   // Mode-specific content
+            Constraint::Length(2), // Help
         ])
         .split(inner);
 
     // Header
-    let header = Paragraph::new("Disk Configuration")
-        .style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD));
+    let header = Paragraph::new("Disk Configuration").style(
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    );
     frame.render_widget(header, chunks[0]);
 
     // Disk source toggle (field_focus == 0)
     let source_focused = state.field_focus == 0;
     let create_style = if !state.use_existing_disk {
-        Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(Color::Green)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(Color::DarkGray)
     };
     let existing_style = if state.use_existing_disk {
-        Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(Color::Green)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(Color::DarkGray)
     };
     let prefix = if source_focused { "> " } else { "  " };
 
     let source_line = Line::from(vec![
-        Span::styled(prefix, if source_focused { Style::default().fg(Color::Yellow) } else { Style::default() }),
+        Span::styled(
+            prefix,
+            if source_focused {
+                Style::default().fg(Color::Yellow)
+            } else {
+                Style::default()
+            },
+        ),
         Span::styled("Disk Source: ", Style::default().fg(Color::Yellow)),
         Span::styled("[ ", Style::default()),
         Span::styled("Create New", create_style),
@@ -1334,9 +1533,9 @@ fn render_new_disk_mode(app: &App, frame: &mut Frame, area: Rect) {
     let sub_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3),   // Disk size input
-            Constraint::Length(1),   // Spacer
-            Constraint::Min(5),      // Disk info
+            Constraint::Length(3), // Disk size input
+            Constraint::Length(1), // Spacer
+            Constraint::Min(5),    // Disk info
         ])
         .split(area);
 
@@ -1346,7 +1545,9 @@ fn render_new_disk_mode(app: &App, frame: &mut Frame, area: Rect) {
     let size_style = if editing {
         Style::default().fg(Color::Yellow)
     } else if size_focused {
-        Style::default().fg(Color::White).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(Color::White)
     };
@@ -1356,7 +1557,8 @@ fn render_new_disk_mode(app: &App, frame: &mut Frame, area: Rect) {
         Style::default().fg(Color::Gray)
     };
 
-    let recommended = app.wizard_selected_profile()
+    let recommended = app
+        .wizard_selected_profile()
         .map(|p| p.disk_size_gb)
         .unwrap_or(32);
 
@@ -1367,7 +1569,10 @@ fn render_new_disk_mode(app: &App, frame: &mut Frame, area: Rect) {
 
     // Show edit buffer when editing, otherwise show current value
     let size_display = if editing {
-        format!("{}|  (e.g., 500, 500GB, 512000MB)", state.wizard_edit_buffer)
+        format!(
+            "{}|  (e.g., 500, 500GB, 512000MB)",
+            state.wizard_edit_buffer
+        )
     } else {
         format!("{} GB", state.disk_size_gb)
     };
@@ -1383,7 +1588,8 @@ fn render_new_disk_mode(app: &App, frame: &mut Frame, area: Rect) {
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Gray));
 
-    let disk_path = app.wizard_vm_path()
+    let disk_path = app
+        .wizard_vm_path()
         .map(|p| p.join(format!("{}.qcow2", state.folder_name)))
         .map(|p| p.display().to_string())
         .unwrap_or_else(|| "~/vm-space/<vm-name>/<vm-name>.qcow2".to_string());
@@ -1418,11 +1624,11 @@ fn render_existing_disk_mode(app: &App, frame: &mut Frame, area: Rect) {
     let sub_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3),   // Browse / selected path
-            Constraint::Length(1),   // Spacer
-            Constraint::Length(1),   // Action toggle
-            Constraint::Length(1),   // Spacer
-            Constraint::Min(3),      // Note
+            Constraint::Length(3), // Browse / selected path
+            Constraint::Length(1), // Spacer
+            Constraint::Length(1), // Action toggle
+            Constraint::Length(1), // Spacer
+            Constraint::Min(3),    // Note
         ])
         .split(area);
 
@@ -1454,31 +1660,43 @@ fn render_existing_disk_mode(app: &App, frame: &mut Frame, area: Rect) {
         Paragraph::new(display).style(Style::default().fg(Color::Green))
     } else {
         let prefix = if browse_focused { "> " } else { "  " };
-        Paragraph::new(format!("{}( ) Browse for qcow2 disk file...", prefix))
-            .style(if browse_focused {
+        Paragraph::new(format!("{}( ) Browse for qcow2 disk file...", prefix)).style(
+            if browse_focused {
                 Style::default().fg(Color::Yellow)
             } else {
                 Style::default().fg(Color::White)
-            })
+            },
+        )
     };
     frame.render_widget(browse_text, browse_inner);
 
     // Action toggle (field_focus == 2)
     let action_focused = state.field_focus == 2;
     let copy_style = if matches!(state.existing_disk_action, DiskAction::Copy) {
-        Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(Color::Green)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(Color::DarkGray)
     };
     let move_style = if matches!(state.existing_disk_action, DiskAction::Move) {
-        Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(Color::Green)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(Color::DarkGray)
     };
     let prefix = if action_focused { "> " } else { "  " };
 
     let action_line = Line::from(vec![
-        Span::styled(prefix, if action_focused { Style::default().fg(Color::Yellow) } else { Style::default() }),
+        Span::styled(
+            prefix,
+            if action_focused {
+                Style::default().fg(Color::Yellow)
+            } else {
+                Style::default()
+            },
+        ),
         Span::styled("Action: ", Style::default().fg(Color::Yellow)),
         Span::styled("[ ", Style::default()),
         Span::styled("Copy to VM folder", copy_style),
@@ -1494,20 +1712,23 @@ fn render_existing_disk_mode(app: &App, frame: &mut Frame, area: Rect) {
         "Note: The disk will be renamed to {}.qcow2",
         state.folder_name
     );
-    let note = Paragraph::new(note_text)
-        .style(Style::default().fg(Color::DarkGray));
+    let note = Paragraph::new(note_text).style(Style::default().fg(Color::DarkGray));
     frame.render_widget(note, sub_chunks[4]);
 }
 
 fn handle_step_configure_disk(app: &mut App, key: KeyEvent) -> Result<()> {
     use crate::app::{DiskAction, FileBrowserMode};
 
-    let (editing, use_existing, field_focus) = app.wizard_state.as_ref()
-        .map(|s| (
-            matches!(s.editing_field, Some(WizardField::DiskSize)),
-            s.use_existing_disk,
-            s.field_focus,
-        ))
+    let (editing, use_existing, field_focus) = app
+        .wizard_state
+        .as_ref()
+        .map(|s| {
+            (
+                matches!(s.editing_field, Some(WizardField::DiskSize)),
+                s.use_existing_disk,
+                s.field_focus,
+            )
+        })
         .unwrap_or((false, false, 0));
 
     // Handle disk size editing mode (only in "Create New" mode)
@@ -1707,9 +1928,9 @@ impl QemuField {
         match self {
             NetBackend | MacAddress => net_on,
             BridgeName => net_on && config.network_backend == "bridge",
-            PortForwards => net_on
-                && (config.network_backend == "user"
-                    || config.network_backend == "passt"),
+            PortForwards => {
+                net_on && (config.network_backend == "user" || config.network_backend == "passt")
+            }
             _ => true,
         }
     }
@@ -1751,7 +1972,11 @@ fn render_step_configure_qemu(app: &App, frame: &mut Frame, area: Rect) {
     let state = app.wizard_state.as_ref().unwrap();
 
     let block = Block::default()
-        .title(format!(" Create New VM ({}/5) - {} ", state.step.number(), state.step.title()))
+        .title(format!(
+            " Create New VM ({}/5) - {} ",
+            state.step.number(),
+            state.step.title()
+        ))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Cyan))
         .style(Style::default().bg(Color::Black));
@@ -1769,9 +1994,9 @@ fn render_step_configure_qemu(app: &App, frame: &mut Frame, area: Rect) {
         .direction(Direction::Vertical)
         .margin(1)
         .constraints([
-            Constraint::Length(1),   // Header
-            Constraint::Min(18),     // Settings
-            Constraint::Length(2),   // Help
+            Constraint::Length(1), // Header
+            Constraint::Min(18),   // Settings
+            Constraint::Length(2), // Help
         ])
         .split(h_chunks[0]);
 
@@ -1779,14 +2004,17 @@ fn render_step_configure_qemu(app: &App, frame: &mut Frame, area: Rect) {
         .direction(Direction::Vertical)
         .margin(1)
         .constraints([
-            Constraint::Length(1),   // Header
-            Constraint::Min(18),     // Notes
+            Constraint::Length(1), // Header
+            Constraint::Min(18),   // Notes
         ])
         .split(h_chunks[1]);
 
     // Left side: Settings header
-    let header = Paragraph::new("QEMU Settings")
-        .style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD));
+    let header = Paragraph::new("QEMU Settings").style(
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    );
     frame.render_widget(header, left_chunks[0]);
 
     // Settings list (editable)
@@ -1878,7 +2106,10 @@ fn render_step_configure_qemu(app: &App, frame: &mut Frame, area: Rect) {
         let backend_display = match config.network_backend.as_str() {
             "user" => "user/SLIRP (NAT)".to_string(),
             "passt" => "passt".to_string(),
-            "bridge" => format!("bridge ({})", config.bridge_name.as_deref().unwrap_or("qemubr0")),
+            "bridge" => format!(
+                "bridge ({})",
+                config.bridge_name.as_deref().unwrap_or("qemubr0")
+            ),
             "none" => "none".to_string(),
             other => other.to_string(),
         };
@@ -1967,15 +2198,26 @@ fn render_step_configure_qemu(app: &App, frame: &mut Frame, area: Rect) {
     ));
 
     lines.push(Line::from(""));
-    lines.push(Line::styled("  Features (toggle with Space):", Style::default().fg(Color::DarkGray)));
+    lines.push(Line::styled(
+        "  Features (toggle with Space):",
+        Style::default().fg(Color::DarkGray),
+    ));
 
     // KVM toggle
     let kvm_selected = focus == 11;
-    lines.push(render_toggle_line("KVM Accel:", config.enable_kvm, kvm_selected));
+    lines.push(render_toggle_line(
+        "KVM Accel:",
+        config.enable_kvm,
+        kvm_selected,
+    ));
 
     // 3D/GL acceleration toggle
     let gl_selected = focus == 12;
-    lines.push(render_toggle_line("3D Accel:", config.gl_acceleration, gl_selected));
+    lines.push(render_toggle_line(
+        "3D Accel:",
+        config.gl_acceleration,
+        gl_selected,
+    ));
 
     // UEFI toggle
     let uefi_selected = focus == 13;
@@ -1987,11 +2229,19 @@ fn render_step_configure_qemu(app: &App, frame: &mut Frame, area: Rect) {
 
     // USB Tablet toggle
     let usb_selected = focus == 15;
-    lines.push(render_toggle_line("USB Tablet:", config.usb_tablet, usb_selected));
+    lines.push(render_toggle_line(
+        "USB Tablet:",
+        config.usb_tablet,
+        usb_selected,
+    ));
 
     // RTC Local toggle
     let rtc_selected = focus == 16;
-    lines.push(render_toggle_line("RTC Local:", config.rtc_localtime, rtc_selected));
+    lines.push(render_toggle_line(
+        "RTC Local:",
+        config.rtc_localtime,
+        rtc_selected,
+    ));
 
     let settings = Paragraph::new(lines);
     frame.render_widget(settings, left_chunks[1]);
@@ -2008,8 +2258,11 @@ fn render_step_configure_qemu(app: &App, frame: &mut Frame, area: Rect) {
     frame.render_widget(help, left_chunks[2]);
 
     // Right side: Notes header
-    let notes_header = Paragraph::new("Why These Defaults?")
-        .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD));
+    let notes_header = Paragraph::new("Why These Defaults?").style(
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    );
     frame.render_widget(notes_header, right_chunks[0]);
 
     // Right side: Explanation notes
@@ -2028,23 +2281,47 @@ fn render_step_configure_qemu(app: &App, frame: &mut Frame, area: Rect) {
     frame.render_widget(notes, notes_inner);
 }
 
-fn render_field_line(label: &str, value: &str, selected: bool, editing: bool, hint: &str) -> Line<'static> {
+fn render_field_line(
+    label: &str,
+    value: &str,
+    selected: bool,
+    editing: bool,
+    hint: &str,
+) -> Line<'static> {
     let prefix = if selected { "> " } else { "  " };
     let label_style = Style::default().fg(Color::Yellow);
     let value_style = if editing {
-        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD)
     } else if selected {
-        Style::default().fg(Color::White).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(Color::White)
     };
     let hint_style = Style::default().fg(Color::DarkGray);
 
     Line::from(vec![
-        Span::styled(prefix.to_string(), if selected { Style::default().fg(Color::Yellow) } else { Style::default() }),
+        Span::styled(
+            prefix.to_string(),
+            if selected {
+                Style::default().fg(Color::Yellow)
+            } else {
+                Style::default()
+            },
+        ),
         Span::styled(format!("{:12}", label), label_style),
         Span::styled(format!("{:15}", value), value_style),
-        Span::styled(if selected { hint.to_string() } else { String::new() }, hint_style),
+        Span::styled(
+            if selected {
+                hint.to_string()
+            } else {
+                String::new()
+            },
+            hint_style,
+        ),
     ])
 }
 
@@ -2053,13 +2330,26 @@ fn render_toggle_line(label: &str, enabled: bool, selected: bool) -> Line<'stati
     let checkbox = if enabled { "[x]" } else { "[ ]" };
     let label_style = Style::default().fg(Color::Yellow);
     let value_style = if selected {
-        Style::default().fg(if enabled { Color::Green } else { Color::Red }).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(if enabled { Color::Green } else { Color::Red })
+            .add_modifier(Modifier::BOLD)
     } else {
-        Style::default().fg(if enabled { Color::Green } else { Color::DarkGray })
+        Style::default().fg(if enabled {
+            Color::Green
+        } else {
+            Color::DarkGray
+        })
     };
 
     Line::from(vec![
-        Span::styled(prefix.to_string(), if selected { Style::default().fg(Color::Yellow) } else { Style::default() }),
+        Span::styled(
+            prefix.to_string(),
+            if selected {
+                Style::default().fg(Color::Yellow)
+            } else {
+                Style::default()
+            },
+        ),
         Span::styled(format!("{:12}", label), label_style),
         Span::styled(checkbox.to_string(), value_style),
     ])
@@ -2081,8 +2371,13 @@ fn get_audio_label(audio: &[String]) -> &'static str {
 
 fn get_field_notes(app: &App, focus: usize) -> String {
     let profile = app.wizard_selected_profile();
-    let profile_notes = profile.and_then(|p| p.notes.as_ref()).cloned().unwrap_or_default();
-    let os_name = profile.map(|p| p.display_name.as_str()).unwrap_or("this OS");
+    let profile_notes = profile
+        .and_then(|p| p.notes.as_ref())
+        .cloned()
+        .unwrap_or_default();
+    let os_name = profile
+        .map(|p| p.display_name.as_str())
+        .unwrap_or("this OS");
 
     let field = QemuField::from_index(focus);
 
@@ -2153,7 +2448,7 @@ fn get_field_notes(app: &App, focus: usize) -> String {
                 Requires qemu-bridge-helper with proper permissions.",
                 os_name, bridges_str
             )
-        },
+        }
         QemuField::PortForwards => format!(
             "Port forwarding for {}.\n\n\
             Forward host ports to the VM for \
@@ -2193,12 +2488,14 @@ fn get_field_notes(app: &App, focus: usize) -> String {
         QemuField::Kvm => "KVM hardware acceleration.\n\n\
             Enables near-native speed using CPU virtualization.\n\n\
             Requires: Linux host with Intel VT-x or AMD-V.\n\
-            Disable for: Non-x86 guests, nested virt issues.".to_string(),
+            Disable for: Non-x86 guests, nested virt issues."
+            .to_string(),
         QemuField::GlAccel => "3D/OpenGL acceleration.\n\n\
             Hardware-accelerated 3D graphics via virtio-gpu.\n\n\
             Requires: virtio VGA (auto-set when enabled)\n\
             Best for: Linux guests, Android x86\n\
-            Not for: Windows (no virtio 3D), retro OSes".to_string(),
+            Not for: Windows (no virtio 3D), retro OSes"
+            .to_string(),
         QemuField::Uefi => format!(
             "UEFI boot mode for {}.\n\n\
             Modern boot firmware (vs legacy BIOS).\n\n\
@@ -2211,15 +2508,18 @@ fn get_field_notes(app: &App, focus: usize) -> String {
             Trusted Platform Module for security features.\n\n\
             Required: Windows 11\n\
             Optional: BitLocker, Secure Boot\n\
-            Not needed: Most other OSes".to_string(),
+            Not needed: Most other OSes"
+            .to_string(),
         QemuField::UsbTablet => "USB tablet device.\n\n\
             Provides seamless mouse integration (no capture).\n\n\
             Recommended: Most modern systems\n\
-            Disable: Old OSes with USB issues".to_string(),
+            Disable: Old OSes with USB issues"
+            .to_string(),
         QemuField::RtcLocal => "RTC in local time.\n\n\
             Sets hardware clock to local timezone.\n\n\
             Enable: Windows (expects local time)\n\
-            Disable: Linux/Unix (expects UTC)".to_string(),
+            Disable: Linux/Unix (expects UTC)"
+            .to_string(),
     };
 
     if profile_notes.is_empty() {
@@ -2236,13 +2536,19 @@ fn handle_step_configure_qemu(app: &mut App, key: KeyEvent) -> Result<()> {
     }
 
     // Check if we're in edit mode for Memory or CPU
-    let editing_memory = app.wizard_state.as_ref()
+    let editing_memory = app
+        .wizard_state
+        .as_ref()
         .map(|s| matches!(s.editing_field, Some(WizardField::MemoryMb)))
         .unwrap_or(false);
-    let editing_cpu = app.wizard_state.as_ref()
+    let editing_cpu = app
+        .wizard_state
+        .as_ref()
         .map(|s| matches!(s.editing_field, Some(WizardField::CpuCores)))
         .unwrap_or(false);
-    let editing_mac = app.wizard_state.as_ref()
+    let editing_mac = app
+        .wizard_state
+        .as_ref()
         .map(|s| matches!(s.editing_field, Some(WizardField::MacAddress)))
         .unwrap_or(false);
 
@@ -2326,7 +2632,11 @@ fn handle_step_configure_qemu(app: &mut App, key: KeyEvent) -> Result<()> {
             }
             KeyCode::Left | KeyCode::Right => {
                 // Allow arrow keys to still adjust while editing
-                let delta = if key.code == KeyCode::Right { 1i32 } else { -1i32 };
+                let delta = if key.code == KeyCode::Right {
+                    1i32
+                } else {
+                    -1i32
+                };
                 handle_qemu_field_change(app, delta);
                 // Update buffer to reflect new value
                 if let Some(ref mut state) = app.wizard_state {
@@ -2349,7 +2659,9 @@ fn handle_step_configure_qemu(app: &mut App, key: KeyEvent) -> Result<()> {
         KeyCode::Enter => {
             // Open port-forward editor only if PortForwards is the focused
             // *and* currently visible row. Issue #31.
-            let on_visible_pf = app.wizard_state.as_ref()
+            let on_visible_pf = app
+                .wizard_state
+                .as_ref()
                 .map(|s| {
                     let field = QemuField::from_index(s.field_focus);
                     field == QemuField::PortForwards && field.is_visible(&s.qemu_config)
@@ -2381,11 +2693,8 @@ fn handle_step_configure_qemu(app: &mut App, key: KeyEvent) -> Result<()> {
                     }
                     QemuField::MacAddress => {
                         state.editing_field = Some(WizardField::MacAddress);
-                        state.wizard_edit_buffer = state
-                            .qemu_config
-                            .mac_address
-                            .clone()
-                            .unwrap_or_default();
+                        state.wizard_edit_buffer =
+                            state.qemu_config.mac_address.clone().unwrap_or_default();
                     }
                     _ => {}
                 }
@@ -2418,14 +2727,20 @@ fn handle_step_configure_qemu(app: &mut App, key: KeyEvent) -> Result<()> {
             }
         }
         KeyCode::Left | KeyCode::Right => {
-            let delta = if key.code == KeyCode::Right { 1i32 } else { -1i32 };
+            let delta = if key.code == KeyCode::Right {
+                1i32
+            } else {
+                -1i32
+            };
             handle_qemu_field_change(app, delta);
             // Show warning if spice-app selected without viewer
             if let Some(ref state) = app.wizard_state {
                 if state.qemu_config.display.contains("spice")
                     && !crate::commands::qemu_system::is_spice_viewer_available()
                 {
-                    app.set_status("Warning: spice-app requires virt-viewer/remote-viewer to be installed");
+                    app.set_status(
+                        "Warning: spice-app requires virt-viewer/remote-viewer to be installed",
+                    );
                 }
             }
         }
@@ -2450,8 +2765,12 @@ fn handle_step_configure_qemu(app: &mut App, key: KeyEvent) -> Result<()> {
                     }
                     QemuField::Uefi => state.qemu_config.uefi = !state.qemu_config.uefi,
                     QemuField::Tpm => state.qemu_config.tpm = !state.qemu_config.tpm,
-                    QemuField::UsbTablet => state.qemu_config.usb_tablet = !state.qemu_config.usb_tablet,
-                    QemuField::RtcLocal => state.qemu_config.rtc_localtime = !state.qemu_config.rtc_localtime,
+                    QemuField::UsbTablet => {
+                        state.qemu_config.usb_tablet = !state.qemu_config.usb_tablet
+                    }
+                    QemuField::RtcLocal => {
+                        state.qemu_config.rtc_localtime = !state.qemu_config.rtc_localtime
+                    }
                     _ => {}
                 }
             }
@@ -2482,34 +2801,32 @@ fn handle_wizard_port_forward_editor(app: &mut App, key: KeyEvent) -> Result<()>
             KeyCode::Esc => {
                 app.wizard_adding_pf = None;
             }
-            KeyCode::Enter => {
-                match adding.step {
-                    AddPfStep::Protocol => {
-                        adding.step = AddPfStep::HostPort;
-                    }
-                    AddPfStep::HostPort => {
-                        if adding.host_port_input.parse::<u16>().is_ok() {
-                            adding.step = AddPfStep::GuestPort;
-                        }
-                    }
-                    AddPfStep::GuestPort => {
-                        if let (Ok(host), Ok(guest)) = (
-                            adding.host_port_input.parse::<u16>(),
-                            adding.guest_port_input.parse::<u16>(),
-                        ) {
-                            let pf = PortForward {
-                                protocol: adding.protocol,
-                                host_port: host,
-                                guest_port: guest,
-                            };
-                            if let Some(ref mut state) = app.wizard_state {
-                                state.qemu_config.port_forwards.push(pf);
-                            }
-                            app.wizard_adding_pf = None;
-                        }
+            KeyCode::Enter => match adding.step {
+                AddPfStep::Protocol => {
+                    adding.step = AddPfStep::HostPort;
+                }
+                AddPfStep::HostPort => {
+                    if adding.host_port_input.parse::<u16>().is_ok() {
+                        adding.step = AddPfStep::GuestPort;
                     }
                 }
-            }
+                AddPfStep::GuestPort => {
+                    if let (Ok(host), Ok(guest)) = (
+                        adding.host_port_input.parse::<u16>(),
+                        adding.guest_port_input.parse::<u16>(),
+                    ) {
+                        let pf = PortForward {
+                            protocol: adding.protocol,
+                            host_port: host,
+                            guest_port: guest,
+                        };
+                        if let Some(ref mut state) = app.wizard_state {
+                            state.qemu_config.port_forwards.push(pf);
+                        }
+                        app.wizard_adding_pf = None;
+                    }
+                }
+            },
             KeyCode::Left | KeyCode::Right => {
                 if adding.step == AddPfStep::Protocol {
                     adding.protocol = match adding.protocol {
@@ -2518,20 +2835,20 @@ fn handle_wizard_port_forward_editor(app: &mut App, key: KeyEvent) -> Result<()>
                     };
                 }
             }
-            KeyCode::Char(c) if c.is_ascii_digit() => {
-                match adding.step {
-                    AddPfStep::HostPort => adding.host_port_input.push(c),
-                    AddPfStep::GuestPort => adding.guest_port_input.push(c),
-                    _ => {}
+            KeyCode::Char(c) if c.is_ascii_digit() => match adding.step {
+                AddPfStep::HostPort => adding.host_port_input.push(c),
+                AddPfStep::GuestPort => adding.guest_port_input.push(c),
+                _ => {}
+            },
+            KeyCode::Backspace => match adding.step {
+                AddPfStep::HostPort => {
+                    adding.host_port_input.pop();
                 }
-            }
-            KeyCode::Backspace => {
-                match adding.step {
-                    AddPfStep::HostPort => { adding.host_port_input.pop(); }
-                    AddPfStep::GuestPort => { adding.guest_port_input.pop(); }
-                    _ => {}
+                AddPfStep::GuestPort => {
+                    adding.guest_port_input.pop();
                 }
-            }
+                _ => {}
+            },
             _ => {}
         }
         return Ok(());
@@ -2543,7 +2860,9 @@ fn handle_wizard_port_forward_editor(app: &mut App, key: KeyEvent) -> Result<()>
             app.wizard_editing_port_forwards = false;
         }
         KeyCode::Char('j') | KeyCode::Down => {
-            let pf_len = app.wizard_state.as_ref()
+            let pf_len = app
+                .wizard_state
+                .as_ref()
                 .map(|s| s.qemu_config.port_forwards.len())
                 .unwrap_or(0);
             if app.wizard_pf_selected < pf_len.saturating_sub(1) {
@@ -2568,7 +2887,10 @@ fn handle_wizard_port_forward_editor(app: &mut App, key: KeyEvent) -> Result<()>
                 if !state.qemu_config.port_forwards.is_empty()
                     && app.wizard_pf_selected < state.qemu_config.port_forwards.len()
                 {
-                    state.qemu_config.port_forwards.remove(app.wizard_pf_selected);
+                    state
+                        .qemu_config
+                        .port_forwards
+                        .remove(app.wizard_pf_selected);
                     if app.wizard_pf_selected >= state.qemu_config.port_forwards.len()
                         && app.wizard_pf_selected > 0
                     {
@@ -2588,28 +2910,48 @@ fn handle_wizard_port_forward_editor(app: &mut App, key: KeyEvent) -> Result<()>
     Ok(())
 }
 
-fn add_wizard_preset(app: &mut App, protocol: crate::vm::qemu_config::PortProtocol, host_port: u16, guest_port: u16) {
+fn add_wizard_preset(
+    app: &mut App,
+    protocol: crate::vm::qemu_config::PortProtocol,
+    host_port: u16,
+    guest_port: u16,
+) {
     if let Some(ref mut state) = app.wizard_state {
-        if !state.qemu_config.port_forwards.iter().any(|pf| pf.host_port == host_port && pf.guest_port == guest_port) {
-            state.qemu_config.port_forwards.push(crate::vm::qemu_config::PortForward {
-                protocol,
-                host_port,
-                guest_port,
-            });
+        if !state
+            .qemu_config
+            .port_forwards
+            .iter()
+            .any(|pf| pf.host_port == host_port && pf.guest_port == guest_port)
+        {
+            state
+                .qemu_config
+                .port_forwards
+                .push(crate::vm::qemu_config::PortForward {
+                    protocol,
+                    host_port,
+                    guest_port,
+                });
         }
     }
 }
 
 /// Render the port-forward editor as a popup over the wizard dialog.
 fn render_wizard_port_forward_editor(app: &App, frame: &mut Frame, parent: Rect) {
-    let Some(state) = app.wizard_state.as_ref() else { return };
+    let Some(state) = app.wizard_state.as_ref() else {
+        return;
+    };
 
     // Centered popup, sized to the parent dialog.
     let width = parent.width.saturating_sub(8).min(64);
     let height = parent.height.saturating_sub(6).min(16);
     let x = parent.x + (parent.width.saturating_sub(width)) / 2;
     let y = parent.y + (parent.height.saturating_sub(height)) / 2;
-    let area = Rect { x, y, width, height };
+    let area = Rect {
+        x,
+        y,
+        width,
+        height,
+    };
 
     frame.render_widget(Clear, area);
 
@@ -2631,10 +2973,10 @@ fn render_wizard_port_forward_editor(app: &App, frame: &mut Frame, parent: Rect)
         .direction(Direction::Vertical)
         .margin(1)
         .constraints([
-            Constraint::Min(3),       // Rules list
-            Constraint::Length(1),    // Spacer
-            Constraint::Length(1),    // Presets
-            Constraint::Length(1),    // Help
+            Constraint::Min(3),    // Rules list
+            Constraint::Length(1), // Spacer
+            Constraint::Length(1), // Presets
+            Constraint::Length(1), // Help
         ])
         .split(inner);
 
@@ -2650,12 +2992,17 @@ fn render_wizard_port_forward_editor(app: &App, frame: &mut Frame, parent: Rect)
             let is_selected = i == app.wizard_pf_selected;
             let prefix = if is_selected { "> " } else { "  " };
             let style = if is_selected {
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(Color::White)
             };
             lines.push(Line::styled(
-                format!("{}{}  {} -> {}", prefix, pf.protocol, pf.host_port, pf.guest_port),
+                format!(
+                    "{}{}  {} -> {}",
+                    prefix, pf.protocol, pf.host_port, pf.guest_port
+                ),
                 style,
             ));
         }
@@ -2680,21 +3027,26 @@ fn render_wizard_adding_pf(adding: &crate::app::AddingPortForward, frame: &mut F
         .direction(Direction::Vertical)
         .margin(1)
         .constraints([
-            Constraint::Length(1),    // Header
-            Constraint::Length(1),    // Spacer
-            Constraint::Length(1),    // Protocol
-            Constraint::Length(1),    // Host port
-            Constraint::Length(1),    // Guest port
-            Constraint::Min(1),       // Spacer
-            Constraint::Length(1),    // Help
+            Constraint::Length(1), // Header
+            Constraint::Length(1), // Spacer
+            Constraint::Length(1), // Protocol
+            Constraint::Length(1), // Host port
+            Constraint::Length(1), // Guest port
+            Constraint::Min(1),    // Spacer
+            Constraint::Length(1), // Help
         ])
         .split(area);
 
-    let header = Paragraph::new("Add Port Forward Rule")
-        .style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD));
+    let header = Paragraph::new("Add Port Forward Rule").style(
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    );
     frame.render_widget(header, chunks[0]);
 
-    let active_style = Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD);
+    let active_style = Style::default()
+        .fg(Color::Yellow)
+        .add_modifier(Modifier::BOLD);
     let idle_style = Style::default().fg(Color::White);
     let hint_style = Style::default().fg(Color::DarkGray);
 
@@ -2704,10 +3056,18 @@ fn render_wizard_adding_pf(adding: &crate::app::AddingPortForward, frame: &mut F
         Span::styled("  Protocol:   ", Style::default().fg(Color::Yellow)),
         Span::styled(
             format!("{}", adding.protocol),
-            if proto_active { active_style } else { idle_style },
+            if proto_active {
+                active_style
+            } else {
+                idle_style
+            },
         ),
         Span::styled(
-            if proto_active { "  [←/→] toggle" } else { "" },
+            if proto_active {
+                "  [←/→] toggle"
+            } else {
+                ""
+            },
             hint_style,
         ),
     ]);
@@ -2724,7 +3084,14 @@ fn render_wizard_adding_pf(adding: &crate::app::AddingPortForward, frame: &mut F
     };
     let host_line = Line::from(vec![
         Span::styled("  Host Port:  ", Style::default().fg(Color::Yellow)),
-        Span::styled(host_value, if host_active { active_style } else { idle_style }),
+        Span::styled(
+            host_value,
+            if host_active {
+                active_style
+            } else {
+                idle_style
+            },
+        ),
     ]);
     frame.render_widget(Paragraph::new(host_line), chunks[3]);
 
@@ -2739,7 +3106,14 @@ fn render_wizard_adding_pf(adding: &crate::app::AddingPortForward, frame: &mut F
     };
     let guest_line = Line::from(vec![
         Span::styled("  Guest Port: ", Style::default().fg(Color::Yellow)),
-        Span::styled(guest_value, if guest_active { active_style } else { idle_style }),
+        Span::styled(
+            guest_value,
+            if guest_active {
+                active_style
+            } else {
+                idle_style
+            },
+        ),
     ]);
     frame.render_widget(Paragraph::new(guest_line), chunks[4]);
 
@@ -2751,21 +3125,28 @@ fn render_wizard_adding_pf(adding: &crate::app::AddingPortForward, frame: &mut F
 
 fn handle_qemu_field_change(app: &mut App, delta: i32) {
     // Get dynamic display options based on the current emulator
-    let emulator = app.wizard_state.as_ref()
+    let emulator = app
+        .wizard_state
+        .as_ref()
         .map(|s| s.qemu_config.emulator.clone())
         .unwrap_or_else(|| "qemu-system-x86_64".to_string());
     let dynamic_display_options = app.get_display_options_for_emulator(&emulator);
 
     // Collect network backend options before mutable borrow
-    let backend_options: Vec<String> = app.get_network_backend_options()
+    let backend_options: Vec<String> = app
+        .get_network_backend_options()
         .iter()
         .map(|(id, _)| id.to_string())
         .collect();
     let system_bridges = app.network_caps.system_bridges.clone();
-    let default_bridge = system_bridges.first().cloned()
+    let default_bridge = system_bridges
+        .first()
+        .cloned()
         .or_else(|| Some("qemubr0".to_string()));
 
-    let Some(ref mut state) = app.wizard_state else { return };
+    let Some(ref mut state) = app.wizard_state else {
+        return;
+    };
     let field = QemuField::from_index(state.field_focus);
 
     // Issue #31: don't mutate config when the cursor is parked on a row
@@ -2778,10 +3159,12 @@ fn handle_qemu_field_change(app: &mut App, delta: i32) {
     match field {
         QemuField::Memory => {
             let change = 256 * delta;
-            state.qemu_config.memory_mb = (state.qemu_config.memory_mb as i32 + change).clamp(128, 1048576) as u32;
+            state.qemu_config.memory_mb =
+                (state.qemu_config.memory_mb as i32 + change).clamp(128, 1048576) as u32;
         }
         QemuField::CpuCores => {
-            state.qemu_config.cpu_cores = (state.qemu_config.cpu_cores as i32 + delta).clamp(1, 256) as u32;
+            state.qemu_config.cpu_cores =
+                (state.qemu_config.cpu_cores as i32 + delta).clamp(1, 256) as u32;
         }
         QemuField::Vga => {
             cycle_option(&mut state.qemu_config.vga, VGA_OPTIONS, delta);
@@ -2797,7 +3180,9 @@ fn handle_qemu_field_change(app: &mut App, delta: i32) {
             cycle_option(&mut state.qemu_config.network_backend, &backend_strs, delta);
 
             // Set default bridge name when switching to bridge
-            if state.qemu_config.network_backend == "bridge" && state.qemu_config.bridge_name.is_none() {
+            if state.qemu_config.network_backend == "bridge"
+                && state.qemu_config.bridge_name.is_none()
+            {
                 state.qemu_config.bridge_name = default_bridge.clone();
             }
         }
@@ -2805,11 +3190,12 @@ fn handle_qemu_field_change(app: &mut App, delta: i32) {
             // Cycle through available system bridges
             if !system_bridges.is_empty() {
                 let current_bridge = state.qemu_config.bridge_name.as_deref().unwrap_or("");
-                let current_idx = system_bridges.iter()
+                let current_idx = system_bridges
+                    .iter()
                     .position(|b| b == current_bridge)
                     .unwrap_or(0);
-                let new_idx = (current_idx as i32 + delta)
-                    .rem_euclid(system_bridges.len() as i32) as usize;
+                let new_idx =
+                    (current_idx as i32 + delta).rem_euclid(system_bridges.len() as i32) as usize;
                 state.qemu_config.bridge_name = Some(system_bridges[new_idx].clone());
             }
         }
@@ -2817,11 +3203,16 @@ fn handle_qemu_field_change(app: &mut App, delta: i32) {
             // Handled via Enter key, not left/right
         }
         QemuField::DiskInterface => {
-            cycle_option(&mut state.qemu_config.disk_interface, DISK_INTERFACE_OPTIONS, delta);
+            cycle_option(
+                &mut state.qemu_config.disk_interface,
+                DISK_INTERFACE_OPTIONS,
+                delta,
+            );
         }
         QemuField::Display => {
             // Use dynamic options from detected capabilities
-            let display_strs: Vec<&str> = dynamic_display_options.iter().map(|s| s.as_str()).collect();
+            let display_strs: Vec<&str> =
+                dynamic_display_options.iter().map(|s| s.as_str()).collect();
             if !display_strs.is_empty() {
                 cycle_option(&mut state.qemu_config.display, &display_strs, delta);
             } else {
@@ -2842,22 +3233,30 @@ fn handle_qemu_field_change(app: &mut App, delta: i32) {
 }
 
 fn cycle_option(current: &mut String, options: &[&str], delta: i32) {
-    let current_idx = options.iter().position(|&o| o == current.as_str()).unwrap_or(0);
+    let current_idx = options
+        .iter()
+        .position(|&o| o == current.as_str())
+        .unwrap_or(0);
     let new_idx = (current_idx as i32 + delta).rem_euclid(options.len() as i32) as usize;
     *current = options[new_idx].to_string();
 }
 
 fn cycle_audio(current: &mut Vec<String>, delta: i32) {
     // Find current audio preset
-    let current_idx = AUDIO_OPTIONS.iter().position(|(_, devices)| {
-        if devices.is_empty() && current.is_empty() {
-            true
-        } else if !devices.is_empty() && !current.is_empty() {
-            current.iter().any(|c| devices.iter().any(|d| c.contains(d)))
-        } else {
-            false
-        }
-    }).unwrap_or(0);
+    let current_idx = AUDIO_OPTIONS
+        .iter()
+        .position(|(_, devices)| {
+            if devices.is_empty() && current.is_empty() {
+                true
+            } else if !devices.is_empty() && !current.is_empty() {
+                current
+                    .iter()
+                    .any(|c| devices.iter().any(|d| c.contains(d)))
+            } else {
+                false
+            }
+        })
+        .unwrap_or(0);
 
     let new_idx = (current_idx as i32 + delta).rem_euclid(AUDIO_OPTIONS.len() as i32) as usize;
     let (_, devices) = AUDIO_OPTIONS[new_idx];
@@ -2872,7 +3271,11 @@ fn render_step_confirm(app: &App, frame: &mut Frame, area: Rect) {
     let state = app.wizard_state.as_ref().unwrap();
 
     let block = Block::default()
-        .title(format!(" Create New VM ({}/5) - {} ", state.step.number(), state.step.title()))
+        .title(format!(
+            " Create New VM ({}/5) - {} ",
+            state.step.number(),
+            state.step.title()
+        ))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Green))
         .style(Style::default().bg(Color::Black));
@@ -2884,31 +3287,39 @@ fn render_step_confirm(app: &App, frame: &mut Frame, area: Rect) {
         .direction(Direction::Vertical)
         .margin(1)
         .constraints([
-            Constraint::Length(1),   // Header
-            Constraint::Length(1),   // Spacer
-            Constraint::Min(15),     // Summary
-            Constraint::Length(3),   // Auto-launch toggle
-            Constraint::Length(1),   // Error
-            Constraint::Length(2),   // Help
+            Constraint::Length(1), // Header
+            Constraint::Length(1), // Spacer
+            Constraint::Min(15),   // Summary
+            Constraint::Length(3), // Auto-launch toggle
+            Constraint::Length(1), // Error
+            Constraint::Length(2), // Help
         ])
         .split(inner);
 
     // Header
-    let header = Paragraph::new("Summary")
-        .style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD));
+    let header = Paragraph::new("Summary").style(
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    );
     frame.render_widget(header, chunks[0]);
 
     // Summary
-    let os_name = state.selected_os.as_ref()
+    let os_name = state
+        .selected_os
+        .as_ref()
         .and_then(|id| app.qemu_profiles.get(id))
         .map(|p| p.display_name.as_str())
         .unwrap_or("Custom OS");
 
-    let vm_path = app.wizard_vm_path()
+    let vm_path = app
+        .wizard_vm_path()
         .map(|p| p.display().to_string())
         .unwrap_or_else(|| "Unknown".to_string());
 
-    let iso_str = state.iso_path.as_ref()
+    let iso_str = state
+        .iso_path
+        .as_ref()
         .map(|p| p.display().to_string())
         .unwrap_or_else(|| "None".to_string());
 
@@ -2951,7 +3362,10 @@ fn render_step_confirm(app: &App, frame: &mut Frame, area: Rect) {
     lines.push(Line::from(""));
     lines.push(Line::from(vec![
         Span::styled("Hardware:       ", Style::default().fg(Color::Yellow)),
-        Span::raw(format!("{} cores, {} MB RAM", config.cpu_cores, config.memory_mb)),
+        Span::raw(format!(
+            "{} cores, {} MB RAM",
+            config.cpu_cores, config.memory_mb
+        )),
     ]));
     lines.push(Line::from(vec![
         Span::styled("Graphics:       ", Style::default().fg(Color::Yellow)),
@@ -2959,14 +3373,23 @@ fn render_step_confirm(app: &App, frame: &mut Frame, area: Rect) {
     ]));
     lines.push(Line::from(vec![
         Span::styled("Audio:          ", Style::default().fg(Color::Yellow)),
-        Span::raw(config.audio.first().cloned().unwrap_or_else(|| "None".to_string())),
+        Span::raw(
+            config
+                .audio
+                .first()
+                .cloned()
+                .unwrap_or_else(|| "None".to_string()),
+        ),
     ]));
     let net_display = if config.network_model == "none" {
         "none".to_string()
     } else {
         let backend_str = match config.network_backend.as_str() {
             "passt" => "passt".to_string(),
-            "bridge" => format!("bridge ({})", config.bridge_name.as_deref().unwrap_or("qemubr0")),
+            "bridge" => format!(
+                "bridge ({})",
+                config.bridge_name.as_deref().unwrap_or("qemubr0")
+            ),
             "none" => "disabled".to_string(),
             _ => "user/SLIRP (NAT)".to_string(),
         };
@@ -2978,18 +3401,24 @@ fn render_step_confirm(app: &App, frame: &mut Frame, area: Rect) {
     ]));
     if !config.port_forwards.is_empty() {
         for pf in &config.port_forwards {
-            lines.push(Line::from(format!("                {} {} -> {}", pf.protocol, pf.host_port, pf.guest_port)));
+            lines.push(Line::from(format!(
+                "                {} {} -> {}",
+                pf.protocol, pf.host_port, pf.guest_port
+            )));
         }
     }
 
-    let accel = if config.enable_kvm { "KVM enabled" } else { "No acceleration" };
+    let accel = if config.enable_kvm {
+        "KVM enabled"
+    } else {
+        "No acceleration"
+    };
     lines.push(Line::from(vec![
         Span::styled("Acceleration:   ", Style::default().fg(Color::Yellow)),
         Span::raw(accel),
     ]));
 
-    let summary = Paragraph::new(lines)
-        .wrap(Wrap { trim: false });
+    let summary = Paragraph::new(lines).wrap(Wrap { trim: false });
     frame.render_widget(summary, chunks[2]);
 
     // Auto-launch toggle
@@ -2997,15 +3426,17 @@ fn render_step_confirm(app: &App, frame: &mut Frame, area: Rect) {
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Gray));
     let checkbox = if state.auto_launch { "[x]" } else { "[ ]" };
-    let launch_text = Paragraph::new(format!("{} Launch VM in install mode after creation", checkbox))
-        .style(Style::default().fg(Color::White))
-        .block(launch_box);
+    let launch_text = Paragraph::new(format!(
+        "{} Launch VM in install mode after creation",
+        checkbox
+    ))
+    .style(Style::default().fg(Color::White))
+    .block(launch_box);
     frame.render_widget(launch_text, chunks[3]);
 
     // Error
     if let Some(ref error) = state.error_message {
-        let error_text = Paragraph::new(error.as_str())
-            .style(Style::default().fg(Color::Red));
+        let error_text = Paragraph::new(error.as_str()).style(Style::default().fg(Color::Red));
         frame.render_widget(error_text, chunks[4]);
     }
 
@@ -3057,13 +3488,17 @@ fn handle_step_confirm(app: &mut App, key: KeyEvent) -> Result<()> {
                     // If auto_launch is enabled, find and launch the new VM
                     if auto_launch {
                         // Find the newly created VM and select it
-                        if let Some(idx) = app.vms.iter().position(|vm| {
-                            vm.launch_script == created.launch_script
-                        }) {
+                        if let Some(idx) = app
+                            .vms
+                            .iter()
+                            .position(|vm| vm.launch_script == created.launch_script)
+                        {
                             // Find in visual order
-                            if let Some(visual_idx) = app.visual_order.iter().position(|&filtered_idx| {
-                                app.filtered_indices.get(filtered_idx) == Some(&idx)
-                            }) {
+                            if let Some(visual_idx) =
+                                app.visual_order.iter().position(|&filtered_idx| {
+                                    app.filtered_indices.get(filtered_idx) == Some(&idx)
+                                })
+                            {
                                 app.selected_vm = visual_idx;
 
                                 // Set boot mode to install
@@ -3075,7 +3510,10 @@ fn handle_step_confirm(app: &mut App, key: KeyEvent) -> Result<()> {
                                         app.set_status(format!("Launched: {}", vm_name));
                                     }
                                     Err(e) => {
-                                        app.set_status(format!("VM created but launch failed: {}", e));
+                                        app.set_status(format!(
+                                            "VM created but launch failed: {}",
+                                            e
+                                        ));
                                     }
                                 }
                             }
@@ -3108,9 +3546,7 @@ fn open_url_in_browser(url: &str) -> Result<()> {
     use std::process::Command;
 
     // Try xdg-open first (standard on Linux)
-    let result = Command::new("xdg-open")
-        .arg(url)
-        .spawn();
+    let result = Command::new("xdg-open").arg(url).spawn();
 
     match result {
         Ok(_) => Ok(()),

--- a/src/ui/screens/help.rs
+++ b/src/ui/screens/help.rs
@@ -24,7 +24,9 @@ pub fn render(frame: &mut Frame) {
     let help_text = vec![
         Line::from(Span::styled(
             "Navigation",
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
         key_line("j / Down", "Move selection down"),
@@ -34,7 +36,9 @@ pub fn render(frame: &mut Frame) {
         Line::from(""),
         Line::from(Span::styled(
             "Actions",
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
         key_line("m", "Open Management menu"),
@@ -44,14 +48,18 @@ pub fn render(frame: &mut Frame) {
         Line::from(""),
         Line::from(Span::styled(
             "Management Menu",
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
         key_line("Network", "Backend, port forwarding"),
         Line::from(""),
         Line::from(Span::styled(
             "General",
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
         key_line("?", "Show this help"),
@@ -69,10 +77,7 @@ pub fn render(frame: &mut Frame) {
 
 fn key_line<'a>(key: &'a str, description: &'a str) -> Line<'a> {
     Line::from(vec![
-        Span::styled(
-            format!("  {:12}", key),
-            Style::default().fg(Color::Green),
-        ),
+        Span::styled(format!("  {:12}", key), Style::default().fg(Color::Green)),
         Span::raw(description),
     ])
 }

--- a/src/ui/screens/import_wizard.rs
+++ b/src/ui/screens/import_wizard.rs
@@ -59,7 +59,7 @@ fn render_step_select_source(state: &ImportWizardState, frame: &mut Frame, area:
         .constraints([
             Constraint::Length(2), // Description
             Constraint::Length(1), // Spacer
-            Constraint::Min(8),   // Options
+            Constraint::Min(8),    // Options
             Constraint::Length(2), // Help
         ])
         .split(inner);
@@ -69,9 +69,18 @@ fn render_step_select_source(state: &ImportWizardState, frame: &mut Frame, area:
     frame.render_widget(desc, chunks[0]);
 
     let options: &[(&str, &str)] = &[
-        ("libvirt (XML)", "Import from libvirt/virt-manager domain XML"),
-        ("quickemu (.conf)", "Import from quickemu configuration file"),
-        ("Browse for config file...", "Browse filesystem for .xml or .conf file"),
+        (
+            "libvirt (XML)",
+            "Import from libvirt/virt-manager domain XML",
+        ),
+        (
+            "quickemu (.conf)",
+            "Import from quickemu configuration file",
+        ),
+        (
+            "Browse for config file...",
+            "Browse filesystem for .xml or .conf file",
+        ),
     ];
 
     let items: Vec<ListItem> = options
@@ -135,7 +144,7 @@ fn render_step_select_vm(state: &ImportWizardState, frame: &mut Frame, area: Rec
         .constraints([
             Constraint::Length(1), // Description
             Constraint::Length(1), // Spacer
-            Constraint::Min(8),   // VM list
+            Constraint::Min(8),    // VM list
             Constraint::Length(2), // Help
         ])
         .split(inner);
@@ -237,7 +246,7 @@ fn render_step_warnings(state: &ImportWizardState, frame: &mut Frame, area: Rect
         .constraints([
             Constraint::Length(3), // Header
             Constraint::Length(1), // Spacer
-            Constraint::Min(8),   // Warnings list
+            Constraint::Min(8),    // Warnings list
             Constraint::Length(2), // Help
         ])
         .split(inner);
@@ -291,7 +300,7 @@ fn render_step_configure_disk(state: &ImportWizardState, frame: &mut Frame, area
         .constraints([
             Constraint::Length(2), // Description
             Constraint::Length(1), // Spacer
-            Constraint::Min(6),   // Disk info + options
+            Constraint::Min(6),    // Disk info + options
             Constraint::Length(4), // Warning text
             Constraint::Length(2), // Help
         ])
@@ -320,11 +329,7 @@ fn render_step_configure_disk(state: &ImportWizardState, frame: &mut Frame, area
                 Span::styled("  Disk: ", Style::default().fg(Color::Gray)),
                 Span::styled(
                     format!("{} ({}){}", disk.display(), size_str, status),
-                    Style::default().fg(if readable {
-                        Color::White
-                    } else {
-                        Color::Red
-                    }),
+                    Style::default().fg(if readable { Color::White } else { Color::Red }),
                 ),
             ]));
         }
@@ -333,9 +338,21 @@ fn render_step_configure_disk(state: &ImportWizardState, frame: &mut Frame, area
 
     // Disk action options
     let actions = [
-        (ImportDiskAction::Symlink, "Symlink", "Instant, saves space. Original must stay in place."),
-        (ImportDiskAction::Copy, "Copy", "Independent copy. Slow for large disks."),
-        (ImportDiskAction::Move, "Move", "Relocates disk to VM library."),
+        (
+            ImportDiskAction::Symlink,
+            "Symlink",
+            "Instant, saves space. Original must stay in place.",
+        ),
+        (
+            ImportDiskAction::Copy,
+            "Copy",
+            "Independent copy. Slow for large disks.",
+        ),
+        (
+            ImportDiskAction::Move,
+            "Move",
+            "Relocates disk to VM library.",
+        ),
     ];
 
     for (i, (action, label, desc)) in actions.iter().enumerate() {
@@ -354,10 +371,7 @@ fn render_step_configure_disk(state: &ImportWizardState, frame: &mut Frame, area
 
         content_lines.push(Line::from(vec![
             Span::styled(format!("  {} {} ", radio, label), style),
-            Span::styled(
-                format!("- {}", desc),
-                Style::default().fg(Color::DarkGray),
-            ),
+            Span::styled(format!("- {}", desc), Style::default().fg(Color::DarkGray)),
         ]));
     }
 
@@ -401,7 +415,7 @@ fn render_step_review(state: &ImportWizardState, frame: &mut Frame, area: Rect) 
         .direction(Direction::Vertical)
         .margin(1)
         .constraints([
-            Constraint::Min(16),  // Config summary
+            Constraint::Min(16),   // Config summary
             Constraint::Length(2), // Help
         ])
         .split(inner);
@@ -423,10 +437,7 @@ fn render_step_review(state: &ImportWizardState, frame: &mut Frame, area: Rect) 
         lines.push(Line::from(vec![
             Span::styled("  VM Name:    ", Style::default().fg(Color::Gray)),
             Span::styled(&state.vm_name, Style::default().fg(Color::White)),
-            Span::styled(
-                "  [Tab to edit]",
-                Style::default().fg(Color::DarkGray),
-            ),
+            Span::styled("  [Tab to edit]", Style::default().fg(Color::DarkGray)),
         ]));
     }
 
@@ -580,7 +591,11 @@ fn handle_select_source(app: &mut App, key: KeyEvent) -> Result<()> {
             }
         }
         KeyCode::Enter => {
-            let focus = app.import_state.as_ref().map(|s| s.field_focus).unwrap_or(0);
+            let focus = app
+                .import_state
+                .as_ref()
+                .map(|s| s.field_focus)
+                .unwrap_or(0);
             match focus {
                 0 => {
                     // libvirt
@@ -651,11 +666,10 @@ fn handle_select_vm(app: &mut App, key: KeyEvent) -> Result<()> {
                 if let Some(vm) = state.discovered_vms.get(state.selected_vm_index).cloned() {
                     let library_path = app.config.vm_library_path.clone();
                     state.vm_name = vm.name.clone();
-                    state.folder_name =
-                        crate::app::CreateWizardState::find_available_folder_name(
-                            &library_path,
-                            &crate::app::CreateWizardState::generate_folder_name(&vm.name),
-                        );
+                    state.folder_name = crate::app::CreateWizardState::find_available_folder_name(
+                        &library_path,
+                        &crate::app::CreateWizardState::generate_folder_name(&vm.name),
+                    );
                     state.selected_vm = Some(vm.clone());
                     state.error_message = None;
                     state.field_focus = 0;
@@ -701,7 +715,11 @@ fn handle_configure_disk(app: &mut App, key: KeyEvent) -> Result<()> {
         KeyCode::Esc => {
             if let Some(ref mut state) = app.import_state {
                 // Go back to warnings if they existed, otherwise to VM selection
-                if state.selected_vm.as_ref().map(|vm| !vm.import_notes.is_empty()).unwrap_or(false)
+                if state
+                    .selected_vm
+                    .as_ref()
+                    .map(|vm| !vm.import_notes.is_empty())
+                    .unwrap_or(false)
                 {
                     state.step = ImportStep::CompatibilityWarnings;
                 } else {

--- a/src/ui/screens/main_menu.rs
+++ b/src/ui/screens/main_menu.rs
@@ -14,9 +14,9 @@ pub fn render(app: &App, frame: &mut Frame) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3),  // Title
-            Constraint::Min(10),    // Main content
-            Constraint::Length(3),  // Status/help bar
+            Constraint::Length(3), // Title
+            Constraint::Min(10),   // Main content
+            Constraint::Length(3), // Status/help bar
         ])
         .split(area);
 
@@ -33,7 +33,8 @@ pub fn render(app: &App, frame: &mut Frame) {
     VmListWidget::new(app).render(main_chunks[0], frame.buffer_mut());
 
     // Render ASCII art and info
-    let vm_name = app.selected_vm()
+    let vm_name = app
+        .selected_vm()
         .map(|vm| vm.display_name())
         .unwrap_or_else(|| "No VM selected".to_string());
 
@@ -116,7 +117,9 @@ fn render_help_bar(app: &App, area: Rect, frame: &mut Frame) {
     if app.status_message.is_none() {
         if let Some((id, sent_at)) = app.stopping_vms.iter().next() {
             let elapsed = sent_at.elapsed().as_secs();
-            let vm_name = app.vms.iter()
+            let vm_name = app
+                .vms
+                .iter()
                 .find(|vm| &vm.id == id)
                 .map(|vm| vm.display_name())
                 .unwrap_or_else(|| id.clone());
@@ -138,10 +141,7 @@ fn render_help_bar(app: &App, area: Rect, frame: &mut Frame) {
     // Add status message if present (overrides everything)
     if let Some(ref msg) = app.status_message {
         hints.clear();
-        hints.push(Span::styled(
-            msg.clone(),
-            Style::default().fg(Color::Green),
-        ));
+        hints.push(Span::styled(msg.clone(), Style::default().fg(Color::Green)));
     }
 
     let help = Paragraph::new(Line::from(hints))

--- a/src/ui/screens/management.rs
+++ b/src/ui/screens/management.rs
@@ -172,20 +172,25 @@ const DISPLAY_OPTIONS: &[(&str, &str)] = &[
 /// Falls back to DISPLAY_OPTIONS if detection is not available.
 pub fn get_display_options(app: &App) -> Vec<(String, String)> {
     // Get the emulator for the currently selected VM
-    let emulator = app.selected_vm()
+    let emulator = app
+        .selected_vm()
         .map(|vm| vm.config.emulator.command())
         .unwrap_or("qemu-system-x86_64");
 
     let detected = app.get_display_options_for_emulator(emulator);
 
     // Map detected backends to (name, description) pairs using DISPLAY_OPTIONS for descriptions
-    detected.iter().map(|backend| {
-        let desc = DISPLAY_OPTIONS.iter()
-            .find(|(name, _)| *name == backend.as_str())
-            .map(|(_, desc)| desc.to_string())
-            .unwrap_or_else(|| format!("{} display", backend));
-        (backend.clone(), desc)
-    }).collect()
+    detected
+        .iter()
+        .map(|backend| {
+            let desc = DISPLAY_OPTIONS
+                .iter()
+                .find(|(name, _)| *name == backend.as_str())
+                .map(|(_, desc)| desc.to_string())
+                .unwrap_or_else(|| format!("{} display", backend));
+            (backend.clone(), desc)
+        })
+        .collect()
 }
 
 /// Render the management menu
@@ -209,7 +214,8 @@ pub fn render(app: &App, frame: &mut Frame) {
     // Clear the background
     frame.render_widget(Clear, dialog_area);
 
-    let vm_name = app.selected_vm()
+    let vm_name = app
+        .selected_vm()
         .map(|vm| vm.display_name())
         .unwrap_or_else(|| "Unknown".to_string());
 
@@ -226,9 +232,9 @@ pub fn render(app: &App, frame: &mut Frame) {
     let h_chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
-            Constraint::Length(2),  // Left margin
-            Constraint::Min(1),     // Content
-            Constraint::Length(2),  // Right margin
+            Constraint::Length(2), // Left margin
+            Constraint::Min(1),    // Content
+            Constraint::Length(2), // Right margin
         ])
         .split(inner);
 
@@ -236,9 +242,9 @@ pub fn render(app: &App, frame: &mut Frame) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1),  // Top padding
-            Constraint::Min(4),     // Menu items
-            Constraint::Length(2),  // Help text
+            Constraint::Length(1), // Top padding
+            Constraint::Min(4),    // Menu items
+            Constraint::Length(2), // Help text
         ])
         .split(h_chunks[1]);
 
@@ -248,7 +254,9 @@ pub fn render(app: &App, frame: &mut Frame) {
         .enumerate()
         .map(|(i, item)| {
             let style = if i == app.selected_menu_item {
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(Color::White)
             };
@@ -268,8 +276,7 @@ pub fn render(app: &App, frame: &mut Frame) {
     let mut state = ListState::default();
     state.select(Some(app.selected_menu_item));
 
-    let list = List::new(items)
-        .highlight_symbol("> ");
+    let list = List::new(items).highlight_symbol("> ");
 
     frame.render_stateful_widget(list, chunks[1], &mut state);
 
@@ -302,9 +309,9 @@ pub fn render_boot_options(app: &App, frame: &mut Frame) {
     let h_chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
-            Constraint::Length(2),  // Left margin
-            Constraint::Min(1),     // Content
-            Constraint::Length(2),  // Right margin
+            Constraint::Length(2), // Left margin
+            Constraint::Min(1),    // Content
+            Constraint::Length(2), // Right margin
         ])
         .split(inner);
 
@@ -312,8 +319,8 @@ pub fn render_boot_options(app: &App, frame: &mut Frame) {
     let v_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1),  // Top padding
-            Constraint::Min(1),     // Content
+            Constraint::Length(1), // Top padding
+            Constraint::Min(1),    // Content
         ])
         .split(h_chunks[1]);
 
@@ -321,8 +328,14 @@ pub fn render_boot_options(app: &App, frame: &mut Frame) {
         ("Normal boot", "Start the VM normally"),
         ("Install mode", "Boot from installation media"),
         ("Boot with custom ISO", "Select an ISO file to boot"),
-        ("Boot with recovery DMG", "Select a DMG file as recovery image"),
-        ("Boot with floppy image", "Select a floppy image (.img, .ima) to boot"),
+        (
+            "Boot with recovery DMG",
+            "Select a DMG file as recovery image",
+        ),
+        (
+            "Boot with floppy image",
+            "Select a floppy image (.img, .ima) to boot",
+        ),
     ];
 
     let items: Vec<ListItem> = boot_items
@@ -330,14 +343,19 @@ pub fn render_boot_options(app: &App, frame: &mut Frame) {
         .enumerate()
         .map(|(i, (name, desc))| {
             let style = if i == app.selected_menu_item {
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(Color::White)
             };
 
             ListItem::new(vec![
                 Line::styled(format!("[{}] {}", i + 1, name), style),
-                Line::styled(format!("    {}", desc), Style::default().fg(Color::DarkGray)),
+                Line::styled(
+                    format!("    {}", desc),
+                    Style::default().fg(Color::DarkGray),
+                ),
             ])
         })
         .collect();
@@ -359,7 +377,8 @@ pub fn render_display_options(app: &App, frame: &mut Frame) {
     frame.render_widget(Clear, dialog_area);
 
     // Get current display setting from VM
-    let current_display = app.selected_vm()
+    let current_display = app
+        .selected_vm()
         .map(|vm| extract_display_from_script(&vm.config.raw_script))
         .unwrap_or_else(|| "gtk".to_string());
 
@@ -376,9 +395,9 @@ pub fn render_display_options(app: &App, frame: &mut Frame) {
     let h_chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
-            Constraint::Length(2),  // Left margin
-            Constraint::Min(1),     // Content
-            Constraint::Length(2),  // Right margin
+            Constraint::Length(2), // Left margin
+            Constraint::Min(1),    // Content
+            Constraint::Length(2), // Right margin
         ])
         .split(inner);
 
@@ -386,9 +405,9 @@ pub fn render_display_options(app: &App, frame: &mut Frame) {
     let v_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1),  // Top padding
-            Constraint::Min(1),     // Content
-            Constraint::Length(2),  // Help
+            Constraint::Length(1), // Top padding
+            Constraint::Min(1),    // Content
+            Constraint::Length(2), // Help
         ])
         .split(h_chunks[1]);
 
@@ -400,7 +419,9 @@ pub fn render_display_options(app: &App, frame: &mut Frame) {
         .map(|(i, (name, desc))| {
             let is_current = *name == current_display;
             let style = if i == app.selected_menu_item {
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
             } else if is_current {
                 Style::default().fg(Color::Green)
             } else {
@@ -411,7 +432,10 @@ pub fn render_display_options(app: &App, frame: &mut Frame) {
 
             ListItem::new(vec![
                 Line::styled(format!("[{}] {}{}", i + 1, name, marker), style),
-                Line::styled(format!("    {}", desc), Style::default().fg(Color::DarkGray)),
+                Line::styled(
+                    format!("    {}", desc),
+                    Style::default().fg(Color::DarkGray),
+                ),
             ])
         })
         .collect();
@@ -435,7 +459,8 @@ fn extract_display_from_script(script: &str) -> String {
     if let Some(pos) = script.find("-display ") {
         let rest = &script[pos + 9..];
         // Find the display value (ends at space, comma, or backslash)
-        let end = rest.find(|c: char| c.is_whitespace() || c == ',' || c == '\\')
+        let end = rest
+            .find(|c: char| c.is_whitespace() || c == ',' || c == '\\')
             .unwrap_or(rest.len());
         let display = rest[..end].trim();
         // Handle gl=on suffix
@@ -458,7 +483,8 @@ pub fn render_snapshots(app: &App, frame: &mut Frame) {
     let dialog_area = centered_rect(dialog_width, dialog_height, area);
     frame.render_widget(Clear, dialog_area);
 
-    let supports_snapshots = app.selected_vm()
+    let supports_snapshots = app
+        .selected_vm()
         .map(|vm| vm.config.supports_snapshots())
         .unwrap_or(false);
 
@@ -481,9 +507,9 @@ pub fn render_snapshots(app: &App, frame: &mut Frame) {
     let h_chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
-            Constraint::Length(2),  // Left margin
-            Constraint::Min(1),     // Content
-            Constraint::Length(2),  // Right margin
+            Constraint::Length(2), // Left margin
+            Constraint::Min(1),    // Content
+            Constraint::Length(2), // Right margin
         ])
         .split(inner);
 
@@ -491,8 +517,8 @@ pub fn render_snapshots(app: &App, frame: &mut Frame) {
     let v_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1),  // Top padding
-            Constraint::Min(1),     // Content
+            Constraint::Length(1), // Top padding
+            Constraint::Min(1),    // Content
         ])
         .split(h_chunks[1]);
 
@@ -508,16 +534,18 @@ pub fn render_snapshots(app: &App, frame: &mut Frame) {
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Length(3), Constraint::Min(4), Constraint::Length(2)])
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(4),
+            Constraint::Length(2),
+        ])
         .split(content_area);
 
     // Action buttons
-    let actions = Paragraph::new(vec![
-        Line::from(vec![
-            Span::styled("[c]", Style::default().fg(Color::Yellow)),
-            Span::raw(" Create new snapshot"),
-        ]),
-    ]);
+    let actions = Paragraph::new(vec![Line::from(vec![
+        Span::styled("[c]", Style::default().fg(Color::Yellow)),
+        Span::raw(" Create new snapshot"),
+    ])]);
     frame.render_widget(actions, chunks[0]);
 
     // Snapshot list
@@ -527,12 +555,15 @@ pub fn render_snapshots(app: &App, frame: &mut Frame) {
             .alignment(Alignment::Center);
         frame.render_widget(msg, chunks[1]);
     } else {
-        let items: Vec<ListItem> = app.snapshots
+        let items: Vec<ListItem> = app
+            .snapshots
             .iter()
             .enumerate()
             .map(|(i, snap)| {
                 let style = if i == app.selected_snapshot {
-                    Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD)
                 } else {
                     Style::default().fg(Color::White)
                 };
@@ -550,8 +581,7 @@ pub fn render_snapshots(app: &App, frame: &mut Frame) {
         let mut state = ListState::default();
         state.select(Some(app.selected_snapshot));
 
-        let list = List::new(items)
-            .highlight_symbol("> ");
+        let list = List::new(items).highlight_symbol("> ");
         frame.render_stateful_widget(list, chunks[1], &mut state);
     }
 

--- a/src/ui/screens/multi_gpu_setup.rs
+++ b/src/ui/screens/multi_gpu_setup.rs
@@ -41,13 +41,13 @@ pub fn render(app: &App, frame: &mut Frame) {
         .direction(Direction::Vertical)
         .margin(1)
         .constraints([
-            Constraint::Length(6),  // System status
-            Constraint::Length(1),  // Separator
-            Constraint::Length(5),  // GPU info
-            Constraint::Length(1),  // Separator
-            Constraint::Length(4),  // Looking Glass config
-            Constraint::Min(1),     // Spacer
-            Constraint::Length(2),  // Help
+            Constraint::Length(6), // System status
+            Constraint::Length(1), // Separator
+            Constraint::Length(5), // GPU info
+            Constraint::Length(1), // Separator
+            Constraint::Length(4), // Looking Glass config
+            Constraint::Min(1),    // Spacer
+            Constraint::Length(2), // Help
         ])
         .split(inner);
 
@@ -83,12 +83,18 @@ fn render_system_status(frame: &mut Frame, area: Rect) {
     // Title
     lines.push(Line::styled(
         "System Requirements:",
-        Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
     ));
 
     // IOMMU check
     let iommu_icon = if status.iommu_enabled { "[+]" } else { "[-]" };
-    let iommu_style = if status.iommu_enabled { Color::Green } else { Color::Red };
+    let iommu_style = if status.iommu_enabled {
+        Color::Green
+    } else {
+        Color::Red
+    };
     lines.push(Line::from(vec![
         Span::raw("  "),
         Span::styled(iommu_icon, Style::default().fg(iommu_style)),
@@ -97,7 +103,11 @@ fn render_system_status(frame: &mut Frame, area: Rect) {
 
     // VFIO check
     let vfio_icon = if status.vfio_loaded { "[+]" } else { "[-]" };
-    let vfio_style = if status.vfio_loaded { Color::Green } else { Color::Red };
+    let vfio_style = if status.vfio_loaded {
+        Color::Green
+    } else {
+        Color::Red
+    };
     lines.push(Line::from(vec![
         Span::raw("  "),
         Span::styled(vfio_icon, Style::default().fg(vfio_style)),
@@ -145,11 +155,14 @@ fn render_gpu_info(app: &App, frame: &mut Frame, area: Rect) {
 
     lines.push(Line::styled(
         "Selected GPUs for Passthrough:",
-        Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
     ));
 
     // Get selected GPUs from PCI devices (selected_pci_devices contains indices)
-    let selected_gpus: Vec<_> = app.selected_pci_devices
+    let selected_gpus: Vec<_> = app
+        .selected_pci_devices
         .iter()
         .filter_map(|&idx| app.pci_devices.get(idx))
         .filter(|d| d.is_gpu())
@@ -194,7 +207,9 @@ fn render_looking_glass_config(app: &App, frame: &mut Frame, area: Rect) {
 
     lines.push(Line::styled(
         "Looking Glass Configuration:",
-        Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
     ));
 
     // IVSHMEM size
@@ -211,7 +226,11 @@ fn render_looking_glass_config(app: &App, frame: &mut Frame, area: Rect) {
     ]));
 
     // Auto-launch
-    let auto_launch = if app.config.looking_glass_auto_launch { "Yes" } else { "No" };
+    let auto_launch = if app.config.looking_glass_auto_launch {
+        "Yes"
+    } else {
+        "No"
+    };
     lines.push(Line::from(vec![
         Span::raw("  Auto-launch client: "),
         Span::styled(auto_launch, Style::default().fg(Color::White)),

--- a/src/ui/screens/network_settings.rs
+++ b/src/ui/screens/network_settings.rs
@@ -50,26 +50,34 @@ pub fn render(app: &App, frame: &mut Frame) {
         .direction(Direction::Vertical)
         .margin(1)
         .constraints([
-            Constraint::Length(1),   // Header
-            Constraint::Length(1),   // Spacer
-            Constraint::Length(1),   // Adapter field
-            Constraint::Length(1),   // Backend field
-            Constraint::Length(1),   // MAC field
-            Constraint::Length(1),   // Bridge name / Port forwards field
-            Constraint::Length(1),   // Spacer
-            Constraint::Min(6),      // Info area
-            Constraint::Length(2),   // Help
+            Constraint::Length(1), // Header
+            Constraint::Length(1), // Spacer
+            Constraint::Length(1), // Adapter field
+            Constraint::Length(1), // Backend field
+            Constraint::Length(1), // MAC field
+            Constraint::Length(1), // Bridge name / Port forwards field
+            Constraint::Length(1), // Spacer
+            Constraint::Min(6),    // Info area
+            Constraint::Length(2), // Help
         ])
         .split(inner);
 
     // Header
-    let header = Paragraph::new("Configure VM Networking")
-        .style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD));
+    let header = Paragraph::new("Configure VM Networking").style(
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    );
     frame.render_widget(header, chunks[0]);
 
     // Adapter model
     let adapter_selected = ns.selected_field == 0;
-    let adapter_line = render_field_line("Adapter:", &ns.model, adapter_selected, "[Left/Right] cycle");
+    let adapter_line = render_field_line(
+        "Adapter:",
+        &ns.model,
+        adapter_selected,
+        "[Left/Right] cycle",
+    );
     frame.render_widget(Paragraph::new(adapter_line), chunks[2]);
 
     // Backend
@@ -77,11 +85,19 @@ pub fn render(app: &App, frame: &mut Frame) {
     let backend_display = match ns.backend.as_str() {
         "user" => "user/SLIRP (NAT)".to_string(),
         "passt" => "passt".to_string(),
-        "bridge" => format!("bridge ({})", ns.bridge_name.as_deref().unwrap_or("qemubr0")),
+        "bridge" => format!(
+            "bridge ({})",
+            ns.bridge_name.as_deref().unwrap_or("qemubr0")
+        ),
         "none" => "none".to_string(),
         other => other.to_string(),
     };
-    let backend_line = render_field_line("Backend:", &backend_display, backend_selected, "[Left/Right] cycle");
+    let backend_line = render_field_line(
+        "Backend:",
+        &backend_display,
+        backend_selected,
+        "[Left/Right] cycle",
+    );
     frame.render_widget(Paragraph::new(backend_line), chunks[3]);
 
     // MAC address (hidden when backend == "none")
@@ -110,7 +126,12 @@ pub fn render(app: &App, frame: &mut Frame) {
     let bridge_pf_selected = ns.selected_field == 3;
     if is_bridge {
         let bridge_display = ns.bridge_name.as_deref().unwrap_or("qemubr0");
-        let bridge_line = render_field_line("Bridge:", bridge_display, bridge_pf_selected, "[Left/Right] cycle");
+        let bridge_line = render_field_line(
+            "Bridge:",
+            bridge_display,
+            bridge_pf_selected,
+            "[Left/Right] cycle",
+        );
         frame.render_widget(Paragraph::new(bridge_line), chunks[5]);
     } else if show_pf {
         let pf_count = ns.port_forwards.len();
@@ -119,7 +140,11 @@ pub fn render(app: &App, frame: &mut Frame) {
         } else {
             format!("{} rule(s)", pf_count)
         };
-        let pf_hint = if bridge_pf_selected { "[Enter] edit" } else { "" };
+        let pf_hint = if bridge_pf_selected {
+            "[Enter] edit"
+        } else {
+            ""
+        };
         let pf_line = render_field_line("Forwards:", &pf_display, bridge_pf_selected, pf_hint);
         frame.render_widget(Paragraph::new(pf_line), chunks[5]);
     }
@@ -134,7 +159,11 @@ pub fn render(app: &App, frame: &mut Frame) {
             Some(p) => format!("found ({})", p.display()),
             None => "not found".to_string(),
         };
-        let helper_color = if caps.bridge_helper_path.is_some() { Color::Green } else { Color::Red };
+        let helper_color = if caps.bridge_helper_path.is_some() {
+            Color::Green
+        } else {
+            Color::Red
+        };
         lines.push(Line::from(vec![
             Span::styled("  bridge-helper: ", Style::default().fg(Color::Yellow)),
             Span::styled(helper_str, Style::default().fg(helper_color)),
@@ -146,7 +175,11 @@ pub fn render(app: &App, frame: &mut Frame) {
         } else {
             "not configured"
         };
-        let perm_color = if caps.bridge_helper_configured { Color::Green } else { Color::Red };
+        let perm_color = if caps.bridge_helper_configured {
+            Color::Green
+        } else {
+            Color::Red
+        };
         lines.push(Line::from(vec![
             Span::styled("  Permissions:   ", Style::default().fg(Color::Yellow)),
             Span::styled(perm_str, Style::default().fg(perm_color)),
@@ -158,25 +191,47 @@ pub fn render(app: &App, frame: &mut Frame) {
         } else {
             caps.system_bridges.join(", ")
         };
-        let bridges_color = if caps.system_bridges.is_empty() { Color::Red } else { Color::Green };
+        let bridges_color = if caps.system_bridges.is_empty() {
+            Color::Red
+        } else {
+            Color::Green
+        };
         lines.push(Line::from(vec![
             Span::styled("  Bridges:       ", Style::default().fg(Color::Yellow)),
             Span::styled(bridges_str, Style::default().fg(bridges_color)),
         ]));
 
         // Setup guidance if incomplete
-        if caps.bridge_helper_path.is_none() || !caps.bridge_helper_configured || caps.system_bridges.is_empty() {
+        if caps.bridge_helper_path.is_none()
+            || !caps.bridge_helper_configured
+            || caps.system_bridges.is_empty()
+        {
             lines.push(Line::from(""));
-            lines.push(Line::styled("  Setup needed:", Style::default().fg(Color::Yellow)));
+            lines.push(Line::styled(
+                "  Setup needed:",
+                Style::default().fg(Color::Yellow),
+            ));
             if caps.bridge_helper_path.is_none() {
-                lines.push(Line::styled("    Install: qemu-bridge-helper (part of QEMU)", Style::default().fg(Color::DarkGray)));
+                lines.push(Line::styled(
+                    "    Install: qemu-bridge-helper (part of QEMU)",
+                    Style::default().fg(Color::DarkGray),
+                ));
             }
             if !caps.bridge_helper_configured {
-                lines.push(Line::styled("    Run: sudo setcap cap_net_admin+ep /usr/lib/qemu/qemu-bridge-helper", Style::default().fg(Color::DarkGray)));
+                lines.push(Line::styled(
+                    "    Run: sudo setcap cap_net_admin+ep /usr/lib/qemu/qemu-bridge-helper",
+                    Style::default().fg(Color::DarkGray),
+                ));
             }
             if caps.system_bridges.is_empty() {
-                lines.push(Line::styled("    Create bridge: sudo ip link add qemubr0 type bridge", Style::default().fg(Color::DarkGray)));
-                lines.push(Line::styled("    Enable:        sudo ip link set qemubr0 up", Style::default().fg(Color::DarkGray)));
+                lines.push(Line::styled(
+                    "    Create bridge: sudo ip link add qemubr0 type bridge",
+                    Style::default().fg(Color::DarkGray),
+                ));
+                lines.push(Line::styled(
+                    "    Enable:        sudo ip link set qemubr0 up",
+                    Style::default().fg(Color::DarkGray),
+                ));
             }
         }
 
@@ -184,9 +239,15 @@ pub fn render(app: &App, frame: &mut Frame) {
         frame.render_widget(info, chunks[7]);
     } else if show_pf && !ns.port_forwards.is_empty() {
         let mut lines = Vec::new();
-        lines.push(Line::styled("  Current port forwarding rules:", Style::default().fg(Color::DarkGray)));
+        lines.push(Line::styled(
+            "  Current port forwarding rules:",
+            Style::default().fg(Color::DarkGray),
+        ));
         for pf in &ns.port_forwards {
-            lines.push(Line::from(format!("    {} {} -> {}", pf.protocol, pf.host_port, pf.guest_port)));
+            lines.push(Line::from(format!(
+                "    {} {} -> {}",
+                pf.protocol, pf.host_port, pf.guest_port
+            )));
         }
         let list = Paragraph::new(lines);
         frame.render_widget(list, chunks[7]);
@@ -200,17 +261,22 @@ pub fn render(app: &App, frame: &mut Frame) {
 }
 
 /// Render the port forward editor overlay
-fn render_port_forward_editor(_app: &App, ns: &NetworkSettingsState, frame: &mut Frame, area: Rect) {
+fn render_port_forward_editor(
+    _app: &App,
+    ns: &NetworkSettingsState,
+    frame: &mut Frame,
+    area: Rect,
+) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(1)
         .constraints([
-            Constraint::Length(1),   // Header
-            Constraint::Length(1),   // Spacer
-            Constraint::Min(8),      // Rules list
-            Constraint::Length(1),   // Spacer
-            Constraint::Length(1),   // Presets
-            Constraint::Length(2),   // Help
+            Constraint::Length(1), // Header
+            Constraint::Length(1), // Spacer
+            Constraint::Min(8),    // Rules list
+            Constraint::Length(1), // Spacer
+            Constraint::Length(1), // Presets
+            Constraint::Length(2), // Help
         ])
         .split(area);
 
@@ -220,8 +286,11 @@ fn render_port_forward_editor(_app: &App, ns: &NetworkSettingsState, frame: &mut
         return;
     }
 
-    let header = Paragraph::new("Port Forwarding Rules")
-        .style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD));
+    let header = Paragraph::new("Port Forwarding Rules").style(
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    );
     frame.render_widget(header, chunks[0]);
 
     // Rules list
@@ -235,12 +304,17 @@ fn render_port_forward_editor(_app: &App, ns: &NetworkSettingsState, frame: &mut
             let is_selected = i == ns.pf_selected;
             let prefix = if is_selected { "> " } else { "  " };
             let style = if is_selected {
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(Color::White)
             };
             lines.push(Line::styled(
-                format!("{}{}  {} -> {}", prefix, pf.protocol, pf.host_port, pf.guest_port),
+                format!(
+                    "{}{}  {} -> {}",
+                    prefix, pf.protocol, pf.host_port, pf.guest_port
+                ),
                 style,
             ));
         }
@@ -266,28 +340,37 @@ fn render_adding_pf(adding: &AddingPortForward, frame: &mut Frame, area: Rect) {
         .direction(Direction::Vertical)
         .margin(1)
         .constraints([
-            Constraint::Length(1),   // Header
-            Constraint::Length(1),   // Spacer
-            Constraint::Length(1),   // Protocol
-            Constraint::Length(1),   // Host port
-            Constraint::Length(1),   // Guest port
-            Constraint::Min(3),      // Spacer
-            Constraint::Length(2),   // Help
+            Constraint::Length(1), // Header
+            Constraint::Length(1), // Spacer
+            Constraint::Length(1), // Protocol
+            Constraint::Length(1), // Host port
+            Constraint::Length(1), // Guest port
+            Constraint::Min(3),    // Spacer
+            Constraint::Length(2), // Help
         ])
         .split(area);
 
-    let header = Paragraph::new("Add Port Forward Rule")
-        .style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD));
+    let header = Paragraph::new("Add Port Forward Rule").style(
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    );
     frame.render_widget(header, chunks[0]);
 
     // Protocol
     let proto_active = adding.step == AddPfStep::Protocol;
     let proto_style = if proto_active {
-        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(Color::White)
     };
-    let proto_hint = if proto_active { " [Left/Right] toggle" } else { "" };
+    let proto_hint = if proto_active {
+        " [Left/Right] toggle"
+    } else {
+        ""
+    };
     let proto_line = Line::from(vec![
         Span::styled("  Protocol: ", Style::default().fg(Color::Yellow)),
         Span::styled(format!("{}", adding.protocol), proto_style),
@@ -298,14 +381,20 @@ fn render_adding_pf(adding: &AddingPortForward, frame: &mut Frame, area: Rect) {
     // Host port
     let host_active = adding.step == AddPfStep::HostPort;
     let host_style = if host_active {
-        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(Color::White)
     };
     let host_line = Line::from(vec![
         Span::styled("  Host Port: ", Style::default().fg(Color::Yellow)),
         Span::styled(
-            if adding.host_port_input.is_empty() { "_" } else { &adding.host_port_input },
+            if adding.host_port_input.is_empty() {
+                "_"
+            } else {
+                &adding.host_port_input
+            },
             host_style,
         ),
     ]);
@@ -314,14 +403,20 @@ fn render_adding_pf(adding: &AddingPortForward, frame: &mut Frame, area: Rect) {
     // Guest port
     let guest_active = adding.step == AddPfStep::GuestPort;
     let guest_style = if guest_active {
-        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(Color::White)
     };
     let guest_line = Line::from(vec![
         Span::styled("  Guest Port: ", Style::default().fg(Color::Yellow)),
         Span::styled(
-            if adding.guest_port_input.is_empty() { "_" } else { &adding.guest_port_input },
+            if adding.guest_port_input.is_empty() {
+                "_"
+            } else {
+                &adding.guest_port_input
+            },
             guest_style,
         ),
     ]);
@@ -336,16 +431,32 @@ fn render_adding_pf(adding: &AddingPortForward, frame: &mut Frame, area: Rect) {
 fn render_field_line<'a>(label: &str, value: &str, selected: bool, hint: &str) -> Line<'a> {
     let prefix = if selected { "> " } else { "  " };
     let value_style = if selected {
-        Style::default().fg(Color::White).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(Color::White)
     };
 
     Line::from(vec![
-        Span::styled(prefix.to_string(), if selected { Style::default().fg(Color::Yellow) } else { Style::default() }),
+        Span::styled(
+            prefix.to_string(),
+            if selected {
+                Style::default().fg(Color::Yellow)
+            } else {
+                Style::default()
+            },
+        ),
         Span::styled(format!("{:12}", label), Style::default().fg(Color::Yellow)),
         Span::styled(format!("{:20}", value), value_style),
-        Span::styled(if selected { hint.to_string() } else { String::new() }, Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            if selected {
+                hint.to_string()
+            } else {
+                String::new()
+            },
+            Style::default().fg(Color::DarkGray),
+        ),
     ])
 }
 
@@ -462,7 +573,8 @@ pub fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> anyhow::Res
     }
 
     // Normal settings mode
-    let backend_options: Vec<String> = app.get_network_backend_options()
+    let backend_options: Vec<String> = app
+        .get_network_backend_options()
         .iter()
         .map(|(id, _)| id.to_string())
         .collect();
@@ -525,7 +637,11 @@ pub fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> anyhow::Res
             }
         }
         KeyCode::Left | KeyCode::Right => {
-            let delta = if key.code == KeyCode::Right { 1i32 } else { -1i32 };
+            let delta = if key.code == KeyCode::Right {
+                1i32
+            } else {
+                -1i32
+            };
             if let Some(ref mut ns) = app.network_settings_state {
                 match ns.selected_field {
                     0 => {
@@ -534,16 +650,20 @@ pub fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> anyhow::Res
                     }
                     1 => {
                         // Cycle backend
-                        let current_idx = backend_options.iter()
+                        let current_idx = backend_options
+                            .iter()
                             .position(|b| b == &ns.backend)
                             .unwrap_or(0);
                         let new_idx = (current_idx as i32 + delta)
-                            .rem_euclid(backend_options.len() as i32) as usize;
+                            .rem_euclid(backend_options.len() as i32)
+                            as usize;
                         ns.backend = backend_options[new_idx].clone();
 
                         // Set default bridge name
                         if ns.backend == "bridge" && ns.bridge_name.is_none() {
-                            ns.bridge_name = system_bridges.first().cloned()
+                            ns.bridge_name = system_bridges
+                                .first()
+                                .cloned()
                                 .or_else(|| Some("qemubr0".to_string()));
                         }
                     }
@@ -551,11 +671,13 @@ pub fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> anyhow::Res
                         // Cycle bridge name
                         if !system_bridges.is_empty() {
                             let current_bridge = ns.bridge_name.as_deref().unwrap_or("");
-                            let current_idx = system_bridges.iter()
+                            let current_idx = system_bridges
+                                .iter()
                                 .position(|b| b == current_bridge)
                                 .unwrap_or(0);
                             let new_idx = (current_idx as i32 + delta)
-                                .rem_euclid(system_bridges.len() as i32) as usize;
+                                .rem_euclid(system_bridges.len() as i32)
+                                as usize;
                             ns.bridge_name = Some(system_bridges[new_idx].clone());
                         }
                     }
@@ -594,39 +716,41 @@ pub fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> anyhow::Res
 fn handle_adding_pf(app: &mut App, key: crossterm::event::KeyEvent) -> anyhow::Result<()> {
     use crossterm::event::KeyCode;
 
-    let Some(ref mut ns) = app.network_settings_state else { return Ok(()) };
-    let Some(ref mut adding) = ns.adding_pf else { return Ok(()) };
+    let Some(ref mut ns) = app.network_settings_state else {
+        return Ok(());
+    };
+    let Some(ref mut adding) = ns.adding_pf else {
+        return Ok(());
+    };
 
     match key.code {
         KeyCode::Esc => {
             ns.adding_pf = None;
         }
-        KeyCode::Enter => {
-            match adding.step {
-                AddPfStep::Protocol => {
-                    adding.step = AddPfStep::HostPort;
-                }
-                AddPfStep::HostPort => {
-                    if adding.host_port_input.parse::<u16>().is_ok() {
-                        adding.step = AddPfStep::GuestPort;
-                    }
-                }
-                AddPfStep::GuestPort => {
-                    if let (Ok(host), Ok(guest)) = (
-                        adding.host_port_input.parse::<u16>(),
-                        adding.guest_port_input.parse::<u16>(),
-                    ) {
-                        let pf = PortForward {
-                            protocol: adding.protocol,
-                            host_port: host,
-                            guest_port: guest,
-                        };
-                        ns.port_forwards.push(pf);
-                        ns.adding_pf = None;
-                    }
+        KeyCode::Enter => match adding.step {
+            AddPfStep::Protocol => {
+                adding.step = AddPfStep::HostPort;
+            }
+            AddPfStep::HostPort => {
+                if adding.host_port_input.parse::<u16>().is_ok() {
+                    adding.step = AddPfStep::GuestPort;
                 }
             }
-        }
+            AddPfStep::GuestPort => {
+                if let (Ok(host), Ok(guest)) = (
+                    adding.host_port_input.parse::<u16>(),
+                    adding.guest_port_input.parse::<u16>(),
+                ) {
+                    let pf = PortForward {
+                        protocol: adding.protocol,
+                        host_port: host,
+                        guest_port: guest,
+                    };
+                    ns.port_forwards.push(pf);
+                    ns.adding_pf = None;
+                }
+            }
+        },
         KeyCode::Left | KeyCode::Right => {
             if adding.step == AddPfStep::Protocol {
                 adding.protocol = match adding.protocol {
@@ -635,20 +759,20 @@ fn handle_adding_pf(app: &mut App, key: crossterm::event::KeyEvent) -> anyhow::R
                 };
             }
         }
-        KeyCode::Char(c) if c.is_ascii_digit() => {
-            match adding.step {
-                AddPfStep::HostPort => adding.host_port_input.push(c),
-                AddPfStep::GuestPort => adding.guest_port_input.push(c),
-                _ => {}
+        KeyCode::Char(c) if c.is_ascii_digit() => match adding.step {
+            AddPfStep::HostPort => adding.host_port_input.push(c),
+            AddPfStep::GuestPort => adding.guest_port_input.push(c),
+            _ => {}
+        },
+        KeyCode::Backspace => match adding.step {
+            AddPfStep::HostPort => {
+                adding.host_port_input.pop();
             }
-        }
-        KeyCode::Backspace => {
-            match adding.step {
-                AddPfStep::HostPort => { adding.host_port_input.pop(); }
-                AddPfStep::GuestPort => { adding.guest_port_input.pop(); }
-                _ => {}
+            AddPfStep::GuestPort => {
+                adding.guest_port_input.pop();
             }
-        }
+            _ => {}
+        },
         _ => {}
     }
 
@@ -658,14 +782,25 @@ fn handle_adding_pf(app: &mut App, key: crossterm::event::KeyEvent) -> anyhow::R
 fn add_preset(app: &mut App, protocol: PortProtocol, host_port: u16, guest_port: u16) {
     if let Some(ref mut ns) = app.network_settings_state {
         // Don't add duplicate
-        if !ns.port_forwards.iter().any(|pf| pf.host_port == host_port && pf.guest_port == guest_port) {
-            ns.port_forwards.push(PortForward { protocol, host_port, guest_port });
+        if !ns
+            .port_forwards
+            .iter()
+            .any(|pf| pf.host_port == host_port && pf.guest_port == guest_port)
+        {
+            ns.port_forwards.push(PortForward {
+                protocol,
+                host_port,
+                guest_port,
+            });
         }
     }
 }
 
 fn cycle_option(current: &mut String, options: &[&str], delta: i32) {
-    let current_idx = options.iter().position(|&o| o == current.as_str()).unwrap_or(0);
+    let current_idx = options
+        .iter()
+        .position(|&o| o == current.as_str())
+        .unwrap_or(0);
     let new_idx = (current_idx as i32 + delta).rem_euclid(options.len() as i32) as usize;
     *current = options[new_idx].to_string();
 }

--- a/src/ui/screens/pci_passthrough.rs
+++ b/src/ui/screens/pci_passthrough.rs
@@ -31,7 +31,11 @@ pub fn render(app: &App, frame: &mut Frame) {
         // Single GPU mode - don't show GPU count (boot VGA is passed through differently)
         format!(" PCI Passthrough ({} selected) ", selected_count)
     } else if app.config.enable_multi_gpu_passthrough {
-        let gpu_count = app.pci_devices.iter().filter(|d| d.is_gpu() && !d.is_boot_vga).count();
+        let gpu_count = app
+            .pci_devices
+            .iter()
+            .filter(|d| d.is_gpu() && !d.is_boot_vga)
+            .count();
         format!(
             " PCI Passthrough ({} selected, {} GPU{} available) ",
             selected_count,
@@ -68,9 +72,9 @@ pub fn render(app: &App, frame: &mut Frame) {
     let h_chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
-            Constraint::Length(1),  // Left margin
-            Constraint::Min(1),     // Content
-            Constraint::Length(1),  // Right margin
+            Constraint::Length(1), // Left margin
+            Constraint::Min(1),    // Content
+            Constraint::Length(1), // Right margin
         ])
         .split(chunks[1]);
 
@@ -97,7 +101,10 @@ fn render_status_bar(app: &App, frame: &mut Frame, area: Rect) {
         vec![
             Span::styled(" Mode: ", Style::default().fg(Color::White)),
             Span::styled("Single GPU Passthrough", Style::default().fg(Color::Cyan)),
-            Span::styled("  (GPU selection managed via Single GPU Setup)", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "  (GPU selection managed via Single GPU Setup)",
+                Style::default().fg(Color::DarkGray),
+            ),
         ]
     } else if app.config.enable_multi_gpu_passthrough {
         // Multi-GPU passthrough mode - show full status
@@ -122,24 +129,36 @@ fn render_status_bar(app: &App, frame: &mut Frame, area: Rect) {
             spans.push(Span::raw("  |  "));
             spans.push(Span::styled(
                 "IOMMU",
-                Style::default().fg(if status.iommu_enabled { Color::Green } else { Color::Red }),
+                Style::default().fg(if status.iommu_enabled {
+                    Color::Green
+                } else {
+                    Color::Red
+                }),
             ));
             spans.push(Span::raw(" "));
             spans.push(Span::styled(
                 "VFIO",
-                Style::default().fg(if status.vfio_loaded { Color::Green } else { Color::Red }),
+                Style::default().fg(if status.vfio_loaded {
+                    Color::Green
+                } else {
+                    Color::Red
+                }),
             ));
         }
         spans
     } else {
         // GPU passthrough disabled - show simple message
-        vec![
-            Span::styled(" Select PCI devices to pass through to the VM", Style::default().fg(Color::DarkGray)),
-        ]
+        vec![Span::styled(
+            " Select PCI devices to pass through to the VM",
+            Style::default().fg(Color::DarkGray),
+        )]
     };
 
-    let status_para = Paragraph::new(Line::from(spans))
-        .block(Block::default().borders(Borders::BOTTOM).border_style(Style::default().fg(Color::DarkGray)));
+    let status_para = Paragraph::new(Line::from(spans)).block(
+        Block::default()
+            .borders(Borders::BOTTOM)
+            .border_style(Style::default().fg(Color::DarkGray)),
+    );
 
     frame.render_widget(status_para, area);
 }
@@ -147,9 +166,11 @@ fn render_status_bar(app: &App, frame: &mut Frame, area: Rect) {
 /// Render the device list
 fn render_device_list(app: &App, frame: &mut Frame, area: Rect) {
     if app.pci_devices.is_empty() {
-        let msg = Paragraph::new("No PCI devices found.\n\nEnsure you have permission to read /sys/bus/pci/devices.")
-            .style(Style::default().fg(Color::DarkGray))
-            .alignment(Alignment::Center);
+        let msg = Paragraph::new(
+            "No PCI devices found.\n\nEnsure you have permission to read /sys/bus/pci/devices.",
+        )
+        .style(Style::default().fg(Color::DarkGray))
+        .alignment(Alignment::Center);
         frame.render_widget(msg, area);
         return;
     }
@@ -230,7 +251,9 @@ fn render_device_list(app: &App, frame: &mut Frame, area: Rect) {
                 Span::styled(
                     format!("{} ", checkbox),
                     if is_current {
-                        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+                        Style::default()
+                            .fg(Color::Yellow)
+                            .add_modifier(Modifier::BOLD)
                     } else if selected {
                         Style::default().fg(Color::Green)
                     } else {
@@ -249,10 +272,7 @@ fn render_device_list(app: &App, frame: &mut Frame, area: Rect) {
                     format!("{:<12} ", driver_info),
                     Style::default().fg(driver_color),
                 ),
-                Span::styled(
-                    iommu_info,
-                    Style::default().fg(Color::DarkGray),
-                ),
+                Span::styled(iommu_info, Style::default().fg(Color::DarkGray)),
             ]);
 
             // Add boot VGA warning
@@ -260,7 +280,9 @@ fn render_device_list(app: &App, frame: &mut Frame, area: Rect) {
             if device.is_boot_vga {
                 lines.push(Line::styled(
                     "     (Boot VGA - cannot be passed through)",
-                    Style::default().fg(Color::Red).add_modifier(Modifier::ITALIC),
+                    Style::default()
+                        .fg(Color::Red)
+                        .add_modifier(Modifier::ITALIC),
                 ));
             }
 
@@ -309,16 +331,25 @@ pub fn render_prerequisites(app: &App, frame: &mut Frame) {
 
     lines.push(Line::styled(
         "GPU Passthrough Prerequisites",
-        Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD),
     ));
     lines.push(Line::raw(""));
 
     if let Some(status) = status {
         // IOMMU check
         let iommu_icon = if status.iommu_enabled { " OK " } else { "FAIL" };
-        let iommu_color = if status.iommu_enabled { Color::Green } else { Color::Red };
+        let iommu_color = if status.iommu_enabled {
+            Color::Green
+        } else {
+            Color::Red
+        };
         lines.push(Line::from(vec![
-            Span::styled(format!("[{}] ", iommu_icon), Style::default().fg(iommu_color)),
+            Span::styled(
+                format!("[{}] ", iommu_icon),
+                Style::default().fg(iommu_color),
+            ),
             Span::raw("IOMMU enabled in kernel"),
         ]));
         if !status.iommu_enabled {
@@ -330,7 +361,11 @@ pub fn render_prerequisites(app: &App, frame: &mut Frame) {
 
         // VFIO check
         let vfio_icon = if status.vfio_loaded { " OK " } else { "FAIL" };
-        let vfio_color = if status.vfio_loaded { Color::Green } else { Color::Red };
+        let vfio_color = if status.vfio_loaded {
+            Color::Green
+        } else {
+            Color::Red
+        };
         lines.push(Line::from(vec![
             Span::styled(format!("[{}] ", vfio_icon), Style::default().fg(vfio_color)),
             Span::raw("VFIO modules loaded"),
@@ -345,7 +380,11 @@ pub fn render_prerequisites(app: &App, frame: &mut Frame) {
         // GPU availability
         let gpu_available = !status.passthrough_gpus.is_empty();
         let gpu_icon = if gpu_available { " OK " } else { "FAIL" };
-        let gpu_color = if gpu_available { Color::Green } else { Color::Red };
+        let gpu_color = if gpu_available {
+            Color::Green
+        } else {
+            Color::Red
+        };
         lines.push(Line::from(vec![
             Span::styled(format!("[{}] ", gpu_icon), Style::default().fg(gpu_color)),
             Span::raw(format!(
@@ -356,7 +395,10 @@ pub fn render_prerequisites(app: &App, frame: &mut Frame) {
 
         if let Some(ref boot_vga) = status.boot_vga {
             lines.push(Line::styled(
-                format!("    Boot VGA: {} (cannot be passed through)", boot_vga.display_name()),
+                format!(
+                    "    Boot VGA: {} (cannot be passed through)",
+                    boot_vga.display_name()
+                ),
                 Style::default().fg(Color::DarkGray),
             ));
         }
@@ -376,9 +418,15 @@ pub fn render_prerequisites(app: &App, frame: &mut Frame) {
         // Warnings
         if !status.warnings.is_empty() {
             lines.push(Line::raw(""));
-            lines.push(Line::styled("Warnings:", Style::default().fg(Color::Yellow)));
+            lines.push(Line::styled(
+                "Warnings:",
+                Style::default().fg(Color::Yellow),
+            ));
             for warning in &status.warnings {
-                lines.push(Line::styled(format!("  - {}", warning), Style::default().fg(Color::Yellow)));
+                lines.push(Line::styled(
+                    format!("  - {}", warning),
+                    Style::default().fg(Color::Yellow),
+                ));
             }
         }
 
@@ -386,10 +434,16 @@ pub fn render_prerequisites(app: &App, frame: &mut Frame) {
         lines.push(Line::raw(""));
         lines.push(Line::styled(
             "VFIO Driver Binding:",
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ));
-        lines.push(Line::raw("  Devices are automatically bound to vfio-pci at launch"));
-        lines.push(Line::raw("  and restored to their original driver on VM exit."));
+        lines.push(Line::raw(
+            "  Devices are automatically bound to vfio-pci at launch",
+        ));
+        lines.push(Line::raw(
+            "  and restored to their original driver on VM exit.",
+        ));
         lines.push(Line::styled(
             "  Requires authentication via pkexec (polkit) or sudo.",
             Style::default().fg(Color::Yellow),
@@ -399,7 +453,9 @@ pub fn render_prerequisites(app: &App, frame: &mut Frame) {
         lines.push(Line::raw(""));
         lines.push(Line::styled(
             "For Looking Glass:",
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ));
         lines.push(Line::raw("  - Install looking-glass-client on host"));
         lines.push(Line::raw("  - Install Looking Glass Host in guest VM"));
@@ -417,8 +473,7 @@ pub fn render_prerequisites(app: &App, frame: &mut Frame) {
         Style::default().fg(Color::DarkGray),
     ));
 
-    let para = Paragraph::new(lines)
-        .wrap(Wrap { trim: false });
+    let para = Paragraph::new(lines).wrap(Wrap { trim: false });
     frame.render_widget(para, inner);
 }
 
@@ -484,7 +539,10 @@ pub fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> anyhow::Res
         }
         KeyCode::Char('j') | KeyCode::Down => {
             // Find current position in relevant devices
-            if let Some(current_pos) = relevant_indices.iter().position(|&i| i == app.selected_menu_item) {
+            if let Some(current_pos) = relevant_indices
+                .iter()
+                .position(|&i| i == app.selected_menu_item)
+            {
                 if current_pos < relevant_indices.len().saturating_sub(1) {
                     app.selected_menu_item = relevant_indices[current_pos + 1];
                 }
@@ -493,7 +551,10 @@ pub fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> anyhow::Res
             }
         }
         KeyCode::Char('k') | KeyCode::Up => {
-            if let Some(current_pos) = relevant_indices.iter().position(|&i| i == app.selected_menu_item) {
+            if let Some(current_pos) = relevant_indices
+                .iter()
+                .position(|&i| i == app.selected_menu_item)
+            {
                 if current_pos > 0 {
                     app.selected_menu_item = relevant_indices[current_pos - 1];
                 }
@@ -529,7 +590,8 @@ pub fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> anyhow::Res
                     if let Some(vm) = app.selected_vm() {
                         if crate::hardware::scripts_exist(&vm.path) {
                             // Try with in-memory config first, fall back to saved config
-                            let regen_result = if let Some(config) = app.single_gpu_config.as_ref() {
+                            let regen_result = if let Some(config) = app.single_gpu_config.as_ref()
+                            {
                                 crate::vm::single_gpu_scripts::regenerate_if_exists(vm, config)
                             } else {
                                 crate::vm::single_gpu_scripts::regenerate_from_saved_config(vm)
@@ -541,7 +603,10 @@ pub fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> anyhow::Res
                                 }
                                 Ok(false) => {} // Scripts don't exist, nothing to regenerate
                                 Err(e) => {
-                                    status_msg.push_str(&format!("; warning: failed to regenerate single-GPU scripts: {}", e));
+                                    status_msg.push_str(&format!(
+                                        "; warning: failed to regenerate single-GPU scripts: {}",
+                                        e
+                                    ));
                                 }
                             }
                         }
@@ -646,7 +711,7 @@ fn generate_pci_section(devices: &[&PciDevice]) -> String {
 
     // Generate the passthrough args
     let args = crate::hardware::generate_passthrough_args(
-        &devices.iter().map(|d| (*d).clone()).collect::<Vec<_>>()
+        &devices.iter().map(|d| (*d).clone()).collect::<Vec<_>>(),
     );
 
     section.push_str("PCI_PASSTHROUGH_ARGS=\"");
@@ -666,7 +731,8 @@ fn generate_pci_section(devices: &[&PciDevice]) -> String {
     section.push('\n');
 
     // Helper to run sysfs commands with privilege escalation
-    section.push_str(r#"# Run a command with elevated privileges if needed
+    section.push_str(
+        r#"# Run a command with elevated privileges if needed
 _pci_elevated() {
     if [[ $EUID -eq 0 ]]; then
         sh -c "$1"
@@ -680,10 +746,12 @@ _pci_elevated() {
         return 1
     fi
 }
-"#);
+"#,
+    );
 
     // VFIO bind function: unbinds devices from current driver, binds to vfio-pci
-    section.push_str(r#"bind_vfio() {
+    section.push_str(
+        r#"bind_vfio() {
     local bind_cmds=""
     for dev in "${PCI_DEVICES[@]}"; do
         local dev_path="/sys/bus/pci/devices/$dev"
@@ -711,10 +779,12 @@ _pci_elevated() {
     fi
     sleep 0.5
 }
-"#);
+"#,
+    );
 
     // VFIO restore function: rebinds devices to their original drivers after VM exit
-    section.push_str(r#"restore_pci() {
+    section.push_str(
+        r#"restore_pci() {
     local restore_cmds=""
     for dev in "${PCI_DEVICES[@]}"; do
         local dev_path="/sys/bus/pci/devices/$dev"
@@ -740,19 +810,22 @@ _pci_elevated() {
         fi
     fi
 }
-"#);
+"#,
+    );
 
     // Hook restore_pci into exit cleanup, then bind devices
     // The trap/cleanup setup must happen before bind_vfio so partially-bound
     // devices get restored if binding fails partway through
-    section.push_str(r#"if declare -f cleanup >/dev/null 2>&1; then
+    section.push_str(
+        r#"if declare -f cleanup >/dev/null 2>&1; then
     eval "$(declare -f cleanup | sed '1s/cleanup/_pci_pre_cleanup/')"
     cleanup() { restore_pci; _pci_pre_cleanup; }
 else
     trap 'restore_pci' EXIT
 fi
 bind_vfio || exit 1
-"#);
+"#,
+    );
 
     section.push_str(PCI_MARKER_END);
     section.push('\n');

--- a/src/ui/screens/settings.rs
+++ b/src/ui/screens/settings.rs
@@ -11,7 +11,10 @@ use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap};
 use crate::app::App;
 use crate::config::Config;
 use crate::fs;
-use crate::hardware::{check_multi_gpu_passthrough_status, check_single_gpu_support, MultiGpuPassthroughStatus, LookingGlassConfig, SingleGpuSupport};
+use crate::hardware::{
+    check_multi_gpu_passthrough_status, check_single_gpu_support, LookingGlassConfig,
+    MultiGpuPassthroughStatus, SingleGpuSupport,
+};
 use crate::vm::single_gpu_scripts::{run_system_setup, SystemSetupResult};
 
 /// GPU passthrough validation result
@@ -108,7 +111,9 @@ impl SettingsItem {
             SettingsItem::EnableMultiGpuPassthrough => String::new(), // Radio button, no value display
             SettingsItem::MultiGpuIvshmemSize => config.default_ivshmem_size_mb.to_string(),
             SettingsItem::MultiGpuShowWarnings => bool_to_yes_no(config.show_gpu_warnings),
-            SettingsItem::MultiGpuAutoLaunchLookingGlass => bool_to_yes_no(config.looking_glass_auto_launch),
+            SettingsItem::MultiGpuAutoLaunchLookingGlass => {
+                bool_to_yes_no(config.looking_glass_auto_launch)
+            }
             SettingsItem::EnableSingleGpuPassthrough => String::new(), // Radio button, no value display
             SettingsItem::SingleGpuRunSetup => String::new(), // Action button, no value display
             SettingsItem::SingleGpuAutoTty => bool_to_yes_no(config.single_gpu_auto_tty),
@@ -177,7 +182,9 @@ impl SettingsItem {
             SettingsItem::GpuPassthroughDisabled => "gpu_passthrough_disabled",
             SettingsItem::EnableMultiGpuPassthrough => "enable_multi_gpu_passthrough",
             SettingsItem::MultiGpuIvshmemSize => "multi_gpu_ivshmem_size",
-            SettingsItem::MultiGpuShowWarnings | SettingsItem::SingleGpuShowWarnings => "show_gpu_warnings",
+            SettingsItem::MultiGpuShowWarnings | SettingsItem::SingleGpuShowWarnings => {
+                "show_gpu_warnings"
+            }
             SettingsItem::MultiGpuAutoLaunchLookingGlass => "auto_launch_looking_glass",
             SettingsItem::EnableSingleGpuPassthrough => "enable_single_gpu_passthrough",
             SettingsItem::SingleGpuRunSetup => "single_gpu_run_setup",
@@ -227,7 +234,10 @@ fn build_visible_items(config: &Config) -> Vec<VisibleItem> {
     if config.enable_multi_gpu_passthrough {
         items.push(make_visible(SettingsItem::MultiGpuIvshmemSize, 2));
         items.push(make_visible(SettingsItem::MultiGpuShowWarnings, 2));
-        items.push(make_visible(SettingsItem::MultiGpuAutoLaunchLookingGlass, 2));
+        items.push(make_visible(
+            SettingsItem::MultiGpuAutoLaunchLookingGlass,
+            2,
+        ));
     }
 
     // Single-GPU option (radio button)
@@ -294,8 +304,8 @@ pub fn render(app: &App, frame: &mut Frame) {
     // Right panel: help text + optional validation
     let right_constraints = if show_validation {
         vec![
-            Constraint::Min(6),      // Help text
-            Constraint::Length(10),  // Validation panel
+            Constraint::Min(6),     // Help text
+            Constraint::Length(10), // Validation panel
         ]
     } else {
         vec![Constraint::Min(6)]
@@ -348,7 +358,9 @@ fn render_settings_list(app: &App, frame: &mut Frame, area: Rect, visible_items:
                     SettingsItem::GpuPassthroughDisabled => {
                         !app.config.enable_multi_gpu_passthrough && !app.config.single_gpu_enabled
                     }
-                    SettingsItem::EnableMultiGpuPassthrough => app.config.enable_multi_gpu_passthrough,
+                    SettingsItem::EnableMultiGpuPassthrough => {
+                        app.config.enable_multi_gpu_passthrough
+                    }
                     SettingsItem::EnableSingleGpuPassthrough => app.config.single_gpu_enabled,
                     _ => false,
                 };
@@ -372,9 +384,13 @@ fn render_settings_list(app: &App, frame: &mut Frame, area: Rect, visible_items:
             };
 
             let style = if vi.is_header {
-                Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD)
             } else if is_selected {
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
             } else if vi.is_action {
                 // Action buttons are styled like links
                 Style::default().fg(Color::Cyan)
@@ -389,19 +405,29 @@ fn render_settings_list(app: &App, frame: &mut Frame, area: Rect, visible_items:
         })
         .collect();
 
-    let list = List::new(items)
-        .block(Block::default().borders(Borders::NONE));
+    let list = List::new(items).block(Block::default().borders(Borders::NONE));
     frame.render_widget(list, area);
 }
 
 /// Render the contextual help panel
-fn render_help_panel(frame: &mut Frame, area: Rect, current_item: Option<&SettingsItem>, help_store: &crate::metadata::SettingsHelpStore) {
-    let help_key = current_item.map(|item| item.help_key()).unwrap_or("default");
+fn render_help_panel(
+    frame: &mut Frame,
+    area: Rect,
+    current_item: Option<&SettingsItem>,
+    help_store: &crate::metadata::SettingsHelpStore,
+) {
+    let help_key = current_item
+        .map(|item| item.help_key())
+        .unwrap_or("default");
     let (title, description) = help_store.get_or_default(help_key);
 
     let help_block = Block::default()
         .title(format!(" {} ", title))
-        .title_style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+        .title_style(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Cyan));
 
@@ -414,7 +440,11 @@ fn render_help_panel(frame: &mut Frame, area: Rect, current_item: Option<&Settin
 }
 
 /// Render the GPU validation panel
-fn render_validation_panel(frame: &mut Frame, area: Rect, validation: &Option<GpuValidationResult>) {
+fn render_validation_panel(
+    frame: &mut Frame,
+    area: Rect,
+    validation: &Option<GpuValidationResult>,
+) {
     let Some(result) = validation else {
         return;
     };
@@ -432,11 +462,19 @@ fn render_validation_panel(frame: &mut Frame, area: Rect, validation: &Option<Gp
 /// Render multi-GPU validation status
 fn render_multi_gpu_validation(frame: &mut Frame, area: Rect, status: &MultiGpuPassthroughStatus) {
     let is_ready = status.is_ready();
-    let border_color = if is_ready { Color::Green } else { Color::Yellow };
+    let border_color = if is_ready {
+        Color::Green
+    } else {
+        Color::Yellow
+    };
 
     let block = Block::default()
         .title(" Multi-GPU Status ")
-        .title_style(Style::default().fg(border_color).add_modifier(Modifier::BOLD))
+        .title_style(
+            Style::default()
+                .fg(border_color)
+                .add_modifier(Modifier::BOLD),
+        )
         .borders(Borders::ALL)
         .border_style(Style::default().fg(border_color));
 
@@ -447,7 +485,11 @@ fn render_multi_gpu_validation(frame: &mut Frame, area: Rect, status: &MultiGpuP
 
     // IOMMU check
     let iommu_icon = if status.iommu_enabled { "[+]" } else { "[-]" };
-    let iommu_style = if status.iommu_enabled { Color::Green } else { Color::Red };
+    let iommu_style = if status.iommu_enabled {
+        Color::Green
+    } else {
+        Color::Red
+    };
     lines.push(Line::from(vec![
         Span::styled(iommu_icon, Style::default().fg(iommu_style)),
         Span::raw(" IOMMU enabled"),
@@ -455,7 +497,11 @@ fn render_multi_gpu_validation(frame: &mut Frame, area: Rect, status: &MultiGpuP
 
     // VFIO check
     let vfio_icon = if status.vfio_loaded { "[+]" } else { "[-]" };
-    let vfio_style = if status.vfio_loaded { Color::Green } else { Color::Red };
+    let vfio_style = if status.vfio_loaded {
+        Color::Green
+    } else {
+        Color::Red
+    };
     lines.push(Line::from(vec![
         Span::styled(vfio_icon, Style::default().fg(vfio_style)),
         Span::raw(" VFIO modules loaded"),
@@ -490,12 +536,16 @@ fn render_multi_gpu_validation(frame: &mut Frame, area: Rect, status: &MultiGpuP
     if is_ready {
         lines.push(Line::from(Span::styled(
             "Ready for passthrough",
-            Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
         )));
     } else {
         lines.push(Line::from(Span::styled(
             "Not ready",
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
         )));
         // Show first error as hint
         if let Some(error) = status.errors.first() {
@@ -521,11 +571,19 @@ fn render_multi_gpu_validation(frame: &mut Frame, area: Rect, status: &MultiGpuP
 /// Render single-GPU validation status
 fn render_single_gpu_validation(frame: &mut Frame, area: Rect, support: &SingleGpuSupport) {
     let is_ready = support.is_supported();
-    let border_color = if is_ready { Color::Green } else { Color::Yellow };
+    let border_color = if is_ready {
+        Color::Green
+    } else {
+        Color::Yellow
+    };
 
     let block = Block::default()
         .title(" Single GPU Status ")
-        .title_style(Style::default().fg(border_color).add_modifier(Modifier::BOLD))
+        .title_style(
+            Style::default()
+                .fg(border_color)
+                .add_modifier(Modifier::BOLD),
+        )
         .borders(Borders::ALL)
         .border_style(Style::default().fg(border_color));
 
@@ -536,7 +594,11 @@ fn render_single_gpu_validation(frame: &mut Frame, area: Rect, support: &SingleG
 
     // IOMMU check
     let iommu_icon = if support.iommu_enabled { "[+]" } else { "[-]" };
-    let iommu_style = if support.iommu_enabled { Color::Green } else { Color::Red };
+    let iommu_style = if support.iommu_enabled {
+        Color::Green
+    } else {
+        Color::Red
+    };
     lines.push(Line::from(vec![
         Span::styled(iommu_icon, Style::default().fg(iommu_style)),
         Span::raw(" IOMMU enabled"),
@@ -544,7 +606,11 @@ fn render_single_gpu_validation(frame: &mut Frame, area: Rect, support: &SingleG
 
     // VFIO check
     let vfio_icon = if support.vfio_available { "[+]" } else { "[-]" };
-    let vfio_style = if support.vfio_available { Color::Green } else { Color::Red };
+    let vfio_style = if support.vfio_available {
+        Color::Green
+    } else {
+        Color::Red
+    };
     lines.push(Line::from(vec![
         Span::styled(vfio_icon, Style::default().fg(vfio_style)),
         Span::raw(" VFIO available"),
@@ -561,7 +627,11 @@ fn render_single_gpu_validation(frame: &mut Frame, area: Rect, support: &SingleG
 
     // Single GPU confirmation (informational - yellow if multiple GPUs detected)
     let single_icon = if support.has_single_gpu { "[+]" } else { "[!]" };
-    let single_style = if support.has_single_gpu { Color::Green } else { Color::Yellow };
+    let single_style = if support.has_single_gpu {
+        Color::Green
+    } else {
+        Color::Yellow
+    };
     let single_text = if support.has_single_gpu {
         " Single GPU confirmed"
     } else {
@@ -588,12 +658,16 @@ fn render_single_gpu_validation(frame: &mut Frame, area: Rect, support: &SingleG
     if is_ready {
         lines.push(Line::from(Span::styled(
             "Ready for passthrough",
-            Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
         )));
     } else {
         lines.push(Line::from(Span::styled(
             "Not ready",
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
         )));
     }
 
@@ -613,10 +687,19 @@ fn render_status_bar(app: &App, frame: &mut Frame, area: Rect, visible_items: &[
 
     // Get help text for current item
     let current_item = visible_items.get(app.settings_selected).map(|vi| &vi.item);
-    let is_header = visible_items.get(app.settings_selected).map(|vi| vi.is_header).unwrap_or(false);
-    let is_radio = visible_items.get(app.settings_selected).map(|vi| vi.is_radio).unwrap_or(false);
+    let is_header = visible_items
+        .get(app.settings_selected)
+        .map(|vi| vi.is_header)
+        .unwrap_or(false);
+    let is_radio = visible_items
+        .get(app.settings_selected)
+        .map(|vi| vi.is_radio)
+        .unwrap_or(false);
 
-    let is_action = visible_items.get(app.settings_selected).map(|vi| vi.is_action).unwrap_or(false);
+    let is_action = visible_items
+        .get(app.settings_selected)
+        .map(|vi| vi.is_action)
+        .unwrap_or(false);
 
     let key_hints = if app.settings_editing {
         "[Enter] Save  [Esc] Cancel"
@@ -753,18 +836,17 @@ fn toggle_radio(app: &mut App, item: SettingsItem) -> anyhow::Result<()> {
             app.config.enable_multi_gpu_passthrough = true;
             app.config.single_gpu_enabled = false;
             // Run validation
-            app.settings_gpu_validation = Some(
-                GpuValidationResult::MultiGpu(check_multi_gpu_passthrough_status())
-            );
+            app.settings_gpu_validation = Some(GpuValidationResult::MultiGpu(
+                check_multi_gpu_passthrough_status(),
+            ));
         }
         SettingsItem::EnableSingleGpuPassthrough => {
             // Enable single-GPU, disable multi-GPU
             app.config.single_gpu_enabled = true;
             app.config.enable_multi_gpu_passthrough = false;
             // Run validation
-            app.settings_gpu_validation = Some(
-                GpuValidationResult::SingleGpu(check_single_gpu_support())
-            );
+            app.settings_gpu_validation =
+                Some(GpuValidationResult::SingleGpu(check_single_gpu_support()));
         }
         _ => {}
     }
@@ -864,7 +946,10 @@ fn apply_edit(app: &mut App, item: SettingsItem) -> anyhow::Result<()> {
                 };
 
                 if !path.is_dir() {
-                    app.set_status(format!("Path does not exist or is not a directory: {}", path.display()));
+                    app.set_status(format!(
+                        "Path does not exist or is not a directory: {}",
+                        path.display()
+                    ));
                     return Ok(());
                 }
 

--- a/src/ui/screens/shared_folders.rs
+++ b/src/ui/screens/shared_folders.rs
@@ -42,7 +42,7 @@ pub fn render(app: &App, frame: &mut Frame) {
         .direction(Direction::Horizontal)
         .constraints([
             Constraint::Length(2), // Left margin
-            Constraint::Min(1),   // Content
+            Constraint::Min(1),    // Content
             Constraint::Length(2), // Right margin
         ])
         .split(inner);
@@ -51,11 +51,11 @@ pub fn render(app: &App, frame: &mut Frame) {
     let v_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1), // Top padding
+            Constraint::Length(1),                       // Top padding
             Constraint::Length(folder_list_height(app)), // Folder list
-            Constraint::Length(1), // Separator
-            Constraint::Min(4),   // Mount instructions
-            Constraint::Length(2), // Help text
+            Constraint::Length(1),                       // Separator
+            Constraint::Min(4),                          // Mount instructions
+            Constraint::Length(2),                       // Help text
         ])
         .split(h_chunks[1]);
 

--- a/src/ui/screens/single_gpu_setup.rs
+++ b/src/ui/screens/single_gpu_setup.rs
@@ -30,10 +30,7 @@ pub enum SetupField {
 
 impl SetupField {
     fn all() -> &'static [SetupField] {
-        &[
-            SetupField::GenerateScripts,
-            SetupField::DeleteScripts,
-        ]
+        &[SetupField::GenerateScripts, SetupField::DeleteScripts]
     }
 }
 
@@ -62,12 +59,12 @@ pub fn render(app: &App, frame: &mut Frame) {
         .direction(Direction::Vertical)
         .margin(1)
         .constraints([
-            Constraint::Length(3),  // System support status
-            Constraint::Length(6),  // GPU info
-            Constraint::Length(1),  // Separator
-            Constraint::Length(6),  // Scripts info
-            Constraint::Min(1),     // Spacer
-            Constraint::Length(2),  // Help
+            Constraint::Length(3), // System support status
+            Constraint::Length(6), // GPU info
+            Constraint::Length(1), // Separator
+            Constraint::Length(6), // Scripts info
+            Constraint::Min(1),    // Spacer
+            Constraint::Length(2), // Help
         ])
         .split(inner);
 
@@ -104,18 +101,31 @@ fn render_system_support(_app: &App, frame: &mut Frame, area: Rect) {
 
     lines.push(Line::from(vec![
         Span::styled("Status: ", Style::default().fg(Color::White)),
-        Span::styled(status_text, Style::default().fg(status_color).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            status_text,
+            Style::default()
+                .fg(status_color)
+                .add_modifier(Modifier::BOLD),
+        ),
     ]));
 
     // Details
     let mut details = Vec::new();
     details.push(format!(
         "IOMMU: {}",
-        if support.iommu_enabled { "Enabled" } else { "Disabled" }
+        if support.iommu_enabled {
+            "Enabled"
+        } else {
+            "Disabled"
+        }
     ));
     details.push(format!(
         "VFIO: {}",
-        if support.vfio_available { "Available" } else { "Not Available" }
+        if support.vfio_available {
+            "Available"
+        } else {
+            "Not Available"
+        }
     ));
 
     lines.push(Line::styled(
@@ -233,11 +243,11 @@ fn render_scripts_info(app: &App, frame: &mut Frame, area: Rect) {
         .unwrap_or_else(|| "~/vm-space/<vm>/".to_string());
 
     let mut lines = vec![
+        Line::styled("Scripts location:", Style::default().fg(Color::White)),
         Line::styled(
-            "Scripts location:",
-            Style::default().fg(Color::White),
+            format!("  {}", vm_path),
+            Style::default().fg(Color::DarkGray),
         ),
-        Line::styled(format!("  {}", vm_path), Style::default().fg(Color::DarkGray)),
     ];
 
     if scripts_present {
@@ -285,11 +295,9 @@ fn render_scripts_info(app: &App, frame: &mut Frame, area: Rect) {
 
 /// Render help text
 fn render_help(_app: &App, frame: &mut Frame, area: Rect) {
-    let help = Paragraph::new(
-        "[g] Generate Scripts  [d] Delete Scripts  [Esc] Back",
-    )
-    .style(Style::default().fg(Color::DarkGray))
-    .alignment(Alignment::Center);
+    let help = Paragraph::new("[g] Generate Scripts  [d] Delete Scripts  [Esc] Back")
+        .style(Style::default().fg(Color::DarkGray))
+        .alignment(Alignment::Center);
     frame.render_widget(help, area);
 }
 
@@ -443,7 +451,11 @@ fn generate_scripts(app: &mut App) -> anyhow::Result<()> {
                     app.set_status(format!(
                         "Generated: {}, {} in {}",
                         scripts.start_script.file_name().unwrap().to_string_lossy(),
-                        scripts.restore_script.file_name().unwrap().to_string_lossy(),
+                        scripts
+                            .restore_script
+                            .file_name()
+                            .unwrap()
+                            .to_string_lossy(),
                         dir.display()
                     ));
                     // Show instructions dialog
@@ -501,7 +513,10 @@ pub fn init_single_gpu_config(app: &mut App) {
     }
 
     // Find the boot VGA device
-    let boot_vga = app.pci_devices.iter().find(|d| d.can_single_gpu_passthrough());
+    let boot_vga = app
+        .pci_devices
+        .iter()
+        .find(|d| d.can_single_gpu_passthrough());
 
     if let Some(gpu) = boot_vga {
         let config = SingleGpuConfig::new(gpu.clone(), &app.pci_devices);

--- a/src/ui/screens/tests/create_wizard.rs
+++ b/src/ui/screens/tests/create_wizard.rs
@@ -8,10 +8,10 @@ fn test_parse_size_with_suffix_memory() {
 
     // GB to MB conversion
     assert_eq!(parse_size_with_suffix("8GB", "MB"), Some(8192));
-    assert_eq!(parse_size_with_suffix("8gb", "MB"), Some(8192));  // case insensitive
+    assert_eq!(parse_size_with_suffix("8gb", "MB"), Some(8192)); // case insensitive
     assert_eq!(parse_size_with_suffix("32GB", "MB"), Some(32768));
-    assert_eq!(parse_size_with_suffix("96GB", "MB"), Some(98304));  // exceeds old 64GB limit
-    assert_eq!(parse_size_with_suffix("1024GB", "MB"), Some(1048576));  // 1TB
+    assert_eq!(parse_size_with_suffix("96GB", "MB"), Some(98304)); // exceeds old 64GB limit
+    assert_eq!(parse_size_with_suffix("1024GB", "MB"), Some(1048576)); // 1TB
 
     // MB to MB (no conversion)
     assert_eq!(parse_size_with_suffix("8192MB", "MB"), Some(8192));
@@ -57,10 +57,11 @@ fn test_parse_size_with_suffix_invalid() {
 // ---------------------------------------------------------------------------
 
 fn cfg_with(network: &str, backend: &str) -> WizardQemuConfig {
-    let mut c = WizardQemuConfig::default();
-    c.network_model = network.to_string();
-    c.network_backend = backend.to_string();
-    c
+    WizardQemuConfig {
+        network_model: network.to_string(),
+        network_backend: backend.to_string(),
+        ..Default::default()
+    }
 }
 
 #[test]

--- a/src/ui/widgets/ascii_display.rs
+++ b/src/ui/widgets/ascii_display.rs
@@ -45,9 +45,12 @@ impl<'a> AsciiInfoWidget<'a> {
 
         // Name and details
         if let Some(info) = self.os_info {
-            lines.push(Line::from(vec![
-                Span::styled(&info.name, Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
-            ]));
+            lines.push(Line::from(vec![Span::styled(
+                &info.name,
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            )]));
             lines.push(Line::from(vec![
                 Span::styled(&info.publisher, Style::default().fg(Color::Gray)),
                 Span::raw(" | "),
@@ -69,7 +72,9 @@ impl<'a> AsciiInfoWidget<'a> {
             if !info.blurb.long.is_empty() {
                 lines.push(Line::from(Span::styled(
                     "About",
-                    Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
                 )));
                 for line in info.blurb.long.lines() {
                     lines.push(Line::from(line.to_string()));
@@ -81,7 +86,9 @@ impl<'a> AsciiInfoWidget<'a> {
             if !info.fun_facts.is_empty() {
                 lines.push(Line::from(Span::styled(
                     "Fun Facts",
-                    Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
                 )));
                 for fact in &info.fun_facts {
                     lines.push(Line::from(format!("• {}", fact)));
@@ -93,7 +100,9 @@ impl<'a> AsciiInfoWidget<'a> {
                 lines.push(Line::from(""));
                 lines.push(Line::from(Span::styled(
                     "Notes",
-                    Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
                 )));
                 for line in notes.lines() {
                     lines.push(Line::from(line.to_string()));
@@ -103,7 +112,9 @@ impl<'a> AsciiInfoWidget<'a> {
             // Just show the VM name
             lines.push(Line::from(Span::styled(
                 self.vm_name,
-                Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
             )));
 
             // User notes (even without OS info)
@@ -111,7 +122,9 @@ impl<'a> AsciiInfoWidget<'a> {
                 lines.push(Line::from(""));
                 lines.push(Line::from(Span::styled(
                     "Notes",
-                    Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
                 )));
                 for line in notes.lines() {
                     lines.push(Line::from(line.to_string()));
@@ -168,7 +181,9 @@ impl<'a> DetailedInfoWidget<'a> {
             if !info.blurb.long.is_empty() {
                 text.push(Line::from(Span::styled(
                     "About",
-                    Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
                 )));
                 for line in info.blurb.long.lines() {
                     text.push(Line::from(line.to_string()));
@@ -180,15 +195,16 @@ impl<'a> DetailedInfoWidget<'a> {
             if !info.fun_facts.is_empty() {
                 text.push(Line::from(Span::styled(
                     "Fun Facts",
-                    Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
                 )));
                 for fact in &info.fun_facts {
                     text.push(Line::from(format!("• {}", fact)));
                 }
             }
 
-            let para = Paragraph::new(text)
-                .wrap(Wrap { trim: true });
+            let para = Paragraph::new(text).wrap(Wrap { trim: true });
             para.render(inner, buf);
         } else {
             let text = Paragraph::new("No detailed information available for this VM.")

--- a/src/ui/widgets/vm_list.rs
+++ b/src/ui/widgets/vm_list.rs
@@ -112,19 +112,32 @@ impl<'a> VmListWidget<'a> {
         let title = format!(" VMs ({}) ", self.filtered_indices.len());
 
         // Build hierarchical structure
-        let vm_hierarchy = build_vm_hierarchy(self.vms, self.filtered_indices, self.hierarchy, self.metadata);
+        let vm_hierarchy = build_vm_hierarchy(
+            self.vms,
+            self.filtered_indices,
+            self.hierarchy,
+            self.metadata,
+        );
 
         // Available width for list items: area minus borders minus highlight symbol ("→ ")
         let inner_width = area.width.saturating_sub(2 + 3) as usize;
 
         // Render as tree with proper indices
-        let (items, index_map) = render_hierarchy_items(&vm_hierarchy, self.hierarchy, self.metadata, self.running_vms, self.stopping_vms, inner_width);
+        let (items, index_map) = render_hierarchy_items(
+            &vm_hierarchy,
+            self.hierarchy,
+            self.metadata,
+            self.running_vms,
+            self.stopping_vms,
+            inner_width,
+        );
 
         // Get the filtered_idx for the currently selected visual position
         let selected_filtered_idx = self.visual_order.get(self.selected).copied();
 
         // Find the selected item's position in the rendered list
-        let selected_pos = index_map.iter()
+        let selected_pos = index_map
+            .iter()
             .position(|&idx| idx == selected_filtered_idx)
             .unwrap_or(0);
 
@@ -195,8 +208,14 @@ fn build_vm_hierarchy<'a>(
                     // Use os_profile for metadata lookup if available
                     let id_a = a.vm.os_profile.as_deref().unwrap_or(&a.vm.id);
                     let id_b = b.vm.os_profile.as_deref().unwrap_or(&b.vm.id);
-                    let date_a = metadata.get(id_a).map(|i| i.release_date.as_str()).unwrap_or("");
-                    let date_b = metadata.get(id_b).map(|i| i.release_date.as_str()).unwrap_or("");
+                    let date_a = metadata
+                        .get(id_a)
+                        .map(|i| i.release_date.as_str())
+                        .unwrap_or("");
+                    let date_b = metadata
+                        .get(id_b)
+                        .map(|i| i.release_date.as_str())
+                        .unwrap_or("");
 
                     match (date_a.is_empty(), date_b.is_empty()) {
                         (true, true) => {
@@ -265,14 +284,17 @@ fn render_hierarchy_items<'a>(
                 Span::raw(format!("{} ", family.icon)),
                 Span::styled(
                     &family.name,
-                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
                 ),
             ])));
             index_map.push(None); // Headers are not selectable
 
             // Get subcategories for this family in order
             let family_subcats: Vec<_> = hierarchy.subcategories_for_family(&family.id);
-            let subcat_count = family_subcats.iter()
+            let subcat_count = family_subcats
+                .iter()
                 .filter(|s| subcats.contains_key(&s.id))
                 .count();
             let mut subcat_rendered = 0;
@@ -284,12 +306,10 @@ fn render_hierarchy_items<'a>(
                     let subcat_branch = if is_last_subcat { "└─" } else { "├─" };
 
                     // Subcategory header
-                    items.push(ListItem::new(Line::from(vec![
-                        Span::styled(
-                            format!("  {} {}", subcat_branch, subcat.name),
-                            Style::default().fg(Color::Magenta),
-                        ),
-                    ])));
+                    items.push(ListItem::new(Line::from(vec![Span::styled(
+                        format!("  {} {}", subcat_branch, subcat.name),
+                        Style::default().fg(Color::Magenta),
+                    )])));
                     index_map.push(None); // Headers are not selectable
 
                     let vm_count = vm_entries.len();
@@ -311,7 +331,11 @@ fn render_hierarchy_items<'a>(
 
                         if is_stopping || is_running {
                             let padding = inner_width.saturating_sub(used_width + 2);
-                            let color = if is_stopping { Color::Yellow } else { Color::Green };
+                            let color = if is_stopping {
+                                Color::Yellow
+                            } else {
+                                Color::Green
+                            };
                             items.push(ListItem::new(Line::from(vec![
                                 Span::styled(prefix, Style::default().fg(Color::DarkGray)),
                                 Span::styled(display_name, Style::default().fg(Color::White)),

--- a/src/vm/create.rs
+++ b/src/vm/create.rs
@@ -11,7 +11,9 @@ use std::path::{Path, PathBuf};
 /// This handles special characters that could cause command injection.
 fn shell_escape(s: &str) -> String {
     // If the string contains only safe characters, return as-is
-    if s.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_' || c == '.' || c == '/') {
+    if s.chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_' || c == '.' || c == '/')
+    {
         return s.to_string();
     }
 
@@ -21,9 +23,9 @@ fn shell_escape(s: &str) -> String {
     format!("'{}'", escaped)
 }
 
-use crate::wizard_types::{CreateWizardState, DiskAction, WizardQemuConfig};
 use crate::commands::qemu_img;
 use crate::vm::qemu_config::{PortForward, PortProtocol};
+use crate::wizard_types::{CreateWizardState, DiskAction, WizardQemuConfig};
 
 /// Install media type for QEMU command generation
 pub enum InstallMedia<'a> {
@@ -84,7 +86,9 @@ fn generate_serial() -> String {
     let mut serial = String::with_capacity(12);
 
     for _ in 0..12 {
-        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
         let idx = ((state >> 33) as usize) % chars.len();
         serial.push(chars[idx]);
     }
@@ -237,12 +241,13 @@ pub fn create_vm(library_path: &Path, state: &CreateWizardState) -> Result<Creat
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_else(|| "rom.bin".to_string());
         let dest = vm_dir.join(&rom_filename);
-        fs::copy(rom_path, &dest)
-            .with_context(|| format!(
+        fs::copy(rom_path, &dest).with_context(|| {
+            format!(
                 "Failed to copy ROM file from {} to {}",
                 rom_path.display(),
                 dest.display()
-            ))?;
+            )
+        })?;
         qemu_config.bios_path = Some(PathBuf::from(&rom_filename));
     }
 
@@ -279,28 +284,31 @@ fn handle_existing_disk(
 
     match action {
         DiskAction::Copy => {
-            fs::copy(source, &dest)
-                .with_context(|| format!(
+            fs::copy(source, &dest).with_context(|| {
+                format!(
                     "Failed to copy disk from {} to {}",
                     source.display(),
                     dest.display()
-                ))?;
+                )
+            })?;
         }
         DiskAction::Move => {
             // Try rename first (works if on same filesystem)
             if fs::rename(source, &dest).is_err() {
                 // Rename failed (likely different filesystem), fall back to copy+delete
-                fs::copy(source, &dest)
-                    .with_context(|| format!(
+                fs::copy(source, &dest).with_context(|| {
+                    format!(
                         "Failed to copy disk from {} to {}",
                         source.display(),
                         dest.display()
-                    ))?;
-                fs::remove_file(source)
-                    .with_context(|| format!(
+                    )
+                })?;
+                fs::remove_file(source).with_context(|| {
+                    format!(
                         "Failed to remove original disk after copying: {}",
                         source.display()
-                    ))?;
+                    )
+                })?;
             }
         }
     }
@@ -319,7 +327,10 @@ pub fn write_vm_metadata(
 
     let mut content = String::new();
     content.push_str("# VM Curator metadata\n\n");
-    content.push_str(&format!("display_name = \"{}\"\n", display_name.replace('"', "\\\"")));
+    content.push_str(&format!(
+        "display_name = \"{}\"\n",
+        display_name.replace('"', "\\\"")
+    ));
 
     if let Some(profile) = os_profile {
         content.push_str(&format!("os_profile = \"{}\"\n", profile));
@@ -330,7 +341,10 @@ pub fn write_vm_metadata(
             // Multi-line: use TOML literal string
             content.push_str(&format!("notes = '''\n{}'''\n", notes_text));
         } else {
-            content.push_str(&format!("notes = \"{}\"\n", notes_text.replace('"', "\\\"")));
+            content.push_str(&format!(
+                "notes = \"{}\"\n",
+                notes_text.replace('"', "\\\"")
+            ));
         }
     }
 
@@ -380,7 +394,7 @@ fn is_intel_macos(os_profile: Option<&str>, emulator: &str) -> bool {
     if !emulator.contains("x86_64") {
         return false;
     }
-    os_profile.map_or(false, |p| p.starts_with("macos-") || p.starts_with("mac-osx-"))
+    os_profile.is_some_and(|p| p.starts_with("macos-") || p.starts_with("mac-osx-"))
 }
 
 /// Check if an OS profile is a modern macOS that requires OpenCore
@@ -406,7 +420,8 @@ fn generate_smbios_options() -> String {
     // Consumer-style SMBIOS that doesn't trigger corporate machine detection
     // Type 1: System Information
     // Type 2: Baseboard Information
-    format!(r#"# SMBIOS configuration (unique per VM to avoid Windows corporate detection)
+    format!(
+        r#"# SMBIOS configuration (unique per VM to avoid Windows corporate detection)
 SMBIOS_OPTS=(
     -smbios "type=1,manufacturer=QEMU,product=Standard PC,version=1.0,serial={system_serial},uuid={uuid}"
     -smbios "type=2,manufacturer=QEMU,product=Standard PC,version=1.0,serial={board_serial}"
@@ -469,7 +484,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-"#.to_string()
+"#
+    .to_string()
 }
 
 /// Generate OVMF variables setup for UEFI
@@ -479,11 +495,11 @@ fn generate_ovmf_vars_setup(needs_secboot: bool) -> String {
         find_ovmf_secboot_vars_template()
             .unwrap_or_else(|| "/usr/share/OVMF/OVMF_VARS.fd".to_string())
     } else {
-        find_ovmf_vars_template()
-            .unwrap_or_else(|| "/usr/share/OVMF/OVMF_VARS.fd".to_string())
+        find_ovmf_vars_template().unwrap_or_else(|| "/usr/share/OVMF/OVMF_VARS.fd".to_string())
     };
 
-    format!(r#"# UEFI variables (writable copy per VM)
+    format!(
+        r#"# UEFI variables (writable copy per VM)
 OVMF_VARS_TEMPLATE="{template}"
 OVMF_VARS="$VM_DIR/OVMF_VARS.fd"
 
@@ -498,7 +514,9 @@ if [[ ! -f "$OVMF_VARS" ]]; then
     fi
 fi
 
-"#, template = ovmf_vars_template)
+"#,
+        template = ovmf_vars_template
+    )
 }
 
 /// Find OVMF_VARS template path
@@ -574,14 +592,20 @@ pub fn generate_launch_script_with_os(
     if is_recovery_image {
         // Recovery image (DMG) variable
         if let Some(path) = iso_path {
-            script.push_str(&format!("RECOVERY_IMG={}\n", shell_escape(&path.display().to_string())));
+            script.push_str(&format!(
+                "RECOVERY_IMG={}\n",
+                shell_escape(&path.display().to_string())
+            ));
         } else {
             script.push_str("RECOVERY_IMG=\"\"\n");
         }
     } else {
         // ISO variable
         if let Some(iso) = iso_path {
-            script.push_str(&format!("ISO={}\n", shell_escape(&iso.display().to_string())));
+            script.push_str(&format!(
+                "ISO={}\n",
+                shell_escape(&iso.display().to_string())
+            ));
         } else {
             script.push_str("ISO=\"\"\n");
         }
@@ -589,7 +613,10 @@ pub fn generate_launch_script_with_os(
 
     // Floppy image variable
     if let Some(floppy) = floppy_path {
-        script.push_str(&format!("FLOPPY={}\n", shell_escape(&floppy.display().to_string())));
+        script.push_str(&format!(
+            "FLOPPY={}\n",
+            shell_escape(&floppy.display().to_string())
+        ));
     }
 
     // BIOS/ROM file variable
@@ -605,7 +632,8 @@ pub fn generate_launch_script_with_os(
 
     // macOS OpenCore bootloader verification
     if is_intel_macos_vm && needs_uefi && config.bios_path.is_some() {
-        script.push_str(r#"# Verify OpenCore bootloader exists
+        script.push_str(
+            r#"# Verify OpenCore bootloader exists
 if [[ ! -f "$ROM" ]]; then
     echo "Error: OpenCore bootloader not found at $ROM"
     echo "Download from: https://github.com/kholia/OSX-KVM"
@@ -613,7 +641,8 @@ if [[ ! -f "$ROM" ]]; then
     exit 1
 fi
 
-"#);
+"#,
+        );
     }
 
     // Windows-specific: SMBIOS options
@@ -644,13 +673,35 @@ fi
     script.push_str("}\n\n");
 
     // Build QEMU commands with OS-awareness
-    let floppy_ref = if floppy_path.is_some() { Some("\"$FLOPPY\"") } else { None };
-    let base_cmd = build_qemu_command_with_os(config, disk_filename, &InstallMedia::None, os_profile, floppy_ref);
+    let floppy_ref = if floppy_path.is_some() {
+        Some("\"$FLOPPY\"")
+    } else {
+        None
+    };
+    let base_cmd = build_qemu_command_with_os(
+        config,
+        disk_filename,
+        &InstallMedia::None,
+        os_profile,
+        floppy_ref,
+    );
 
     let install_cmd = if is_recovery_image {
-        build_qemu_command_with_os(config, disk_filename, &InstallMedia::RecoveryImage(None), os_profile, floppy_ref)
+        build_qemu_command_with_os(
+            config,
+            disk_filename,
+            &InstallMedia::RecoveryImage(None),
+            os_profile,
+            floppy_ref,
+        )
     } else {
-        build_qemu_command_with_os(config, disk_filename, &InstallMedia::Iso(None), os_profile, floppy_ref)
+        build_qemu_command_with_os(
+            config,
+            disk_filename,
+            &InstallMedia::Iso(None),
+            os_profile,
+            floppy_ref,
+        )
     };
 
     // Main script logic
@@ -658,16 +709,22 @@ fi
     script.push_str("    --install)\n");
 
     if is_recovery_image {
-        script.push_str("        if [[ -z \"$RECOVERY_IMG\" ]] || [[ ! -f \"$RECOVERY_IMG\" ]]; then\n");
+        script.push_str(
+            "        if [[ -z \"$RECOVERY_IMG\" ]] || [[ ! -f \"$RECOVERY_IMG\" ]]; then\n",
+        );
         script.push_str("            echo \"Error: Recovery image not found at $RECOVERY_IMG\"\n");
-        script.push_str("            echo \"Please edit this script to set the path or use --recovery\"\n");
+        script.push_str(
+            "            echo \"Please edit this script to set the path or use --recovery\"\n",
+        );
         script.push_str("            exit 1\n");
         script.push_str("        fi\n");
         script.push_str("        echo \"Booting from recovery image...\"\n");
     } else {
         script.push_str("        if [[ -z \"$ISO\" ]] || [[ ! -f \"$ISO\" ]]; then\n");
         script.push_str("            echo \"Error: Installation ISO not found at $ISO\"\n");
-        script.push_str("            echo \"Please edit this script to set the ISO path or use --cdrom\"\n");
+        script.push_str(
+            "            echo \"Please edit this script to set the ISO path or use --cdrom\"\n",
+        );
         script.push_str("            exit 1\n");
         script.push_str("        fi\n");
         script.push_str("        echo \"Booting from installation ISO...\"\n");
@@ -693,7 +750,13 @@ fi
         script.push_str("        start_tpm\n");
     }
 
-    let cdrom_cmd = build_qemu_command_with_os(config, disk_filename, &InstallMedia::Iso(Some("\"$2\"")), os_profile, floppy_ref);
+    let cdrom_cmd = build_qemu_command_with_os(
+        config,
+        disk_filename,
+        &InstallMedia::Iso(Some("\"$2\"")),
+        os_profile,
+        floppy_ref,
+    );
     script.push_str(&format!("        {}\n", cdrom_cmd));
     script.push_str("        ;;\n");
 
@@ -709,7 +772,13 @@ fi
         script.push_str("        start_tpm\n");
     }
 
-    let recovery_cmd = build_qemu_command_with_os(config, disk_filename, &InstallMedia::RecoveryImage(Some("\"$2\"")), os_profile, floppy_ref);
+    let recovery_cmd = build_qemu_command_with_os(
+        config,
+        disk_filename,
+        &InstallMedia::RecoveryImage(Some("\"$2\"")),
+        os_profile,
+        floppy_ref,
+    );
     script.push_str(&format!("        {}\n", recovery_cmd));
     script.push_str("        ;;\n");
 
@@ -725,7 +794,13 @@ fi
         script.push_str("        start_tpm\n");
     }
 
-    let floppy_cmd = build_qemu_command_with_os(config, disk_filename, &InstallMedia::None, os_profile, Some("\"$2\""));
+    let floppy_cmd = build_qemu_command_with_os(
+        config,
+        disk_filename,
+        &InstallMedia::None,
+        os_profile,
+        Some("\"$2\""),
+    );
     script.push_str(&format!("        {}\n", floppy_cmd));
     script.push_str("        ;;\n");
 
@@ -827,8 +902,7 @@ fn build_qemu_command_with_os(
                 .or_else(find_ovmf_code_path)
                 .unwrap_or_else(|| "/usr/share/OVMF/OVMF_CODE.fd".to_string())
         } else {
-            find_ovmf_code_path()
-                .unwrap_or_else(|| "/usr/share/OVMF/OVMF_CODE.fd".to_string())
+            find_ovmf_code_path().unwrap_or_else(|| "/usr/share/OVMF/OVMF_CODE.fd".to_string())
         };
         // OVMF_CODE is read-only
         args.push(format!(
@@ -869,7 +943,11 @@ fn build_qemu_command_with_os(
                     args.push("-device ide-hd,drive=oc,bus=sata.0".to_string());
                 }
                 // Main disk (sata.1 with OpenCore, sata.0 without)
-                let disk_bus = if config.bios_path.is_some() { "sata.1" } else { "sata.0" };
+                let disk_bus = if config.bios_path.is_some() {
+                    "sata.1"
+                } else {
+                    "sata.0"
+                };
                 args.push("-drive file=\"$DISK\",format=qcow2,if=none,id=maindisk".to_string());
                 args.push(format!("-device ide-hd,drive=maindisk,bus={}", disk_bus));
             } else {
@@ -893,18 +971,31 @@ fn build_qemu_command_with_os(
             let iso_ref = custom_path.unwrap_or("\"$ISO\"");
             match machine_name {
                 "q800" => {
-                    args.push(format!("-drive file={},format=raw,if=none,id=cd0,media=cdrom", iso_ref));
+                    args.push(format!(
+                        "-drive file={},format=raw,if=none,id=cd0,media=cdrom",
+                        iso_ref
+                    ));
                     args.push("-device scsi-cd,drive=cd0".to_string());
                 }
                 "mac99" => {
-                    args.push(format!("-drive file={},format=raw,if=none,id=cd0,media=cdrom", iso_ref));
+                    args.push(format!(
+                        "-drive file={},format=raw,if=none,id=cd0,media=cdrom",
+                        iso_ref
+                    ));
                     args.push("-device ide-cd,drive=cd0,bus=ide.1".to_string());
                 }
                 _ => {
                     if is_intel_macos_vm && needs_uefi {
                         // macOS UEFI: attach ISO on AHCI bus
-                        let iso_bus = if config.bios_path.is_some() { "sata.3" } else { "sata.2" };
-                        args.push(format!("-drive file={},format=raw,if=none,id=cd0,media=cdrom", iso_ref));
+                        let iso_bus = if config.bios_path.is_some() {
+                            "sata.3"
+                        } else {
+                            "sata.2"
+                        };
+                        args.push(format!(
+                            "-drive file={},format=raw,if=none,id=cd0,media=cdrom",
+                            iso_ref
+                        ));
                         args.push(format!("-device ide-cd,drive=cd0,bus={}", iso_bus));
                         // No -boot d for macOS (OpenCore handles boot)
                     } else {
@@ -926,12 +1017,25 @@ fn build_qemu_command_with_os(
             if is_intel_macos_vm && needs_uefi {
                 // macOS UEFI: attach recovery image on AHCI bus
                 // No format= specified — QEMU auto-detects DMG vs qcow2
-                let recovery_bus = if config.bios_path.is_some() { "sata.2" } else { "sata.1" };
-                args.push(format!("-drive file={},snapshot=on,if=none,id=recovery", dmg_ref));
-                args.push(format!("-device ide-hd,drive=recovery,bus={}", recovery_bus));
+                let recovery_bus = if config.bios_path.is_some() {
+                    "sata.2"
+                } else {
+                    "sata.1"
+                };
+                args.push(format!(
+                    "-drive file={},snapshot=on,if=none,id=recovery",
+                    dmg_ref
+                ));
+                args.push(format!(
+                    "-device ide-hd,drive=recovery,bus={}",
+                    recovery_bus
+                ));
             } else {
                 // Non-macOS UEFI: use legacy IDE attachment
-                args.push(format!("-drive file={},snapshot=on,format=dmg,if=ide,index=2,media=disk", dmg_ref));
+                args.push(format!(
+                    "-drive file={},snapshot=on,format=dmg,if=ide,index=2,media=disk",
+                    dmg_ref
+                ));
             }
             // No -boot d: OpenCore/UEFI bootloader handles boot selection
         }
@@ -1030,7 +1134,10 @@ fn build_qemu_command_with_os(
                         PortProtocol::Tcp => "tcp",
                         PortProtocol::Udp => "udp",
                     };
-                    netdev.push_str(&format!(",hostfwd={}::{}-:{}", proto, pf.host_port, pf.guest_port));
+                    netdev.push_str(&format!(
+                        ",hostfwd={}::{}-:{}",
+                        proto, pf.host_port, pf.guest_port
+                    ));
                 }
                 args.push(netdev);
                 args.push(format!("-device {},netdev=net0{}", net_device, mac_suffix));
@@ -1105,7 +1212,8 @@ pub fn update_network_in_script(
         .with_context(|| format!("Failed to read launch script: {}", script_path.display()))?;
 
     // Build new network arguments
-    let new_net_args = generate_network_args(model, backend, bridge_name, port_forwards, mac_address);
+    let new_net_args =
+        generate_network_args(model, backend, bridge_name, port_forwards, mac_address);
 
     // Remove existing network lines and replace
     let mut new_lines = Vec::new();
@@ -1215,12 +1323,21 @@ fn generate_network_args(
         }
         "passt" => {
             args.push("        -netdev passt,id=net0 \\".to_string());
-            args.push(format!("        -device {},netdev=net0{} \\", net_device, mac_suffix));
+            args.push(format!(
+                "        -device {},netdev=net0{} \\",
+                net_device, mac_suffix
+            ));
         }
         "bridge" => {
             let br = bridge_name.unwrap_or("qemubr0");
-            args.push(format!("        -netdev bridge,id=net0,br={} \\", shell_escape(br)));
-            args.push(format!("        -device {},netdev=net0{} \\", net_device, mac_suffix));
+            args.push(format!(
+                "        -netdev bridge,id=net0,br={} \\",
+                shell_escape(br)
+            ));
+            args.push(format!(
+                "        -device {},netdev=net0{} \\",
+                net_device, mac_suffix
+            ));
         }
         _ => {
             // User/SLIRP
@@ -1230,11 +1347,17 @@ fn generate_network_args(
                     PortProtocol::Tcp => "tcp",
                     PortProtocol::Udp => "udp",
                 };
-                netdev.push_str(&format!(",hostfwd={}::{}-:{}", proto, pf.host_port, pf.guest_port));
+                netdev.push_str(&format!(
+                    ",hostfwd={}::{}-:{}",
+                    proto, pf.host_port, pf.guest_port
+                ));
             }
             netdev.push_str(" \\");
             args.push(netdev);
-            args.push(format!("        -device {},netdev=net0{} \\", net_device, mac_suffix));
+            args.push(format!(
+                "        -device {},netdev=net0{} \\",
+                net_device, mac_suffix
+            ));
         }
     }
 

--- a/src/vm/discovery.rs
+++ b/src/vm/discovery.rs
@@ -122,7 +122,8 @@ fn format_windows_name(id: &str) -> String {
 
 /// Format IBM OS/2 names
 fn format_os2_name(id: &str) -> String {
-    let version = id.strip_prefix("os2-")
+    let version = id
+        .strip_prefix("os2-")
         .or_else(|| id.strip_prefix("os-2-"))
         .unwrap_or(id);
 
@@ -178,10 +179,24 @@ fn format_linux_name(id: &str) -> String {
 
     // Rolling release distributions - check both full name and base (for duplicates)
     match distro {
-        "arch" | "artix" | "cachyos" | "endeavouros" | "endeavour" | "garuda" |
-        "gentoo" | "manjaro" | "nixos" | "void" | "bazzite" |
-        "opensuse-tumbleweed" | "suse-tumbleweed" | "tumbleweed" |
-        "pclinuxos" | "solus" | "puppy" | "clear" => {
+        "arch"
+        | "artix"
+        | "cachyos"
+        | "endeavouros"
+        | "endeavour"
+        | "garuda"
+        | "gentoo"
+        | "manjaro"
+        | "nixos"
+        | "void"
+        | "bazzite"
+        | "opensuse-tumbleweed"
+        | "suse-tumbleweed"
+        | "tumbleweed"
+        | "pclinuxos"
+        | "solus"
+        | "puppy"
+        | "clear" => {
             return format_rolling_distro(distro);
         }
         _ => {}
@@ -190,10 +205,24 @@ fn format_linux_name(id: &str) -> String {
     // Check if base_distro (without numeric suffix) matches a rolling distro
     if distro != base_distro {
         match base_distro {
-            "arch" | "artix" | "cachyos" | "endeavouros" | "endeavour" | "garuda" |
-            "gentoo" | "manjaro" | "nixos" | "void" | "bazzite" |
-            "opensuse-tumbleweed" | "suse-tumbleweed" | "tumbleweed" |
-            "pclinuxos" | "solus" | "puppy" | "clear" => {
+            "arch"
+            | "artix"
+            | "cachyos"
+            | "endeavouros"
+            | "endeavour"
+            | "garuda"
+            | "gentoo"
+            | "manjaro"
+            | "nixos"
+            | "void"
+            | "bazzite"
+            | "opensuse-tumbleweed"
+            | "suse-tumbleweed"
+            | "tumbleweed"
+            | "pclinuxos"
+            | "solus"
+            | "puppy"
+            | "clear" => {
                 return format_rolling_distro(base_distro);
             }
             _ => {}
@@ -217,7 +246,11 @@ fn format_linux_name(id: &str) -> String {
         return format_versioned_distro(distro, "centos", "CentOS Linux");
     }
     if distro.starts_with("rhel") || distro.starts_with("redhat") {
-        let prefix = if distro.starts_with("rhel") { "rhel" } else { "redhat" };
+        let prefix = if distro.starts_with("rhel") {
+            "rhel"
+        } else {
+            "redhat"
+        };
         return format_versioned_distro(distro, prefix, "Red Hat® Enterprise Linux");
     }
     if distro.starts_with("suse") || distro.starts_with("opensuse") {
@@ -230,7 +263,11 @@ fn format_linux_name(id: &str) -> String {
             return "openSUSE Tumbleweed (rolling)".to_string();
         }
         // Versioned SuSE = old SuSE Linux (e.g., SuSE Linux 7)
-        let prefix = if distro.starts_with("opensuse") { "opensuse" } else { "suse" };
+        let prefix = if distro.starts_with("opensuse") {
+            "opensuse"
+        } else {
+            "suse"
+        };
         return format_versioned_distro(distro, prefix, "SuSE Linux");
     }
     if distro.starts_with("slackware") {
@@ -243,7 +280,11 @@ fn format_linux_name(id: &str) -> String {
         return format_versioned_distro(distro, "elementary", "elementary OS");
     }
     if distro.starts_with("pop") || distro.starts_with("popos") {
-        let prefix = if distro.starts_with("popos") { "popos" } else { "pop" };
+        let prefix = if distro.starts_with("popos") {
+            "popos"
+        } else {
+            "pop"
+        };
         return format_versioned_distro(distro, prefix, "Pop!_OS");
     }
     if distro.starts_with("zorin") {
@@ -259,7 +300,11 @@ fn format_linux_name(id: &str) -> String {
         return format_versioned_distro(distro, "rocky", "Rocky Linux");
     }
     if distro.starts_with("alma") || distro.starts_with("almalinux") {
-        let prefix = if distro.starts_with("almalinux") { "almalinux" } else { "alma" };
+        let prefix = if distro.starts_with("almalinux") {
+            "almalinux"
+        } else {
+            "alma"
+        };
         return format_versioned_distro(distro, prefix, "AlmaLinux");
     }
     if distro.starts_with("mageia") {
@@ -281,7 +326,9 @@ fn format_rolling_distro(distro: &str) -> String {
         "gentoo" => "Gentoo Linux (rolling)".to_string(),
         "manjaro" => "Manjaro Linux (rolling)".to_string(),
         "nixos" => "NixOS (rolling)".to_string(),
-        "opensuse-tumbleweed" | "suse-tumbleweed" | "tumbleweed" => "openSUSE Tumbleweed (rolling)".to_string(),
+        "opensuse-tumbleweed" | "suse-tumbleweed" | "tumbleweed" => {
+            "openSUSE Tumbleweed (rolling)".to_string()
+        }
         "void" => "Void Linux (rolling)".to_string(),
         "bazzite" => "Bazzite (rolling)".to_string(),
         "pclinuxos" => "PCLinuxOS".to_string(),
@@ -305,7 +352,8 @@ fn strip_numeric_suffix_local(s: &str) -> Option<&str> {
 
 /// Format a versioned distribution name
 fn format_versioned_distro(full: &str, prefix: &str, display_name: &str) -> String {
-    let version = full.strip_prefix(prefix)
+    let version = full
+        .strip_prefix(prefix)
         .map(|s| s.trim_start_matches('-').trim_start_matches('_'))
         .filter(|s| !s.is_empty());
 
@@ -320,21 +368,33 @@ fn format_bsd_name(id: &str) -> String {
     let id_lower = id.to_lowercase();
 
     if id_lower.contains("freebsd") {
-        let version = id_lower.replace("freebsd", "").replace('-', " ").trim().to_string();
+        let version = id_lower
+            .replace("freebsd", "")
+            .replace('-', " ")
+            .trim()
+            .to_string();
         if version.is_empty() {
             return "FreeBSD".to_string();
         }
         return format!("FreeBSD {}", version);
     }
     if id_lower.contains("openbsd") {
-        let version = id_lower.replace("openbsd", "").replace('-', " ").trim().to_string();
+        let version = id_lower
+            .replace("openbsd", "")
+            .replace('-', " ")
+            .trim()
+            .to_string();
         if version.is_empty() {
             return "OpenBSD".to_string();
         }
         return format!("OpenBSD {}", version);
     }
     if id_lower.contains("netbsd") {
-        let version = id_lower.replace("netbsd", "").replace('-', " ").trim().to_string();
+        let version = id_lower
+            .replace("netbsd", "")
+            .replace('-', " ")
+            .trim()
+            .to_string();
         if version.is_empty() {
             return "NetBSD".to_string();
         }
@@ -446,7 +506,7 @@ fn extract_toml_string_value(line: &str) -> Option<String> {
 
     let value = parts[1].trim();
     if value.starts_with('"') && value.ends_with('"') && value.len() >= 2 {
-        Some(value[1..value.len()-1].replace("\\\"", "\""))
+        Some(value[1..value.len() - 1].replace("\\\"", "\""))
     } else {
         None
     }
@@ -483,13 +543,16 @@ pub fn discover_vms(library_path: &Path) -> Result<Vec<DiscoveredVm>> {
             .to_string();
 
         // Try to parse the launch script
-        let script_content = std::fs::read_to_string(&launch_script)
-            .unwrap_or_default();
+        let script_content = std::fs::read_to_string(&launch_script).unwrap_or_default();
 
         let config = match parse_launch_script(&launch_script, &script_content) {
             Ok(cfg) => cfg,
             Err(e) => {
-                warn!("Failed to parse launch script {}: {}", launch_script.display(), e);
+                warn!(
+                    "Failed to parse launch script {}: {}",
+                    launch_script.display(),
+                    e
+                );
                 QemuConfig {
                     raw_script: script_content,
                     ..QemuConfig::default()
@@ -526,7 +589,10 @@ pub fn group_vms_by_category(vms: &[DiscoveredVm]) -> Vec<(&'static str, Vec<&Di
 
     for vm in vms {
         let id_lower = vm.id.to_lowercase();
-        if id_lower.starts_with("windows") || id_lower.contains("dos") || id_lower.starts_with("my-first") {
+        if id_lower.starts_with("windows")
+            || id_lower.contains("dos")
+            || id_lower.starts_with("my-first")
+        {
             windows.push(vm);
         } else if id_lower.starts_with("mac") {
             mac.push(vm);

--- a/src/vm/import.rs
+++ b/src/vm/import.rs
@@ -84,16 +84,14 @@ fn parse_libvirt_xml_str(xml: &str, config_path: &Path) -> Result<ImportableVm> 
                     "name" if parent == "domain" => {
                         capture_text_for = Some("name".to_string());
                     }
-                    "memory" | "currentMemory" => {
-                        if memory_kb == 0 {
-                            memory_unit = "KiB".to_string();
-                            for attr in e.attributes().flatten() {
-                                if attr.key.as_ref() == b"unit" {
-                                    memory_unit = attr_value(&attr);
-                                }
+                    "memory" | "currentMemory" if memory_kb == 0 => {
+                        memory_unit = "KiB".to_string();
+                        for attr in e.attributes().flatten() {
+                            if attr.key.as_ref() == b"unit" {
+                                memory_unit = attr_value(&attr);
                             }
-                            capture_text_for = Some("memory".to_string());
                         }
+                        capture_text_for = Some("memory".to_string());
                     }
                     "vcpu" => {
                         capture_text_for = Some("vcpu".to_string());
@@ -663,7 +661,9 @@ fn get_quickemu_search_dirs() -> Vec<PathBuf> {
 #[allow(dead_code)]
 pub fn discover_vms_in_dir(dir: &Path) -> Vec<ImportableVm> {
     let mut vms = Vec::new();
-    let Ok(entries) = fs::read_dir(dir) else { return vms };
+    let Ok(entries) = fs::read_dir(dir) else {
+        return vms;
+    };
     for entry in entries.flatten() {
         let path = entry.path();
         if path.is_file() {
@@ -699,8 +699,7 @@ pub fn execute_import(
     disk_action: ImportDiskAction,
 ) -> Result<PathBuf> {
     use crate::vm::create::{
-        create_vm_directory, generate_launch_script_with_os, write_launch_script,
-        write_vm_metadata,
+        create_vm_directory, generate_launch_script_with_os, write_launch_script, write_vm_metadata,
     };
 
     let vm_dir = create_vm_directory(library_path, folder_name)?;
@@ -722,9 +721,8 @@ pub fn execute_import(
 
         match disk_action {
             ImportDiskAction::Symlink => {
-                let abs_source = fs::canonicalize(disk_path).with_context(|| {
-                    format!("Failed to resolve path: {}", disk_path.display())
-                })?;
+                let abs_source = fs::canonicalize(disk_path)
+                    .with_context(|| format!("Failed to resolve path: {}", disk_path.display()))?;
                 unix_fs::symlink(&abs_source, &dest).with_context(|| {
                     format!(
                         "Failed to create symlink from {} to {}",

--- a/src/vm/import.rs
+++ b/src/vm/import.rs
@@ -23,246 +23,368 @@ pub fn parse_libvirt_xml(path: &Path) -> Result<ImportableVm> {
     parse_libvirt_xml_str(&content, path)
 }
 
-/// Parse libvirt XML from a string (for testing)
+/// Return the value of the first attribute named `key` on an element, if present.
+fn find_attr(e: &quick_xml::events::BytesStart, key: &[u8]) -> Option<String> {
+    e.attributes()
+        .flatten()
+        .find(|attr| attr.key.as_ref() == key)
+        .map(|attr| attr_value(&attr))
+}
+
+/// Mutable accumulator for streaming a libvirt domain XML document.
+///
+/// quick-xml is event-based, so parsed values build up across Start/Empty/Text/End
+/// events. Each `handle_*` method applies a single event, and
+/// [`LibvirtParse::into_importable_vm`] validates and maps the accumulated values
+/// onto a [`WizardQemuConfig`]. Splitting the work this way keeps each step small
+/// and independently readable instead of one large event loop.
+#[derive(Default)]
+struct LibvirtParse {
+    domain_type: String,
+    vm_name: String,
+    memory_kb: u64,
+    memory_unit: String,
+    vcpu: u32,
+    emulator_path: String,
+    arch: String,
+    machine_type: String,
+    has_uefi: bool,
+    has_tpm: bool,
+    disk_paths: Vec<PathBuf>,
+    disk_buses: Vec<String>,
+    graphics_type: String,
+    vga_model: String,
+    import_notes: Vec<String>,
+
+    // Network (first interface found)
+    net_type: String,
+    net_model: String,
+    net_bridge: String,
+
+    // Streaming bookkeeping
+    element_stack: Vec<String>,
+    /// Element name whose text content should be captured on the next Text event.
+    capture_text_for: Option<String>,
+
+    // Current <disk> being parsed
+    in_disk: bool,
+    current_disk_bus: String,
+    current_disk_source: PathBuf,
+
+    // Current <interface> being parsed
+    in_interface: bool,
+    current_net_type: String,
+    current_net_model: String,
+    current_net_bridge: String,
+}
+
+impl LibvirtParse {
+    /// Name of the currently-open enclosing element.
+    fn parent(&self) -> String {
+        self.element_stack
+            .last()
+            .map(|s| s.to_string())
+            .unwrap_or_default()
+    }
+
+    /// Read `arch`/`machine` from an `<os><type ...>` element.
+    fn apply_os_type(&mut self, e: &quick_xml::events::BytesStart) {
+        if let Some(v) = find_attr(e, b"arch") {
+            self.arch = v;
+        }
+        if let Some(v) = find_attr(e, b"machine") {
+            self.machine_type = v;
+        }
+    }
+
+    /// Read the VGA model from a `<video><model type=...>` element.
+    fn apply_video_model(&mut self, e: &quick_xml::events::BytesStart) {
+        if let Some(v) = find_attr(e, b"type") {
+            self.vga_model = v;
+        }
+    }
+
+    /// Read the NIC model from an `<interface><model type=...>` element.
+    fn apply_interface_model(&mut self, e: &quick_xml::events::BytesStart) {
+        if let Some(v) = find_attr(e, b"type") {
+            self.current_net_model = v;
+        }
+    }
+
+    /// Apply a Start element (one with children or text content).
+    fn handle_start(&mut self, e: &quick_xml::events::BytesStart) {
+        let tag = String::from_utf8_lossy(e.local_name().as_ref()).to_string();
+        let parent = self.parent();
+
+        match tag.as_str() {
+            "domain" => {
+                if let Some(v) = find_attr(e, b"type") {
+                    self.domain_type = v;
+                }
+            }
+            "name" if parent == "domain" => {
+                self.capture_text_for = Some("name".to_string());
+            }
+            "memory" | "currentMemory" if self.memory_kb == 0 => {
+                self.memory_unit = find_attr(e, b"unit").unwrap_or_else(|| "KiB".to_string());
+                self.capture_text_for = Some("memory".to_string());
+            }
+            "vcpu" => {
+                self.capture_text_for = Some("vcpu".to_string());
+            }
+            "type" if parent == "os" => self.apply_os_type(e),
+            "loader" => self.has_uefi = true,
+            "emulator" => {
+                self.capture_text_for = Some("emulator".to_string());
+            }
+            "disk" => {
+                self.in_disk = true;
+                self.current_disk_bus.clear();
+                self.current_disk_source = PathBuf::new();
+            }
+            "interface" => {
+                self.in_interface = true;
+                self.current_net_type.clear();
+                self.current_net_model.clear();
+                self.current_net_bridge.clear();
+                if let Some(v) = find_attr(e, b"type") {
+                    self.current_net_type = v;
+                }
+            }
+            "video" => {} // Just track in stack
+            "model" if parent == "video" => self.apply_video_model(e),
+            "model" if self.in_interface => self.apply_interface_model(e),
+            "tpm" => self.has_tpm = true,
+            _ => {}
+        }
+
+        self.element_stack.push(tag);
+    }
+
+    /// Apply an Empty element (self-closing, e.g. `<source .../>`).
+    fn handle_empty(&mut self, e: &quick_xml::events::BytesStart) {
+        let tag = String::from_utf8_lossy(e.local_name().as_ref()).to_string();
+        let parent = self.parent();
+
+        match tag.as_str() {
+            "loader" => self.has_uefi = true,
+            "source" if self.in_disk => {
+                if let Some(v) = find_attr(e, b"file") {
+                    self.current_disk_source = PathBuf::from(v);
+                }
+            }
+            "target" if self.in_disk => {
+                if let Some(v) = find_attr(e, b"bus") {
+                    self.current_disk_bus = v;
+                }
+            }
+            "source" if self.in_interface => {
+                // A libvirt interface source uses `bridge` or `network`.
+                if let Some(v) = find_attr(e, b"bridge") {
+                    self.current_net_bridge = v;
+                }
+                if let Some(v) = find_attr(e, b"network") {
+                    self.current_net_bridge = v;
+                }
+            }
+            "model" if parent == "video" => self.apply_video_model(e),
+            "model" if self.in_interface => self.apply_interface_model(e),
+            "graphics" => {
+                if let Some(v) = find_attr(e, b"type") {
+                    self.graphics_type = v;
+                }
+            }
+            "tpm" => self.has_tpm = true,
+            "type" if parent == "os" => self.apply_os_type(e),
+            _ => {}
+        }
+    }
+
+    /// Apply a Text event, storing the content for the pending captured element.
+    fn handle_text(&mut self, raw: &str) {
+        let Some(target) = self.capture_text_for.take() else {
+            return;
+        };
+        let text = raw.trim();
+        match target.as_str() {
+            "name" => self.vm_name = text.to_string(),
+            "memory" => {
+                if let Ok(val) = text.parse::<u64>() {
+                    self.memory_kb = convert_memory_to_kib(val, &self.memory_unit);
+                }
+            }
+            "vcpu" => {
+                if let Ok(val) = text.parse::<u32>() {
+                    self.vcpu = val;
+                }
+            }
+            "emulator" => self.emulator_path = text.to_string(),
+            _ => {}
+        }
+    }
+
+    /// Apply an End element, finalizing the current disk/interface and popping the stack.
+    fn handle_end(&mut self, tag: &str) {
+        if tag == "disk" && self.in_disk {
+            if !self.current_disk_source.as_os_str().is_empty() {
+                self.disk_paths.push(self.current_disk_source.clone());
+                self.disk_buses.push(self.current_disk_bus.clone());
+            }
+            self.in_disk = false;
+        }
+        if tag == "interface" && self.in_interface {
+            // Take the first network interface found
+            if self.net_type.is_empty() {
+                self.net_type = self.current_net_type.clone();
+                self.net_model = self.current_net_model.clone();
+                self.net_bridge = self.current_net_bridge.clone();
+            }
+            self.in_interface = false;
+        }
+
+        // Pop from stack
+        if self.element_stack.last().map(|s| s.as_str()) == Some(tag) {
+            self.element_stack.pop();
+        }
+        self.capture_text_for = None;
+    }
+
+    /// Validate the parsed domain and map it onto an [`ImportableVm`].
+    fn into_importable_vm(mut self, config_path: &Path) -> Result<ImportableVm> {
+        // Validate domain type
+        match self.domain_type.as_str() {
+            "kvm" | "qemu" => {}
+            "" => {
+                bail!("No domain type found in XML. Only QEMU/KVM domains can be imported.");
+            }
+            other => {
+                bail!(
+                    "This VM uses the {} hypervisor, which is not supported. Only QEMU/KVM domains can be imported.",
+                    other
+                );
+            }
+        }
+
+        if self.vm_name.is_empty() {
+            self.vm_name = config_path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("imported-vm")
+                .to_string();
+        }
+
+        let emulator = map_emulator_path(&self.emulator_path, &self.arch);
+        let machine = normalize_machine_type(&self.machine_type);
+        let vga = map_vga_model(&self.vga_model);
+        let display = map_graphics_type(&self.graphics_type);
+        let (network_backend, bridge_name, network_model) = map_network(
+            &self.net_type,
+            &self.net_model,
+            &self.net_bridge,
+            &mut self.import_notes,
+        );
+
+        // Map disk interface from first disk
+        let disk_interface = self
+            .disk_buses
+            .first()
+            .map(|bus| map_disk_bus(bus))
+            .unwrap_or_else(|| "ide".to_string());
+
+        // Move disks out so we can push readability notes onto import_notes.
+        let disk_paths = std::mem::take(&mut self.disk_paths);
+        let disks_readable: Vec<bool> = disk_paths
+            .iter()
+            .map(|p| p.exists() && fs::File::open(p).is_ok())
+            .collect();
+
+        // Add notes for unreadable/missing disks
+        for (i, (path, readable)) in disk_paths.iter().zip(disks_readable.iter()).enumerate() {
+            if !readable && path.exists() {
+                self.import_notes.push(format!(
+                    "Disk {}: {} is not readable by current user. You may need: sudo chmod +r {}",
+                    i + 1,
+                    path.display(),
+                    path.display()
+                ));
+            } else if !path.exists() {
+                self.import_notes.push(format!(
+                    "Disk {}: {} does not exist",
+                    i + 1,
+                    path.display()
+                ));
+            }
+        }
+
+        let enable_kvm = self.domain_type == "kvm";
+        let detected_os_profile = detect_os_profile(&self.vm_name);
+
+        let qemu_config = WizardQemuConfig {
+            emulator,
+            memory_mb: (self.memory_kb / 1024) as u32,
+            cpu_cores: if self.vcpu == 0 { 1 } else { self.vcpu },
+            cpu_model: if enable_kvm {
+                Some("host".to_string())
+            } else {
+                None
+            },
+            machine: if machine.is_empty() {
+                None
+            } else {
+                Some(machine)
+            },
+            vga,
+            audio: vec!["intel-hda".to_string(), "hda-duplex".to_string()],
+            network_model,
+            disk_interface,
+            enable_kvm,
+            gl_acceleration: false,
+            uefi: self.has_uefi,
+            tpm: self.has_tpm,
+            rtc_localtime: false,
+            usb_tablet: true,
+            display,
+            network_backend,
+            port_forwards: Vec::new(),
+            bridge_name,
+            mac_address: None,
+            extra_args: Vec::new(),
+            bios_path: None,
+        };
+
+        Ok(ImportableVm {
+            name: self.vm_name,
+            config_path: config_path.to_path_buf(),
+            source: ImportSource::Libvirt,
+            qemu_config,
+            disk_paths,
+            detected_os_profile,
+            import_notes: self.import_notes,
+            disks_readable,
+        })
+    }
+}
+
+/// Parse libvirt XML from a string (separated from file IO so it can be tested).
 fn parse_libvirt_xml_str(xml: &str, config_path: &Path) -> Result<ImportableVm> {
     use quick_xml::events::Event;
     use quick_xml::Reader;
 
     let mut reader = Reader::from_str(xml);
-
-    // Parsed values
-    let mut domain_type = String::new();
-    let mut vm_name = String::new();
-    let mut memory_kb: u64 = 0;
-    let mut memory_unit = String::new();
-    let mut vcpu: u32 = 0;
-    let mut emulator_path = String::new();
-    let mut arch = String::new();
-    let mut machine_type = String::new();
-    let mut has_uefi = false;
-    let mut has_tpm = false;
-    let mut disk_paths: Vec<PathBuf> = Vec::new();
-    let mut disk_buses: Vec<String> = Vec::new();
-    let mut graphics_type = String::new();
-    let mut vga_model = String::new();
-    let mut import_notes: Vec<String> = Vec::new();
-
-    // Network (first interface found)
-    let mut net_type = String::new();
-    let mut net_model = String::new();
-    let mut net_bridge = String::new();
-
-    // Element tracking
-    let mut element_stack: Vec<String> = Vec::new();
-    // Text capture for the next Text event
-    let mut capture_text_for: Option<String> = None;
-
-    // Current disk/interface state
-    let mut in_disk = false;
-    let mut current_disk_bus = String::new();
-    let mut current_disk_source = PathBuf::new();
-    let mut in_interface = false;
-    let mut current_net_type = String::new();
-    let mut current_net_model = String::new();
-    let mut current_net_bridge = String::new();
-
+    let mut state = LibvirtParse::default();
     let mut buf = Vec::new();
+
     loop {
         match reader.read_event_into(&mut buf) {
-            Ok(Event::Start(ref e)) => {
-                let tag = String::from_utf8_lossy(e.local_name().as_ref()).to_string();
-                let parent = element_stack.last().map(|s| s.as_str()).unwrap_or("");
-
-                match tag.as_str() {
-                    "domain" => {
-                        for attr in e.attributes().flatten() {
-                            if attr.key.as_ref() == b"type" {
-                                domain_type = attr_value(&attr);
-                            }
-                        }
-                    }
-                    "name" if parent == "domain" => {
-                        capture_text_for = Some("name".to_string());
-                    }
-                    "memory" | "currentMemory" if memory_kb == 0 => {
-                        memory_unit = "KiB".to_string();
-                        for attr in e.attributes().flatten() {
-                            if attr.key.as_ref() == b"unit" {
-                                memory_unit = attr_value(&attr);
-                            }
-                        }
-                        capture_text_for = Some("memory".to_string());
-                    }
-                    "vcpu" => {
-                        capture_text_for = Some("vcpu".to_string());
-                    }
-                    "type" if parent == "os" => {
-                        for attr in e.attributes().flatten() {
-                            if attr.key.as_ref() == b"arch" {
-                                arch = attr_value(&attr);
-                            }
-                            if attr.key.as_ref() == b"machine" {
-                                machine_type = attr_value(&attr);
-                            }
-                        }
-                    }
-                    "loader" => {
-                        has_uefi = true;
-                    }
-                    "emulator" => {
-                        capture_text_for = Some("emulator".to_string());
-                    }
-                    "disk" => {
-                        in_disk = true;
-                        current_disk_bus.clear();
-                        current_disk_source = PathBuf::new();
-                    }
-                    "interface" => {
-                        in_interface = true;
-                        current_net_type.clear();
-                        current_net_model.clear();
-                        current_net_bridge.clear();
-                        for attr in e.attributes().flatten() {
-                            if attr.key.as_ref() == b"type" {
-                                current_net_type = attr_value(&attr);
-                            }
-                        }
-                    }
-                    "video" => {} // Just track in stack
-                    "model" if parent == "video" => {
-                        for attr in e.attributes().flatten() {
-                            if attr.key.as_ref() == b"type" {
-                                vga_model = attr_value(&attr);
-                            }
-                        }
-                    }
-                    "model" if in_interface => {
-                        for attr in e.attributes().flatten() {
-                            if attr.key.as_ref() == b"type" {
-                                current_net_model = attr_value(&attr);
-                            }
-                        }
-                    }
-                    "tpm" => {
-                        has_tpm = true;
-                    }
-                    _ => {}
-                }
-
-                element_stack.push(tag);
-            }
-            Ok(Event::Empty(ref e)) => {
-                let tag = String::from_utf8_lossy(e.local_name().as_ref()).to_string();
-                let parent = element_stack.last().map(|s| s.as_str()).unwrap_or("");
-
-                match tag.as_str() {
-                    "loader" => {
-                        has_uefi = true;
-                    }
-                    "source" if in_disk => {
-                        for attr in e.attributes().flatten() {
-                            if attr.key.as_ref() == b"file" {
-                                current_disk_source = PathBuf::from(attr_value(&attr));
-                            }
-                        }
-                    }
-                    "target" if in_disk => {
-                        for attr in e.attributes().flatten() {
-                            if attr.key.as_ref() == b"bus" {
-                                current_disk_bus = attr_value(&attr);
-                            }
-                        }
-                    }
-                    "source" if in_interface => {
-                        for attr in e.attributes().flatten() {
-                            if attr.key.as_ref() == b"bridge" || attr.key.as_ref() == b"network" {
-                                current_net_bridge = attr_value(&attr);
-                            }
-                        }
-                    }
-                    "model" if parent == "video" => {
-                        for attr in e.attributes().flatten() {
-                            if attr.key.as_ref() == b"type" {
-                                vga_model = attr_value(&attr);
-                            }
-                        }
-                    }
-                    "model" if in_interface => {
-                        for attr in e.attributes().flatten() {
-                            if attr.key.as_ref() == b"type" {
-                                current_net_model = attr_value(&attr);
-                            }
-                        }
-                    }
-                    "graphics" => {
-                        for attr in e.attributes().flatten() {
-                            if attr.key.as_ref() == b"type" {
-                                graphics_type = attr_value(&attr);
-                            }
-                        }
-                    }
-                    "tpm" => {
-                        has_tpm = true;
-                    }
-                    "type" if parent == "os" => {
-                        for attr in e.attributes().flatten() {
-                            if attr.key.as_ref() == b"arch" {
-                                arch = attr_value(&attr);
-                            }
-                            if attr.key.as_ref() == b"machine" {
-                                machine_type = attr_value(&attr);
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            }
+            Ok(Event::Start(ref e)) => state.handle_start(e),
+            Ok(Event::Empty(ref e)) => state.handle_empty(e),
             Ok(Event::Text(ref t)) => {
-                if let Some(ref target) = capture_text_for {
-                    let text = String::from_utf8_lossy(t.as_ref()).trim().to_string();
-                    match target.as_str() {
-                        "name" => vm_name = text,
-                        "memory" => {
-                            if let Ok(val) = text.parse::<u64>() {
-                                memory_kb = convert_memory_to_kib(val, &memory_unit);
-                            }
-                        }
-                        "vcpu" => {
-                            if let Ok(val) = text.parse::<u32>() {
-                                vcpu = val;
-                            }
-                        }
-                        "emulator" => emulator_path = text,
-                        _ => {}
-                    }
-                    capture_text_for = None;
-                }
+                let text = String::from_utf8_lossy(t.as_ref());
+                state.handle_text(&text);
             }
             Ok(Event::End(ref e)) => {
                 let tag = String::from_utf8_lossy(e.local_name().as_ref()).to_string();
-
-                if tag == "disk" && in_disk {
-                    if !current_disk_source.as_os_str().is_empty() {
-                        disk_paths.push(current_disk_source.clone());
-                        disk_buses.push(current_disk_bus.clone());
-                    }
-                    in_disk = false;
-                }
-                if tag == "interface" && in_interface {
-                    // Take the first network interface found
-                    if net_type.is_empty() {
-                        net_type = current_net_type.clone();
-                        net_model = current_net_model.clone();
-                        net_bridge = current_net_bridge.clone();
-                    }
-                    in_interface = false;
-                }
-
-                // Pop from stack
-                if element_stack.last().map(|s| s.as_str()) == Some(&tag) {
-                    element_stack.pop();
-                }
-                capture_text_for = None;
+                state.handle_end(&tag);
             }
             Ok(Event::Eof) => break,
             Err(e) => bail!("Error parsing libvirt XML: {}", e),
@@ -271,117 +393,7 @@ fn parse_libvirt_xml_str(xml: &str, config_path: &Path) -> Result<ImportableVm> 
         buf.clear();
     }
 
-    // Validate domain type
-    match domain_type.as_str() {
-        "kvm" | "qemu" => {}
-        "" => {
-            bail!("No domain type found in XML. Only QEMU/KVM domains can be imported.");
-        }
-        other => {
-            bail!(
-                "This VM uses the {} hypervisor, which is not supported. Only QEMU/KVM domains can be imported.",
-                other
-            );
-        }
-    }
-
-    if vm_name.is_empty() {
-        vm_name = config_path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("imported-vm")
-            .to_string();
-    }
-
-    // Map emulator path to emulator string
-    let emulator = map_emulator_path(&emulator_path, &arch);
-
-    // Map machine type
-    let machine = normalize_machine_type(&machine_type);
-
-    // Map VGA model
-    let vga = map_vga_model(&vga_model);
-
-    // Map display
-    let display = map_graphics_type(&graphics_type);
-
-    // Map network
-    let (network_backend, bridge_name, network_model) =
-        map_network(&net_type, &net_model, &net_bridge, &mut import_notes);
-
-    // Map disk interface from first disk
-    let disk_interface = disk_buses
-        .first()
-        .map(|bus| map_disk_bus(bus))
-        .unwrap_or_else(|| "ide".to_string());
-
-    // Check disk readability
-    let disks_readable: Vec<bool> = disk_paths
-        .iter()
-        .map(|p| p.exists() && fs::File::open(p).is_ok())
-        .collect();
-
-    // Add notes for unreadable/missing disks
-    for (i, (path, readable)) in disk_paths.iter().zip(disks_readable.iter()).enumerate() {
-        if !readable && path.exists() {
-            import_notes.push(format!(
-                "Disk {}: {} is not readable by current user. You may need: sudo chmod +r {}",
-                i + 1,
-                path.display(),
-                path.display()
-            ));
-        } else if !path.exists() {
-            import_notes.push(format!("Disk {}: {} does not exist", i + 1, path.display()));
-        }
-    }
-
-    let enable_kvm = domain_type == "kvm";
-
-    let qemu_config = WizardQemuConfig {
-        emulator,
-        memory_mb: (memory_kb / 1024) as u32,
-        cpu_cores: if vcpu == 0 { 1 } else { vcpu },
-        cpu_model: if enable_kvm {
-            Some("host".to_string())
-        } else {
-            None
-        },
-        machine: if machine.is_empty() {
-            None
-        } else {
-            Some(machine)
-        },
-        vga,
-        audio: vec!["intel-hda".to_string(), "hda-duplex".to_string()],
-        network_model,
-        disk_interface,
-        enable_kvm,
-        gl_acceleration: false,
-        uefi: has_uefi,
-        tpm: has_tpm,
-        rtc_localtime: false,
-        usb_tablet: true,
-        display,
-        network_backend,
-        port_forwards: Vec::new(),
-        bridge_name,
-        mac_address: None,
-        extra_args: Vec::new(),
-        bios_path: None,
-    };
-
-    let detected_os_profile = detect_os_profile(&vm_name);
-
-    Ok(ImportableVm {
-        name: vm_name,
-        config_path: config_path.to_path_buf(),
-        source: ImportSource::Libvirt,
-        qemu_config,
-        disk_paths,
-        detected_os_profile,
-        import_notes,
-        disks_readable,
-    })
+    state.into_importable_vm(config_path)
 }
 
 /// Helper: extract attribute value as String

--- a/src/vm/launch_parser.rs
+++ b/src/vm/launch_parser.rs
@@ -665,18 +665,10 @@ fn parse_hostfwd_segment(segment: &str) -> Option<PortForward> {
     };
 
     // Extract host port (last number in host_part after protocol)
-    let host_port: u16 = host_part
-        .rsplit(':')
-        .next()?
-        .parse()
-        .ok()?;
+    let host_port: u16 = host_part.rsplit(':').next()?.parse().ok()?;
 
     // Extract guest port (last number in guest_part)
-    let guest_port: u16 = guest_part
-        .rsplit(':')
-        .next()?
-        .parse()
-        .ok()?;
+    let guest_port: u16 = guest_part.rsplit(':').next()?.parse().ok()?;
 
     Some(PortForward {
         protocol,
@@ -700,9 +692,8 @@ fn extract_bios_path(content: &str, vm_dir: &Path) -> Option<PathBuf> {
 
         if let Some(idx) = trimmed.find("-bios ") {
             let rest = &trimmed[idx + 6..];
-            let raw_path = if rest.starts_with('"') {
+            let raw_path = if let Some(inner) = rest.strip_prefix('"') {
                 // Quoted path like -bios "$ROM"
-                let inner = &rest[1..];
                 if let Some(end) = inner.find('"') {
                     inner[..end].to_string()
                 } else {

--- a/src/vm/lifecycle.rs
+++ b/src/vm/lifecycle.rs
@@ -519,7 +519,7 @@ pub fn save_notes(vm: &DiscoveredVm, notes: Option<&str>) -> Result<()> {
 pub struct QemuProcess {
     pub pid: u32,
     pub cmdline: String,
-    /// The working directory of the process (from /proc/<pid>/cwd)
+    /// The working directory of the process (from `/proc/<pid>/cwd`)
     pub cwd: Option<std::path::PathBuf>,
 }
 
@@ -1237,6 +1237,10 @@ bind_vfio || exit 1
 }
 
 // ── QMP (QEMU Machine Protocol) ─────────────────────────────────────────────
+//
+// The items below are `#[allow(dead_code)]` infrastructure for planned
+// runtime VM control (pause/resume, GUI embedding via D-Bus). They are wired up
+// but not yet surfaced in the UI — intentional, not dead.
 
 #[allow(dead_code)]
 const QMP_ARG: &str = "        -qmp unix:$VM_DIR/qemu.sock,server=on,wait=off";

--- a/src/vm/lifecycle.rs
+++ b/src/vm/lifecycle.rs
@@ -116,7 +116,10 @@ pub fn launch_vm_with_error_check(vm: &DiscoveredVm, options: &LaunchOptions) ->
             if !dmg_path.is_file() {
                 return LaunchResult {
                     success: false,
-                    error: Some(format!("Recovery image path is not a file: {}", dmg_path.display())),
+                    error: Some(format!(
+                        "Recovery image path is not a file: {}",
+                        dmg_path.display()
+                    )),
                     vm_name,
                 };
             }
@@ -134,7 +137,10 @@ pub fn launch_vm_with_error_check(vm: &DiscoveredVm, options: &LaunchOptions) ->
             if !floppy_path.is_file() {
                 return LaunchResult {
                     success: false,
-                    error: Some(format!("Floppy path is not a file: {}", floppy_path.display())),
+                    error: Some(format!(
+                        "Floppy path is not a file: {}",
+                        floppy_path.display()
+                    )),
                     vm_name,
                 };
             }
@@ -230,11 +236,13 @@ pub fn launch_vm_with_error_check(vm: &DiscoveredVm, options: &LaunchOptions) ->
             thread::sleep(Duration::from_millis(300));
 
             // Try to get error output
-            let stderr_lines = rx.recv_timeout(Duration::from_millis(500))
+            let stderr_lines = rx
+                .recv_timeout(Duration::from_millis(500))
                 .unwrap_or_default();
 
             // Filter for error-related lines for display
-            let error_lines: Vec<&String> = stderr_lines.iter()
+            let error_lines: Vec<&String> = stderr_lines
+                .iter()
                 .filter(|line| {
                     let lower = line.to_lowercase();
                     lower.contains("error")
@@ -252,7 +260,11 @@ pub fn launch_vm_with_error_check(vm: &DiscoveredVm, options: &LaunchOptions) ->
                 .collect();
 
             let error_msg = if !error_lines.is_empty() {
-                error_lines.iter().map(|s| s.as_str()).collect::<Vec<_>>().join("\n")
+                error_lines
+                    .iter()
+                    .map(|s| s.as_str())
+                    .collect::<Vec<_>>()
+                    .join("\n")
             } else if !stderr_lines.is_empty() {
                 // Show all stderr if no specific errors found
                 stderr_lines.join("\n")
@@ -295,7 +307,10 @@ pub fn launch_vm_sync(vm: &DiscoveredVm, options: &LaunchOptions) -> Result<()> 
     if result.success {
         Ok(())
     } else {
-        bail!("{}", result.error.unwrap_or_else(|| "Unknown error".to_string()))
+        bail!(
+            "{}",
+            result.error.unwrap_or_else(|| "Unknown error".to_string())
+        )
     }
 }
 
@@ -305,7 +320,7 @@ pub fn launch_vm_sync(vm: &DiscoveredVm, options: &LaunchOptions) -> Result<()> 
 #[allow(dead_code)]
 pub fn launch_vm_dbus(vm: &DiscoveredVm) -> Result<u32> {
     let tmp = vm.path.join(".launch_dbus_tmp.sh");
-    let _ = std::fs::remove_file(&tmp);                       // stale temp script from prior crash
+    let _ = std::fs::remove_file(&tmp); // stale temp script from prior crash
     let _ = std::fs::remove_file(vm.path.join("qemu.sock")); // stale socket from unclean shutdown
 
     if let Err(e) = ensure_qmp_in_script(&vm.path) {
@@ -313,8 +328,7 @@ pub fn launch_vm_dbus(vm: &DiscoveredVm) -> Result<u32> {
     }
 
     let script_path = vm.path.join("launch.sh");
-    let content = std::fs::read_to_string(&script_path)
-        .context("Failed to read launch.sh")?;
+    let content = std::fs::read_to_string(&script_path).context("Failed to read launch.sh")?;
 
     let modified = replace_display_for_dbus(&content, "-display dbus");
 
@@ -335,8 +349,14 @@ pub fn launch_vm_dbus(vm: &DiscoveredVm) -> Result<u32> {
     thread::sleep(Duration::from_millis(300));
     if let Ok(Some(status)) = child.try_wait() {
         use std::io::Read;
-        let stderr = child.stderr.take()
-            .map(|mut s| { let mut b = String::new(); s.read_to_string(&mut b).ok(); b })
+        let stderr = child
+            .stderr
+            .take()
+            .map(|mut s| {
+                let mut b = String::new();
+                s.read_to_string(&mut b).ok();
+                b
+            })
             .unwrap_or_default();
         bail!("QEMU exited immediately ({}): {}", status, stderr.trim());
     }
@@ -359,8 +379,8 @@ fn replace_display_for_dbus(content: &str, replacement: &str) -> String {
     let mut out: Vec<String> = Vec::new();
     for line in content.lines() {
         let t = line.trim();
-        let is_display = !t.starts_with('#')
-            && (t.starts_with("-display ") || t.contains(" -display "));
+        let is_display =
+            !t.starts_with('#') && (t.starts_with("-display ") || t.contains(" -display "));
         let is_spice = t.starts_with("-spice ")
             || (t.starts_with("-device virtio-serial") && t.contains("spice"))
             || (t.starts_with("-device virtserialport") && t.contains("com.redhat.spice"))
@@ -378,21 +398,24 @@ fn replace_display_for_dbus(content: &str, replacement: &str) -> String {
         }
     }
     let mut s = out.join("\n");
-    if content.ends_with('\n') { s.push('\n'); }
+    if content.ends_with('\n') {
+        s.push('\n');
+    }
     s
 }
 
 /// Reset a VM by recreating its disk from a backing file or template
 pub fn reset_vm(vm: &DiscoveredVm) -> Result<()> {
     // Find the primary disk
-    let disk = vm.config.primary_disk()
+    let disk = vm
+        .config
+        .primary_disk()
         .context("VM has no disk configured")?;
 
     let disk_path = &disk.path;
 
     // Check for a backing file or template
-    let info = super::snapshot::get_disk_info(disk_path)
-        .context("Failed to get disk info")?;
+    let info = super::snapshot::get_disk_info(disk_path).context("Failed to get disk info")?;
 
     if let Some(backing) = &info.backing_file {
         // Recreate from backing file
@@ -402,18 +425,13 @@ pub fn reset_vm(vm: &DiscoveredVm) -> Result<()> {
         }
 
         // Remove old disk
-        std::fs::remove_file(disk_path)
-            .context("Failed to remove old disk")?;
+        std::fs::remove_file(disk_path).context("Failed to remove old disk")?;
 
         // Create new disk with backing file
         let disk_str = path_to_str(disk_path)?;
         let output = Command::new("qemu-img")
             .args([
-                "create",
-                "-f", "qcow2",
-                "-F", "qcow2",
-                "-b", backing,
-                disk_str,
+                "create", "-f", "qcow2", "-F", "qcow2", "-b", backing, disk_str,
             ])
             .output()
             .context("Failed to create disk from backing file")?;
@@ -445,23 +463,17 @@ pub fn reset_vm(vm: &DiscoveredVm) -> Result<()> {
 /// Delete a VM (move to trash or permanently delete)
 pub fn delete_vm(vm: &DiscoveredVm, permanent: bool) -> Result<()> {
     if permanent {
-        std::fs::remove_dir_all(&vm.path)
-            .context("Failed to delete VM directory")?;
+        std::fs::remove_dir_all(&vm.path).context("Failed to delete VM directory")?;
     } else {
         // Move to trash using trash-cli if available
-        let result = Command::new("trash-put")
-            .arg(&vm.path)
-            .output();
+        let result = Command::new("trash-put").arg(&vm.path).output();
 
         match result {
             Ok(output) if output.status.success() => {}
             _ => {
                 // Fall back to moving to a .trash directory
-                let trash_dir = vm.path.parent()
-                    .unwrap_or(Path::new("."))
-                    .join(".trash");
-                std::fs::create_dir_all(&trash_dir)
-                    .context("Failed to create trash directory")?;
+                let trash_dir = vm.path.parent().unwrap_or(Path::new(".")).join(".trash");
+                std::fs::create_dir_all(&trash_dir).context("Failed to create trash directory")?;
 
                 // Find a unique name in trash (append timestamp if needed)
                 let mut trash_path = trash_dir.join(&vm.id);
@@ -473,8 +485,7 @@ pub fn delete_vm(vm: &DiscoveredVm, permanent: bool) -> Result<()> {
                     trash_path = trash_dir.join(format!("{}-{}", vm.id, timestamp));
                 }
 
-                std::fs::rename(&vm.path, &trash_path)
-                    .context("Failed to move VM to trash")?;
+                std::fs::rename(&vm.path, &trash_path).context("Failed to move VM to trash")?;
             }
         }
     }
@@ -485,8 +496,7 @@ pub fn delete_vm(vm: &DiscoveredVm, permanent: bool) -> Result<()> {
 /// Rename a VM by updating its display name in vm-curator.toml
 pub fn rename_vm(vm: &DiscoveredVm, new_name: &str) -> Result<()> {
     // Preserve existing os_profile and notes
-    let os_profile = vm.os_profile.as_deref()
-        .or(Some(&vm.id));
+    let os_profile = vm.os_profile.as_deref().or(Some(&vm.id));
     let notes = vm.notes.as_deref();
 
     crate::vm::create::write_vm_metadata(&vm.path, new_name, os_profile, notes)
@@ -516,10 +526,7 @@ pub struct QemuProcess {
 /// Detect all running QEMU processes.
 /// Returns process info including the working directory read from /proc.
 pub fn detect_qemu_processes() -> Vec<QemuProcess> {
-    let output = match Command::new("pgrep")
-        .args(["-a", "qemu-system"])
-        .output()
-    {
+    let output = match Command::new("pgrep").args(["-a", "qemu-system"]).output() {
         Ok(o) => o,
         Err(_) => return Vec::new(),
     };
@@ -572,8 +579,6 @@ pub fn force_stop_vm(pid: u32) -> Result<()> {
     Ok(())
 }
 
-
-
 // USB Passthrough configuration markers
 const USB_MARKER_START: &str = "# >>> USB Passthrough (managed by vm-curator) >>>";
 const USB_MARKER_END: &str = "# <<< USB Passthrough <<<";
@@ -581,8 +586,7 @@ const USB_MARKER_END: &str = "# <<< USB Passthrough <<<";
 /// Save USB passthrough configuration to the VM's launch.sh
 pub fn save_usb_passthrough(vm: &DiscoveredVm, devices: &[UsbPassthrough]) -> Result<()> {
     let script_path = &vm.launch_script;
-    let content = std::fs::read_to_string(script_path)
-        .context("Failed to read launch.sh")?;
+    let content = std::fs::read_to_string(script_path).context("Failed to read launch.sh")?;
 
     // Remove existing USB passthrough section if present
     let content = remove_usb_section(&content);
@@ -595,8 +599,7 @@ pub fn save_usb_passthrough(vm: &DiscoveredVm, devices: &[UsbPassthrough]) -> Re
     let new_content = insert_usb_section(&content, &usb_section);
 
     // Write back
-    std::fs::write(script_path, new_content)
-        .context("Failed to write launch.sh")?;
+    std::fs::write(script_path, new_content).context("Failed to write launch.sh")?;
 
     Ok(())
 }
@@ -736,7 +739,8 @@ pub fn insert_args_section(content: &str, section: &str, var_ref: &str) -> Strin
     }
 
     // Track which end lines we need to modify
-    let qemu_end_indices: std::collections::HashSet<usize> = qemu_commands.iter().map(|(_, end)| *end).collect();
+    let qemu_end_indices: std::collections::HashSet<usize> =
+        qemu_commands.iter().map(|(_, end)| *end).collect();
 
     // Determine where to insert the section: before a `case` statement if present
     // (so the variable is in top-level scope), otherwise before the first QEMU command.
@@ -845,8 +849,7 @@ fn extract_hex_value(s: &str, prefix: &str) -> Option<u16> {
     let rest = &s[start..];
 
     // Find end of hex value (comma, space, quote, or end of string)
-    let end = rest.find([',', ' ', '"', '\''])
-        .unwrap_or(rest.len());
+    let end = rest.find([',', ' ', '"', '\'']).unwrap_or(rest.len());
 
     let hex_str = &rest[..end];
 
@@ -881,18 +884,13 @@ fn shell_escape(s: &str) -> String {
 /// Save shared folders configuration to the VM's launch.sh
 pub fn save_shared_folders(vm: &DiscoveredVm, folders: &[SharedFolder]) -> Result<()> {
     let script_path = &vm.launch_script;
-    let content =
-        std::fs::read_to_string(script_path).context("Failed to read launch.sh")?;
+    let content = std::fs::read_to_string(script_path).context("Failed to read launch.sh")?;
 
     // Remove existing shared folders section if present
     let content = remove_shared_folders_section(&content);
 
     // Determine device name based on architecture
-    let device_name = if vm
-        .config
-        .emulator
-        .command()
-        .contains("aarch64")
+    let device_name = if vm.config.emulator.command().contains("aarch64")
         || vm.config.emulator.command().contains("arm")
     {
         "virtio-9p-device"
@@ -1047,9 +1045,7 @@ fn extract_path_value(s: &str) -> Option<String> {
         Some(result)
     } else {
         // Unquoted path: ends at comma or space
-        let end = rest
-            .find([',', ' ', '"'])
-            .unwrap_or(rest.len());
+        let end = rest.find([',', ' ', '"']).unwrap_or(rest.len());
         Some(rest[..end].to_string())
     }
 }
@@ -1058,9 +1054,7 @@ fn extract_path_value(s: &str) -> Option<String> {
 fn extract_simple_value(s: &str, prefix: &str) -> Option<String> {
     let start = s.find(prefix)? + prefix.len();
     let rest = &s[start..];
-    let end = rest
-        .find([',', ' ', '"', '\''])
-        .unwrap_or(rest.len());
+    let end = rest.find([',', ' ', '"', '\'']).unwrap_or(rest.len());
     let value = rest[..end].trim();
     if value.is_empty() {
         None
@@ -1111,7 +1105,10 @@ fn parse_pci_section(content: &str) -> Vec<String> {
                             let part = part.trim();
                             if part.starts_with("vfio-pci,host=") {
                                 // Extract the host address (ends at space or end of string)
-                                let arg = format!("-device {}", part.split_whitespace().next().unwrap_or(part));
+                                let arg = format!(
+                                    "-device {}",
+                                    part.split_whitespace().next().unwrap_or(part)
+                                );
                                 args.push(arg);
                             }
                         }
@@ -1129,8 +1126,8 @@ pub fn save_pci_passthrough(
     vm: &DiscoveredVm,
     devices: &[crate::hardware::PciDevice],
 ) -> Result<()> {
-    let content = std::fs::read_to_string(&vm.launch_script)
-        .context("Failed to read launch script")?;
+    let content =
+        std::fs::read_to_string(&vm.launch_script).context("Failed to read launch script")?;
 
     // Strip existing section and $PCI_PASSTHROUGH_ARGS variable references
     let mut cleaned = String::new();
@@ -1158,8 +1155,7 @@ pub fn save_pci_passthrough(
     }
 
     if devices.is_empty() {
-        std::fs::write(&vm.launch_script, cleaned)
-            .context("Failed to write launch script")?;
+        std::fs::write(&vm.launch_script, cleaned).context("Failed to write launch script")?;
         return Ok(());
     }
 
@@ -1173,7 +1169,9 @@ pub fn save_pci_passthrough(
     section.push_str("\"\n");
     section.push_str("PCI_DEVICES=(");
     for (i, dev) in devices.iter().enumerate() {
-        if i > 0 { section.push(' '); }
+        if i > 0 {
+            section.push(' ');
+        }
         section.push_str(&format!("\"{}\"", dev.address));
     }
     section.push_str(")\n");
@@ -1234,8 +1232,7 @@ bind_vfio || exit 1
     section.push('\n');
 
     let new_content = insert_args_section(&cleaned, &section, "$PCI_PASSTHROUGH_ARGS");
-    std::fs::write(&vm.launch_script, new_content)
-        .context("Failed to write launch script")?;
+    std::fs::write(&vm.launch_script, new_content).context("Failed to write launch script")?;
     Ok(())
 }
 
@@ -1249,8 +1246,8 @@ const QMP_ARG: &str = "        -qmp unix:$VM_DIR/qemu.sock,server=on,wait=off";
 #[allow(dead_code)]
 pub fn ensure_qmp_in_script(vm_path: &Path) -> Result<()> {
     let script_path = vm_path.join("launch.sh");
-    let content = std::fs::read_to_string(&script_path)
-        .context("Failed to read launch.sh for QMP patch")?;
+    let content =
+        std::fs::read_to_string(&script_path).context("Failed to read launch.sh for QMP patch")?;
 
     if content.contains("qemu.sock") {
         return Ok(());

--- a/src/vm/mac.rs
+++ b/src/vm/mac.rs
@@ -23,7 +23,10 @@ pub fn generate_random_mac() -> String {
         bytes[1] = ((nanos >> 8) & 0xff) as u8;
         bytes[2] = ((nanos >> 16) & 0xff) as u8;
     }
-    format!("52:54:00:{:02x}:{:02x}:{:02x}", bytes[0], bytes[1], bytes[2])
+    format!(
+        "52:54:00:{:02x}:{:02x}:{:02x}",
+        bytes[0], bytes[1], bytes[2]
+    )
 }
 
 /// Validate a MAC address in canonical colon-separated hex form
@@ -33,9 +36,9 @@ pub fn is_valid_mac(s: &str) -> bool {
     if parts.len() != 6 {
         return false;
     }
-    parts.iter().all(|p| {
-        p.len() == 2 && p.chars().all(|c| c.is_ascii_hexdigit())
-    })
+    parts
+        .iter()
+        .all(|p| p.len() == 2 && p.chars().all(|c| c.is_ascii_hexdigit()))
 }
 
 #[cfg(test)]

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -10,7 +10,11 @@ pub mod snapshot;
 
 pub use create::create_vm;
 pub use discovery::{discover_vms, group_vms_by_category, DiscoveredVm};
-pub use lifecycle::{detect_qemu_processes, force_stop_vm, launch_vm_sync, launch_vm_with_error_check, load_pci_passthrough, load_shared_folders, load_usb_passthrough, save_shared_folders, save_usb_passthrough, stop_vm_by_pid, LaunchOptions, QemuProcess, SharedFolder, UsbPassthrough};
+pub use lifecycle::{
+    detect_qemu_processes, force_stop_vm, launch_vm_sync, launch_vm_with_error_check,
+    load_pci_passthrough, load_shared_folders, load_usb_passthrough, save_shared_folders,
+    save_usb_passthrough, stop_vm_by_pid, LaunchOptions, QemuProcess, SharedFolder, UsbPassthrough,
+};
 pub use qemu_config::{BootMode, QemuConfig};
 pub use single_gpu_scripts::generate_single_gpu_scripts;
 pub use snapshot::{create_snapshot, delete_snapshot, list_snapshots, restore_snapshot, Snapshot};
@@ -19,9 +23,14 @@ pub use snapshot::{create_snapshot, delete_snapshot, list_snapshots, restore_sna
 #[allow(unused_imports)]
 pub use create::update_network_in_script;
 #[allow(unused_imports)]
-pub use import::{discover_libvirt_vms, discover_quickemu_vms, discover_vms_in_dir, execute_import};
+pub use import::{
+    discover_libvirt_vms, discover_quickemu_vms, discover_vms_in_dir, execute_import,
+};
 #[allow(unused_imports)]
-pub use lifecycle::{delete_vm, ensure_qmp_in_script, is_vm_paused, launch_vm_dbus, pause_vm, rename_vm, reset_vm, resume_vm, save_notes, save_pci_passthrough};
+pub use lifecycle::{
+    delete_vm, ensure_qmp_in_script, is_vm_paused, launch_vm_dbus, pause_vm, rename_vm, reset_vm,
+    resume_vm, save_notes, save_pci_passthrough,
+};
 #[allow(unused_imports)]
 pub use qemu_config::{NetworkBackend, NetworkConfig, PortForward, PortProtocol};
 #[allow(unused_imports)]

--- a/src/vm/qemu_config.rs
+++ b/src/vm/qemu_config.rs
@@ -66,6 +66,9 @@ pub enum VgaType {
 }
 
 impl VgaType {
+    // Infallible parser (unknown values map to `Other`), so an inherent method is
+    // more ergonomic than the fallible `std::str::FromStr` trait.
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
         match s.to_lowercase().as_str() {
             "std" => Self::Std,
@@ -91,7 +94,9 @@ pub enum AudioDevice {
 }
 
 impl AudioDevice {
-    #[allow(dead_code)]
+    // Infallible parser (unknown values map to `Other`), so an inherent method is
+    // more ergonomic than the fallible `std::str::FromStr` trait.
+    #[allow(dead_code, clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
         match s.to_lowercase().as_str() {
             "sb16" => Self::Sb16,
@@ -139,7 +144,11 @@ pub struct PortForward {
 
 impl fmt::Display for PortForward {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {} -> {}", self.protocol, self.host_port, self.guest_port)
+        write!(
+            f,
+            "{} {} -> {}",
+            self.protocol, self.host_port, self.guest_port
+        )
     }
 }
 
@@ -322,22 +331,29 @@ mod tests {
 
     #[test]
     fn has_gl_acceleration_detects_device() {
-        let mut cfg = QemuConfig::default();
-        cfg.raw_script = "qemu-system-x86_64 \\\n  -device virtio-vga-gl \\\n  -display sdl,gl=on".to_string();
+        let cfg = QemuConfig {
+            raw_script: "qemu-system-x86_64 \\\n  -device virtio-vga-gl \\\n  -display sdl,gl=on"
+                .to_string(),
+            ..Default::default()
+        };
         assert!(cfg.has_gl_acceleration());
     }
 
     #[test]
     fn has_gl_acceleration_detects_extra_arg() {
-        let mut cfg = QemuConfig::default();
-        cfg.extra_args = vec!["-display gtk,gl=on".to_string()];
+        let cfg = QemuConfig {
+            extra_args: vec!["-display gtk,gl=on".to_string()],
+            ..Default::default()
+        };
         assert!(cfg.has_gl_acceleration());
     }
 
     #[test]
     fn has_gl_acceleration_negative() {
-        let mut cfg = QemuConfig::default();
-        cfg.raw_script = "qemu-system-x86_64 \\\n  -vga std \\\n  -display gtk".to_string();
+        let cfg = QemuConfig {
+            raw_script: "qemu-system-x86_64 \\\n  -vga std \\\n  -display gtk".to_string(),
+            ..Default::default()
+        };
         assert!(!cfg.has_gl_acceleration());
     }
 }

--- a/src/vm/single_gpu_scripts.rs
+++ b/src/vm/single_gpu_scripts.rs
@@ -17,24 +17,20 @@ use std::path::{Path, PathBuf};
 // These are used in extract_qemu_command_for_passthrough() and compiled once
 
 /// Regex to match -name "..." arguments
-static RE_NAME: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"-name\s+["'][^"']+["']"#).expect("Invalid regex: RE_NAME")
-});
+static RE_NAME: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"-name\s+["'][^"']+["']"#).expect("Invalid regex: RE_NAME"));
 
 /// Regex to match -display arguments
-static RE_DISPLAY: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"-display\s+\S+(,\S+)*").expect("Invalid regex: RE_DISPLAY")
-});
+static RE_DISPLAY: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"-display\s+\S+(,\S+)*").expect("Invalid regex: RE_DISPLAY"));
 
 /// Regex to match -vga arguments
-static RE_VGA: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"-vga\s+\S+").expect("Invalid regex: RE_VGA")
-});
+static RE_VGA: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"-vga\s+\S+").expect("Invalid regex: RE_VGA"));
 
 /// Regex to match -audiodev arguments
-static RE_AUDIODEV: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"-audiodev\s+\S+(,\S+)*").expect("Invalid regex: RE_AUDIODEV")
-});
+static RE_AUDIODEV: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"-audiodev\s+\S+(,\S+)*").expect("Invalid regex: RE_AUDIODEV"));
 
 /// Regex to match sound/audio device arguments
 static RE_SOUNDHW: Lazy<Regex> = Lazy::new(|| {
@@ -58,24 +54,20 @@ static RE_DRIVE_ISO: Lazy<Regex> = Lazy::new(|| {
 });
 
 /// Regex to match empty continuation lines
-static RE_EMPTY_CONT: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"\\\n\s*\\\n").expect("Invalid regex: RE_EMPTY_CONT")
-});
+static RE_EMPTY_CONT: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\\\n\s*\\\n").expect("Invalid regex: RE_EMPTY_CONT"));
 
 /// Regex to match -cpu host
-static RE_CPU_HOST: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"-cpu\s+host\b").expect("Invalid regex: RE_CPU_HOST")
-});
+static RE_CPU_HOST: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"-cpu\s+host\b").expect("Invalid regex: RE_CPU_HOST"));
 
 /// Regex to match -machine arguments
-static RE_MACHINE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"-machine\s+(\S+)").expect("Invalid regex: RE_MACHINE")
-});
+static RE_MACHINE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"-machine\s+(\S+)").expect("Invalid regex: RE_MACHINE"));
 
 /// Regex to match -boot order=d
-static RE_BOOT_D: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"-boot\s+order=d\b").expect("Invalid regex: RE_BOOT_D")
-});
+static RE_BOOT_D: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"-boot\s+order=d\b").expect("Invalid regex: RE_BOOT_D"));
 
 use crate::hardware::SingleGpuConfig;
 use crate::vm::lifecycle::{load_pci_passthrough, load_usb_passthrough};
@@ -236,8 +228,7 @@ pub fn generate_single_gpu_scripts(
 
 /// Write a script file and make it executable
 fn write_executable_script(path: &Path, content: &str) -> Result<()> {
-    fs::write(path, content)
-        .with_context(|| format!("Failed to write script: {:?}", path))?;
+    fs::write(path, content).with_context(|| format!("Failed to write script: {:?}", path))?;
 
     let mut perms = fs::metadata(path)?.permissions();
     perms.set_mode(0o755);
@@ -249,7 +240,11 @@ fn write_executable_script(path: &Path, content: &str) -> Result<()> {
 /// Generate the main start script
 fn generate_start_script(vm: &DiscoveredVm, config: &SingleGpuConfig) -> Result<String> {
     let gpu_addr = &config.gpu.address;
-    let audio_addr = config.audio.as_ref().map(|a| a.address.as_str()).unwrap_or("");
+    let audio_addr = config
+        .audio
+        .as_ref()
+        .map(|a| a.address.as_str())
+        .unwrap_or("");
     let original_driver = config.original_driver.module_name();
     let display_manager = config.display_manager.service_name();
     let vm_dir = vm.path.display();
@@ -295,7 +290,13 @@ fn generate_start_script(vm: &DiscoveredVm, config: &SingleGpuConfig) -> Result<
     };
 
     // Build QEMU command from existing launch.sh
-    let qemu_command = extract_qemu_command_for_passthrough(vm, config, &components, &usb_passthrough_args, &pci_passthrough_args)?;
+    let qemu_command = extract_qemu_command_for_passthrough(
+        vm,
+        config,
+        &components,
+        &usb_passthrough_args,
+        &pci_passthrough_args,
+    )?;
 
     // Generate variable definitions
     let variable_defs = generate_variable_definitions(vm, &components);
@@ -312,7 +313,8 @@ fn generate_start_script(vm: &DiscoveredVm, config: &SingleGpuConfig) -> Result<
         r#"
 # Start TPM emulator
 start_tpm
-"#.to_string()
+"#
+        .to_string()
     } else {
         String::new()
     };
@@ -327,11 +329,15 @@ start_tpm
     sleep 0.5
     modprobe nvidia_drm 2>/dev/null || true
     modprobe nvidia_uvm 2>/dev/null || true
-    sleep 1"#.to_string()
+    sleep 1"#
+            .to_string()
     } else {
-        format!(r#"
+        format!(
+            r#"
     modprobe "{}" 2>/dev/null || true
-    sleep 1"#, original_driver)
+    sleep 1"#,
+            original_driver
+        )
     };
 
     let script = format!(
@@ -561,7 +567,9 @@ echo "VM has exited."
         pkill -f "swtpm.*$TPM_DIR" 2>/dev/null || true
     fi
 "#
-        } else { "" },
+        } else {
+            ""
+        },
         nvidia_module_load = nvidia_module_load,
         unload_modules_cmd = unload_modules_cmd,
         tpm_start = tpm_start,
@@ -620,7 +628,8 @@ fn generate_variable_definitions(vm: &DiscoveredVm, components: &LaunchScriptCom
 fn generate_tpm_functions(components: &LaunchScriptComponents) -> String {
     let tpm_dir = components.tpm_dir.as_deref().unwrap_or("$VM_DIR/tpm");
 
-    format!(r#"
+    format!(
+        r#"
 # ============================================================================
 # TPM Functions
 # ============================================================================
@@ -643,7 +652,9 @@ start_tpm() {{
         --daemon
     sleep 1
 }}
-"#, tpm_dir = tpm_dir)
+"#,
+        tpm_dir = tpm_dir
+    )
 }
 
 /// Extract PCI addresses from passthrough args (e.g., "-device vfio-pci,host=0000:47:00.0")
@@ -652,12 +663,9 @@ fn extract_pci_addresses(pci_args: &[String]) -> Vec<String> {
         .iter()
         .filter_map(|arg| {
             // Format: "-device vfio-pci,host=0000:XX:XX.X"
-            arg.split("host=").nth(1).map(|s| {
-                s.split([',', ' '])
-                    .next()
-                    .unwrap_or(s)
-                    .to_string()
-            })
+            arg.split("host=")
+                .nth(1)
+                .map(|s| s.split([',', ' ']).next().unwrap_or(s).to_string())
         })
         .collect()
 }
@@ -730,11 +738,14 @@ fn generate_restore_script(vm: &DiscoveredVm, config: &SingleGpuConfig) -> Strin
 
     let tpm_cleanup = if components.has_tpm {
         let tpm_dir = components.tpm_dir.as_deref().unwrap_or("$VM_DIR/tpm");
-        format!(r#"
+        format!(
+            r#"
 # Kill TPM emulator if running
 TPM_DIR="{tpm_dir}"
 pkill -f "swtpm.*$TPM_DIR" 2>/dev/null || true
-"#, tpm_dir = tpm_dir)
+"#,
+            tpm_dir = tpm_dir
+        )
     } else {
         String::new()
     };
@@ -749,12 +760,16 @@ pkill -f "swtpm.*$TPM_DIR" 2>/dev/null || true
     sleep 0.5
     modprobe nvidia_drm 2>/dev/null || true
     modprobe nvidia_uvm 2>/dev/null || true
-    sleep 1"#.to_string()
+    sleep 1"#
+            .to_string()
     } else {
-        format!(r#"
+        format!(
+            r#"
     echo "Loading {} driver..."
     modprobe "{}" 2>/dev/null || true
-    sleep 2"#, original_driver, original_driver)
+    sleep 2"#,
+            original_driver, original_driver
+        )
     };
 
     format!(
@@ -1092,14 +1107,22 @@ fn extract_qemu_command_for_passthrough(
 
     if !found_qemu {
         // Fallback: generate a basic QEMU command
-        return Ok(generate_basic_qemu_command(vm, config, components, usb_passthrough_args, pci_passthrough_args));
+        return Ok(generate_basic_qemu_command(
+            vm,
+            config,
+            components,
+            usb_passthrough_args,
+            pci_passthrough_args,
+        ));
     }
 
     // Build the modified QEMU command
     let mut qemu_cmd = qemu_lines.join("\n");
 
     // Replace any hardcoded -name with $VM_NAME variable (for cleanup to work correctly)
-    qemu_cmd = RE_NAME.replace_all(&qemu_cmd, r#"-name "$VM_NAME""#).to_string();
+    qemu_cmd = RE_NAME
+        .replace_all(&qemu_cmd, r#"-name "$VM_NAME""#)
+        .to_string();
 
     // Remove existing -display if present (we'll use the GPU's display)
     qemu_cmd = RE_DISPLAY.replace_all(&qemu_cmd, "").to_string();
@@ -1133,10 +1156,7 @@ fn extract_qemu_command_for_passthrough(
 
     // Audio passthrough (if present)
     if let Some(ref audio) = config.audio {
-        passthrough_args.push(format!(
-            "-device vfio-pci,host={}",
-            audio.address
-        ));
+        passthrough_args.push(format!("-device vfio-pci,host={}", audio.address));
     }
 
     // Display settings - none (output goes to physical GPU)
@@ -1170,11 +1190,7 @@ fn extract_qemu_command_for_passthrough(
     // Find the end of the QEMU command and insert our args
     if let Some(last_backslash) = qemu_cmd.rfind('\\') {
         let (before, _) = qemu_cmd.split_at(last_backslash);
-        qemu_cmd = format!(
-            "{} \\\n    {}",
-            before.trim_end(),
-            passthrough_str
-        );
+        qemu_cmd = format!("{} \\\n    {}", before.trim_end(), passthrough_str);
     } else {
         // No continuation, just append
         qemu_cmd = format!("{} \\\n    {}", qemu_cmd.trim_end(), passthrough_str);
@@ -1193,7 +1209,9 @@ fn extract_qemu_command_for_passthrough(
             let machine_opts = caps.get(1).unwrap().as_str();
             if !machine_opts.contains("kernel_irqchip") {
                 let new_opts = format!("{},kernel_irqchip=on", machine_opts);
-                qemu_cmd = RE_MACHINE.replace(&qemu_cmd, format!("-machine {}", new_opts).as_str()).to_string();
+                qemu_cmd = RE_MACHINE
+                    .replace(&qemu_cmd, format!("-machine {}", new_opts).as_str())
+                    .to_string();
             }
         }
     }
@@ -1231,31 +1249,34 @@ fn generate_basic_qemu_command(
     -m {} \
     -smp {} \
     -enable-kvm"#,
-        qemu_emulator,
-        cpu_flags,
-        memory,
-        cpu_cores
+        qemu_emulator, cpu_flags, memory, cpu_cores
     );
 
     // Add SMBIOS options if present (for Windows to avoid corporate machine detection)
     if components.smbios_opts.is_some() {
-        cmd.push_str(r#" \
-    "${SMBIOS_OPTS[@]}""#);
+        cmd.push_str(
+            r#" \
+    "${SMBIOS_OPTS[@]}""#,
+        );
     }
 
     // Add UEFI if present
     if components.has_uefi {
-        cmd.push_str(r#" \
+        cmd.push_str(
+            r#" \
     -drive if=pflash,format=raw,readonly=on,file="$OVMF_CODE" \
-    -drive if=pflash,format=raw,file="$OVMF_VARS""#);
+    -drive if=pflash,format=raw,file="$OVMF_VARS""#,
+        );
     }
 
     // Add TPM if present
     if components.has_tpm {
-        cmd.push_str(r#" \
+        cmd.push_str(
+            r#" \
     -chardev socket,id=chrtpm,path="$TPM_DIR/swtpm-sock" \
     -tpmdev emulator,id=tpm0,chardev=chrtpm \
-    -device tpm-tis,tpmdev=tpm0"#);
+    -device tpm-tis,tpmdev=tpm0"#,
+        );
     }
 
     // Add disk
@@ -1339,10 +1360,7 @@ fn generate_basic_qemu_command(
 
 /// Delete single GPU scripts for a VM
 pub fn delete_scripts(vm_path: &Path) -> Result<()> {
-    let scripts = [
-        "single-gpu-start.sh",
-        "single-gpu-restore.sh",
-    ];
+    let scripts = ["single-gpu-start.sh", "single-gpu-restore.sh"];
 
     for script in scripts {
         let path = vm_path.join(script);
@@ -1380,8 +1398,8 @@ pub fn regenerate_from_saved_config(vm: &DiscoveredVm) -> Result<bool> {
     }
 
     // Try to load saved config
-    let config = load_config(&vm.path)
-        .ok_or_else(|| anyhow::anyhow!("No saved single-GPU config found"))?;
+    let config =
+        load_config(&vm.path).ok_or_else(|| anyhow::anyhow!("No saved single-GPU config found"))?;
 
     // Regenerate scripts
     generate_single_gpu_scripts(vm, &config)?;

--- a/src/vm/snapshot.rs
+++ b/src/vm/snapshot.rs
@@ -108,8 +108,8 @@ pub fn list_snapshots(disk_path: &Path) -> Result<Vec<Snapshot>> {
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let info: QemuImgInfo = serde_json::from_str(&stdout)
-        .context("Failed to parse qemu-img JSON output")?;
+    let info: QemuImgInfo =
+        serde_json::from_str(&stdout).context("Failed to parse qemu-img JSON output")?;
 
     let snapshots = info
         .snapshots
@@ -239,13 +239,16 @@ pub fn get_disk_info(disk_path: &Path) -> Result<DiskInfo> {
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let info: QemuImgInfo = serde_json::from_str(&stdout)
-        .context("Failed to parse qemu-img JSON output")?;
+    let info: QemuImgInfo =
+        serde_json::from_str(&stdout).context("Failed to parse qemu-img JSON output")?;
 
     Ok(DiskInfo {
         format: info.format,
         virtual_size: format_size(info.virtual_size),
-        disk_size: info.actual_size.map(format_size).unwrap_or_else(|| "unknown".to_string()),
+        disk_size: info
+            .actual_size
+            .map(format_size)
+            .unwrap_or_else(|| "unknown".to_string()),
         cluster_size: info.cluster_size.map(format_size),
         backing_file: info.backing_filename,
     })

--- a/src/vm/tests/create.rs
+++ b/src/vm/tests/create.rs
@@ -19,15 +19,30 @@ fn test_shell_escape_unsafe_strings() {
     assert_eq!(shell_escape("test; echo pwned"), "'test; echo pwned'");
     assert_eq!(shell_escape("$(whoami)"), "'$(whoami)'");
     assert_eq!(shell_escape("`whoami`"), "'`whoami`'");
-    assert_eq!(shell_escape("test\"; echo pwned; echo \""), "'test\"; echo pwned; echo \"'");
+    assert_eq!(
+        shell_escape("test\"; echo pwned; echo \""),
+        "'test\"; echo pwned; echo \"'"
+    );
 }
 
 #[test]
 fn test_generate_folder_name() {
-    assert_eq!(CreateWizardState::generate_folder_name("Windows 10"), "windows-10");
-    assert_eq!(CreateWizardState::generate_folder_name("Debian GNU/Linux"), "debian-gnu-linux");
-    assert_eq!(CreateWizardState::generate_folder_name("MS-DOS 6.22"), "ms-dos-6-22");
-    assert_eq!(CreateWizardState::generate_folder_name("  Spaced  Out  "), "spaced-out");
+    assert_eq!(
+        CreateWizardState::generate_folder_name("Windows 10"),
+        "windows-10"
+    );
+    assert_eq!(
+        CreateWizardState::generate_folder_name("Debian GNU/Linux"),
+        "debian-gnu-linux"
+    );
+    assert_eq!(
+        CreateWizardState::generate_folder_name("MS-DOS 6.22"),
+        "ms-dos-6-22"
+    );
+    assert_eq!(
+        CreateWizardState::generate_folder_name("  Spaced  Out  "),
+        "spaced-out"
+    );
 }
 
 #[test]
@@ -95,7 +110,8 @@ fn test_build_qemu_command_basic() {
 #[test]
 fn test_build_qemu_command_with_cdrom() {
     let config = WizardQemuConfig::default();
-    let cmd = build_qemu_command_with_os(&config, "disk.qcow2", &InstallMedia::Iso(None), None, None);
+    let cmd =
+        build_qemu_command_with_os(&config, "disk.qcow2", &InstallMedia::Iso(None), None, None);
 
     assert!(cmd.contains("-drive file=\"$ISO\",media=cdrom"));
     assert!(cmd.contains("-boot d"));
@@ -104,8 +120,16 @@ fn test_build_qemu_command_with_cdrom() {
 #[test]
 fn test_generate_network_args_user_with_portfwd() {
     let forwards = vec![
-        PortForward { protocol: PortProtocol::Tcp, host_port: 2222, guest_port: 22 },
-        PortForward { protocol: PortProtocol::Tcp, host_port: 8080, guest_port: 80 },
+        PortForward {
+            protocol: PortProtocol::Tcp,
+            host_port: 2222,
+            guest_port: 22,
+        },
+        PortForward {
+            protocol: PortProtocol::Tcp,
+            host_port: 8080,
+            guest_port: 80,
+        },
     ];
     let args = generate_network_args("e1000", "user", None, &forwards, None);
     assert_eq!(args.len(), 2);
@@ -139,7 +163,11 @@ fn test_generate_network_args_with_mac_bridge() {
         Some("52:54:00:de:ad:be"),
     );
     assert_eq!(args.len(), 2);
-    assert!(args[1].contains("mac=52:54:00:de:ad:be"), "device line missing mac=: {}", args[1]);
+    assert!(
+        args[1].contains("mac=52:54:00:de:ad:be"),
+        "device line missing mac=: {}",
+        args[1]
+    );
 }
 
 #[test]
@@ -202,16 +230,32 @@ fn test_build_qemu_command_with_bios() {
         bios_path: Some(PathBuf::from("MacROM.bin")),
     };
 
-    let cmd = build_qemu_command_with_os(&config, "disk.qcow2", &InstallMedia::None, Some("mac-system7"), None);
-    assert!(cmd.contains("-bios \"$ROM\""), "Should contain -bios \"$ROM\", got:\n{}", cmd);
-    assert!(cmd.contains("qemu-system-m68k"), "Should contain m68k emulator");
+    let cmd = build_qemu_command_with_os(
+        &config,
+        "disk.qcow2",
+        &InstallMedia::None,
+        Some("mac-system7"),
+        None,
+    );
+    assert!(
+        cmd.contains("-bios \"$ROM\""),
+        "Should contain -bios \"$ROM\", got:\n{}",
+        cmd
+    );
+    assert!(
+        cmd.contains("qemu-system-m68k"),
+        "Should contain m68k emulator"
+    );
 }
 
 #[test]
 fn test_build_qemu_command_without_bios() {
     let config = WizardQemuConfig::default();
     let cmd = build_qemu_command_with_os(&config, "disk.qcow2", &InstallMedia::None, None, None);
-    assert!(!cmd.contains("-bios"), "Should NOT contain -bios when no bios_path");
+    assert!(
+        !cmd.contains("-bios"),
+        "Should NOT contain -bios when no bios_path"
+    );
 }
 
 #[test]
@@ -232,26 +276,59 @@ fn test_generate_launch_script_with_rom() {
         None,
     );
 
-    assert!(script.contains("ROM=\"$VM_DIR/MacROM.bin\""), "Script should contain ROM variable");
-    assert!(script.contains("-bios \"$ROM\""), "Script should contain -bios \"$ROM\"");
+    assert!(
+        script.contains("ROM=\"$VM_DIR/MacROM.bin\""),
+        "Script should contain ROM variable"
+    );
+    assert!(
+        script.contains("-bios \"$ROM\""),
+        "Script should contain -bios \"$ROM\""
+    );
 }
 
 #[test]
 fn test_build_qemu_command_with_recovery_image() {
     let config = WizardQemuConfig::default();
-    let cmd = build_qemu_command_with_os(&config, "disk.qcow2", &InstallMedia::RecoveryImage(None), None, None);
+    let cmd = build_qemu_command_with_os(
+        &config,
+        "disk.qcow2",
+        &InstallMedia::RecoveryImage(None),
+        None,
+        None,
+    );
 
-    assert!(cmd.contains("format=dmg"), "Should contain format=dmg for recovery image");
-    assert!(cmd.contains("snapshot=on"), "Should use snapshot overlay for writability");
-    assert!(cmd.contains("if=ide,index=2"), "Should attach via IDE/AHCI at index 2");
-    assert!(!cmd.contains("-boot d"), "Should NOT contain -boot d for recovery images");
-    assert!(cmd.contains("\"$RECOVERY_IMG\""), "Should reference $RECOVERY_IMG variable");
+    assert!(
+        cmd.contains("format=dmg"),
+        "Should contain format=dmg for recovery image"
+    );
+    assert!(
+        cmd.contains("snapshot=on"),
+        "Should use snapshot overlay for writability"
+    );
+    assert!(
+        cmd.contains("if=ide,index=2"),
+        "Should attach via IDE/AHCI at index 2"
+    );
+    assert!(
+        !cmd.contains("-boot d"),
+        "Should NOT contain -boot d for recovery images"
+    );
+    assert!(
+        cmd.contains("\"$RECOVERY_IMG\""),
+        "Should reference $RECOVERY_IMG variable"
+    );
 }
 
 #[test]
 fn test_build_qemu_command_with_recovery_image_custom_path() {
     let config = WizardQemuConfig::default();
-    let cmd = build_qemu_command_with_os(&config, "disk.qcow2", &InstallMedia::RecoveryImage(Some("\"$2\"")), None, None);
+    let cmd = build_qemu_command_with_os(
+        &config,
+        "disk.qcow2",
+        &InstallMedia::RecoveryImage(Some("\"$2\"")),
+        None,
+        None,
+    );
 
     assert!(cmd.contains("format=dmg"), "Should contain format=dmg");
     assert!(cmd.contains("\"$2\""), "Should use custom path expression");
@@ -271,11 +348,26 @@ fn test_generate_launch_script_with_recovery_image() {
         None,
     );
 
-    assert!(script.contains("RECOVERY_IMG="), "Should use RECOVERY_IMG variable");
-    assert!(!script.contains("ISO="), "Should NOT contain ISO variable when recovery image");
-    assert!(script.contains("/tmp/BaseSystem.dmg"), "Should contain DMG path");
-    assert!(script.contains("--recovery"), "Should contain --recovery option");
-    assert!(script.contains("format=dmg"), "Install mode should use format=dmg");
+    assert!(
+        script.contains("RECOVERY_IMG="),
+        "Should use RECOVERY_IMG variable"
+    );
+    assert!(
+        !script.contains("ISO="),
+        "Should NOT contain ISO variable when recovery image"
+    );
+    assert!(
+        script.contains("/tmp/BaseSystem.dmg"),
+        "Should contain DMG path"
+    );
+    assert!(
+        script.contains("--recovery"),
+        "Should contain --recovery option"
+    );
+    assert!(
+        script.contains("format=dmg"),
+        "Install mode should use format=dmg"
+    );
 }
 
 #[test]
@@ -292,10 +384,19 @@ fn test_generate_launch_script_iso_unchanged() {
     );
 
     assert!(script.contains("ISO="), "Should use ISO variable");
-    assert!(!script.contains("RECOVERY_IMG="), "Should NOT contain RECOVERY_IMG variable");
+    assert!(
+        !script.contains("RECOVERY_IMG="),
+        "Should NOT contain RECOVERY_IMG variable"
+    );
     assert!(script.contains("--cdrom"), "Should contain --cdrom option");
-    assert!(script.contains("--recovery"), "Should still contain --recovery option for flexibility");
-    assert!(script.contains("-boot d"), "Install mode should boot from CD-ROM");
+    assert!(
+        script.contains("--recovery"),
+        "Should still contain --recovery option for flexibility"
+    );
+    assert!(
+        script.contains("-boot d"),
+        "Install mode should boot from CD-ROM"
+    );
 }
 
 // === macOS-specific tests ===
@@ -359,67 +460,149 @@ fn macos_non_uefi_config() -> WizardQemuConfig {
 #[test]
 fn test_macos_includes_smc_and_smbios() {
     let config = macos_non_uefi_config();
-    let cmd = build_qemu_command_with_os(&config, "disk.qcow2", &InstallMedia::None, Some("mac-osx-leopard"), None);
+    let cmd = build_qemu_command_with_os(
+        &config,
+        "disk.qcow2",
+        &InstallMedia::None,
+        Some("mac-osx-leopard"),
+        None,
+    );
 
-    assert!(cmd.contains("isa-applesmc,osk="), "Should contain Apple SMC device with quoted value");
-    assert!(cmd.contains("-smbios type=2"), "Should contain SMBIOS type=2");
+    assert!(
+        cmd.contains("isa-applesmc,osk="),
+        "Should contain Apple SMC device with quoted value"
+    );
+    assert!(
+        cmd.contains("-smbios type=2"),
+        "Should contain SMBIOS type=2"
+    );
 }
 
 #[test]
 fn test_macos_uefi_uses_ahci() {
     let config = macos_uefi_config();
-    let cmd = build_qemu_command_with_os(&config, "disk.qcow2", &InstallMedia::None, Some("macos-sonoma"), None);
+    let cmd = build_qemu_command_with_os(
+        &config,
+        "disk.qcow2",
+        &InstallMedia::None,
+        Some("macos-sonoma"),
+        None,
+    );
 
-    assert!(cmd.contains("ich9-ahci,id=sata"), "Should have explicit AHCI controller");
+    assert!(
+        cmd.contains("ich9-ahci,id=sata"),
+        "Should have explicit AHCI controller"
+    );
     assert!(cmd.contains("bus=sata."), "Should use sata bus addressing");
     // Should NOT use the old if=ide,index=0 style
-    assert!(!cmd.contains("if=ide,index=0"), "Should NOT use legacy if=ide,index=0 for macOS UEFI");
+    assert!(
+        !cmd.contains("if=ide,index=0"),
+        "Should NOT use legacy if=ide,index=0 for macOS UEFI"
+    );
 }
 
 #[test]
 fn test_macos_uefi_with_opencore() {
     let config = macos_uefi_config();
-    let cmd = build_qemu_command_with_os(&config, "disk.qcow2", &InstallMedia::None, Some("macos-sonoma"), None);
+    let cmd = build_qemu_command_with_os(
+        &config,
+        "disk.qcow2",
+        &InstallMedia::None,
+        Some("macos-sonoma"),
+        None,
+    );
 
     // OpenCore as sata.0
-    assert!(cmd.contains("file=\"$ROM\",format=qcow2,if=none,id=oc"), "Should have OpenCore drive");
-    assert!(cmd.contains("drive=oc,bus=sata.0"), "OpenCore should be on sata.0");
+    assert!(
+        cmd.contains("file=\"$ROM\",format=qcow2,if=none,id=oc"),
+        "Should have OpenCore drive"
+    );
+    assert!(
+        cmd.contains("drive=oc,bus=sata.0"),
+        "OpenCore should be on sata.0"
+    );
     // Main disk as sata.1
-    assert!(cmd.contains("drive=maindisk,bus=sata.1"), "Main disk should be on sata.1");
+    assert!(
+        cmd.contains("drive=maindisk,bus=sata.1"),
+        "Main disk should be on sata.1"
+    );
     // Should NOT have -bios "$ROM" (OpenCore is an AHCI drive, not a BIOS)
-    assert!(!cmd.contains("-bios \"$ROM\""), "Should NOT use -bios for macOS UEFI with OpenCore");
+    assert!(
+        !cmd.contains("-bios \"$ROM\""),
+        "Should NOT use -bios for macOS UEFI with OpenCore"
+    );
 }
 
 #[test]
 fn test_macos_recovery_image_qcow2_on_ahci() {
     let config = macos_uefi_config();
     let cmd = build_qemu_command_with_os(
-        &config, "disk.qcow2", &InstallMedia::RecoveryImage(None), Some("macos-sonoma"), None
+        &config,
+        "disk.qcow2",
+        &InstallMedia::RecoveryImage(None),
+        Some("macos-sonoma"),
+        None,
     );
 
     // Recovery image on AHCI bus (no format= so QEMU auto-detects DMG vs qcow2)
-    assert!(cmd.contains("if=none,id=recovery"), "Recovery should be on AHCI bus");
-    assert!(!cmd.contains("format=qcow2,if=none,id=recovery"), "Recovery should NOT hardcode format (auto-detect)");
-    assert!(cmd.contains("bus=sata.2"), "Recovery should be on sata.2 (after OpenCore on sata.0 and disk on sata.1)");
-    assert!(!cmd.contains("-boot d"), "Should NOT boot from recovery directly (OpenCore handles it)");
+    assert!(
+        cmd.contains("if=none,id=recovery"),
+        "Recovery should be on AHCI bus"
+    );
+    assert!(
+        !cmd.contains("format=qcow2,if=none,id=recovery"),
+        "Recovery should NOT hardcode format (auto-detect)"
+    );
+    assert!(
+        cmd.contains("bus=sata.2"),
+        "Recovery should be on sata.2 (after OpenCore on sata.0 and disk on sata.1)"
+    );
+    assert!(
+        !cmd.contains("-boot d"),
+        "Should NOT boot from recovery directly (OpenCore handles it)"
+    );
 }
 
 #[test]
 fn test_macos_spice_audio() {
     let config = macos_uefi_config();
-    let cmd = build_qemu_command_with_os(&config, "disk.qcow2", &InstallMedia::None, Some("macos-sonoma"), None);
+    let cmd = build_qemu_command_with_os(
+        &config,
+        "disk.qcow2",
+        &InstallMedia::None,
+        Some("macos-sonoma"),
+        None,
+    );
 
-    assert!(cmd.contains("-audiodev spice,id=audio0"), "Should use spice audio backend with spice-app display");
-    assert!(!cmd.contains("-audiodev pa,id=audio0"), "Should NOT use pa audio with spice-app display");
+    assert!(
+        cmd.contains("-audiodev spice,id=audio0"),
+        "Should use spice audio backend with spice-app display"
+    );
+    assert!(
+        !cmd.contains("-audiodev pa,id=audio0"),
+        "Should NOT use pa audio with spice-app display"
+    );
 }
 
 #[test]
 fn test_macos_usb_kbd() {
     let config = macos_uefi_config();
-    let cmd = build_qemu_command_with_os(&config, "disk.qcow2", &InstallMedia::None, Some("macos-sonoma"), None);
+    let cmd = build_qemu_command_with_os(
+        &config,
+        "disk.qcow2",
+        &InstallMedia::None,
+        Some("macos-sonoma"),
+        None,
+    );
 
-    assert!(cmd.contains("-device usb-kbd"), "Should include USB keyboard for macOS");
-    assert!(cmd.contains("-device usb-tablet"), "Should also include USB tablet");
+    assert!(
+        cmd.contains("-device usb-kbd"),
+        "Should include USB keyboard for macOS"
+    );
+    assert!(
+        cmd.contains("-device usb-tablet"),
+        "Should also include USB tablet"
+    );
 }
 
 #[test]
@@ -439,38 +622,87 @@ fn test_ppc_macos_no_smc() {
         ..Default::default()
     };
 
-    let cmd = build_qemu_command_with_os(&config, "disk.qcow2", &InstallMedia::None, Some("mac-osx-tiger"), None);
+    let cmd = build_qemu_command_with_os(
+        &config,
+        "disk.qcow2",
+        &InstallMedia::None,
+        Some("mac-osx-tiger"),
+        None,
+    );
 
-    assert!(!cmd.contains("applesmc"), "PPC macOS should NOT have Apple SMC");
-    assert!(!cmd.contains("-smbios type=2"), "PPC macOS should NOT have SMBIOS type=2");
-    assert!(!cmd.contains("usb-kbd"), "PPC macOS should NOT have USB keyboard");
+    assert!(
+        !cmd.contains("applesmc"),
+        "PPC macOS should NOT have Apple SMC"
+    );
+    assert!(
+        !cmd.contains("-smbios type=2"),
+        "PPC macOS should NOT have SMBIOS type=2"
+    );
+    assert!(
+        !cmd.contains("usb-kbd"),
+        "PPC macOS should NOT have USB keyboard"
+    );
 }
 
 #[test]
 fn test_non_macos_unchanged() {
     // Linux VM should not get any macOS-specific args
     let config = WizardQemuConfig::default();
-    let cmd = build_qemu_command_with_os(&config, "disk.qcow2", &InstallMedia::None, Some("ubuntu-24-04"), None);
+    let cmd = build_qemu_command_with_os(
+        &config,
+        "disk.qcow2",
+        &InstallMedia::None,
+        Some("ubuntu-24-04"),
+        None,
+    );
 
-    assert!(!cmd.contains("applesmc"), "Linux VM should NOT have Apple SMC");
-    assert!(!cmd.contains("-smbios type=2"), "Linux VM should NOT have SMBIOS type=2");
-    assert!(!cmd.contains("usb-kbd"), "Linux VM should NOT have USB keyboard");
-    assert!(!cmd.contains("ich9-ahci"), "Linux VM should NOT have explicit AHCI controller");
+    assert!(
+        !cmd.contains("applesmc"),
+        "Linux VM should NOT have Apple SMC"
+    );
+    assert!(
+        !cmd.contains("-smbios type=2"),
+        "Linux VM should NOT have SMBIOS type=2"
+    );
+    assert!(
+        !cmd.contains("usb-kbd"),
+        "Linux VM should NOT have USB keyboard"
+    );
+    assert!(
+        !cmd.contains("ich9-ahci"),
+        "Linux VM should NOT have explicit AHCI controller"
+    );
     // Default config includes audio, so pa backend should be used (not spice)
-    assert!(cmd.contains("-audiodev pa,id=audio0"), "Linux VM should use pa audio backend");
-    assert!(!cmd.contains("-audiodev spice"), "Linux VM should NOT use spice audio backend");
+    assert!(
+        cmd.contains("-audiodev pa,id=audio0"),
+        "Linux VM should use pa audio backend"
+    );
+    assert!(
+        !cmd.contains("-audiodev spice"),
+        "Linux VM should NOT use spice audio backend"
+    );
 }
 
 #[test]
 fn test_macos_uefi_iso_no_boot_d() {
     let config = macos_uefi_config();
     let cmd = build_qemu_command_with_os(
-        &config, "disk.qcow2", &InstallMedia::Iso(None), Some("macos-sonoma"), None
+        &config,
+        "disk.qcow2",
+        &InstallMedia::Iso(None),
+        Some("macos-sonoma"),
+        None,
     );
 
     // macOS UEFI should attach ISO on AHCI bus and NOT add -boot d
-    assert!(cmd.contains("bus=sata.3"), "ISO should be on sata.3 (after OpenCore.0, disk.1, skipping .2 for recovery)");
-    assert!(!cmd.contains("-boot d"), "macOS UEFI should NOT use -boot d (OpenCore handles boot)");
+    assert!(
+        cmd.contains("bus=sata.3"),
+        "ISO should be on sata.3 (after OpenCore.0, disk.1, skipping .2 for recovery)"
+    );
+    assert!(
+        !cmd.contains("-boot d"),
+        "macOS UEFI should NOT use -boot d (OpenCore handles boot)"
+    );
 }
 
 #[test]
@@ -486,8 +718,14 @@ fn test_macos_opencore_bootloader_check_in_script() {
         None,
     );
 
-    assert!(script.contains("Verify OpenCore bootloader exists"), "Script should verify OpenCore exists");
-    assert!(script.contains("kholia/OSX-KVM"), "Script should mention OSX-KVM download source");
+    assert!(
+        script.contains("Verify OpenCore bootloader exists"),
+        "Script should verify OpenCore exists"
+    );
+    assert!(
+        script.contains("kholia/OSX-KVM"),
+        "Script should mention OSX-KVM download source"
+    );
 }
 
 #[test]
@@ -495,10 +733,22 @@ fn test_macos_non_uefi_uses_bios() {
     // Leopard-era macOS: non-UEFI Intel, with a bios_path should use -bios "$ROM"
     let mut config = macos_non_uefi_config();
     config.bios_path = Some(PathBuf::from("some-rom.bin"));
-    let cmd = build_qemu_command_with_os(&config, "disk.qcow2", &InstallMedia::None, Some("mac-osx-leopard"), None);
+    let cmd = build_qemu_command_with_os(
+        &config,
+        "disk.qcow2",
+        &InstallMedia::None,
+        Some("mac-osx-leopard"),
+        None,
+    );
 
-    assert!(cmd.contains("-bios \"$ROM\""), "Non-UEFI macOS with bios_path should use -bios");
-    assert!(!cmd.contains("ich9-ahci"), "Non-UEFI macOS should NOT use explicit AHCI controller");
+    assert!(
+        cmd.contains("-bios \"$ROM\""),
+        "Non-UEFI macOS with bios_path should use -bios"
+    );
+    assert!(
+        !cmd.contains("ich9-ahci"),
+        "Non-UEFI macOS should NOT use explicit AHCI controller"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -512,12 +762,19 @@ impl TestVmDir {
         static SEQ: AtomicU64 = AtomicU64::new(0);
         let seq = SEQ.fetch_add(1, Ordering::Relaxed);
         let mut dir = std::env::temp_dir();
-        dir.push(format!("vm-curator-test-{}-{}-{}", name, std::process::id(), seq));
+        dir.push(format!(
+            "vm-curator-test-{}-{}-{}",
+            name,
+            std::process::id(),
+            seq
+        ));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         TestVmDir(dir)
     }
-    fn path(&self) -> &Path { &self.0 }
+    fn path(&self) -> &Path {
+        &self.0
+    }
 }
 impl Drop for TestVmDir {
     fn drop(&mut self) {
@@ -562,7 +819,11 @@ fn test_update_network_in_script_inserts_into_all_branches() {
     // MAC must rewrite the network args in every case branch, not just the
     // first one (--install).
     let vm = TestVmDir::new("issue38-bridge");
-    std::fs::write(vm.path().join("launch.sh"), fixture_launch_sh_five_branch_user_net()).unwrap();
+    std::fs::write(
+        vm.path().join("launch.sh"),
+        fixture_launch_sh_five_branch_user_net(),
+    )
+    .unwrap();
 
     update_network_in_script(
         vm.path(),
@@ -576,21 +837,44 @@ fn test_update_network_in_script_inserts_into_all_branches() {
 
     let updated = std::fs::read_to_string(vm.path().join("launch.sh")).unwrap();
 
-    let netdev_count = updated.matches("-netdev bridge,id=net0,br=nm-bridge").count();
-    assert_eq!(netdev_count, 5, "expected -netdev in all 5 case branches, got {netdev_count}\n---\n{updated}");
+    let netdev_count = updated
+        .matches("-netdev bridge,id=net0,br=nm-bridge")
+        .count();
+    assert_eq!(
+        netdev_count, 5,
+        "expected -netdev in all 5 case branches, got {netdev_count}\n---\n{updated}"
+    );
 
     let device_count = updated
         .matches("-device virtio-net-pci,netdev=net0,mac=52:54:00:12:34:56")
         .count();
-    assert_eq!(device_count, 5, "expected -device with MAC in all 5 case branches, got {device_count}\n---\n{updated}");
+    assert_eq!(
+        device_count, 5,
+        "expected -device with MAC in all 5 case branches, got {device_count}\n---\n{updated}"
+    );
 
     // No stray remnants of the original user-mode backend.
-    assert!(!updated.contains("-netdev user,id=net0"), "old user-mode -netdev not stripped:\n{updated}");
+    assert!(
+        !updated.contains("-netdev user,id=net0"),
+        "old user-mode -netdev not stripped:\n{updated}"
+    );
 
     // Non-network args surrounding the network block must survive the rewrite.
-    assert_eq!(updated.matches("-usb").count(), 5, "trailing -usb arg must survive in all 5 branches:\n{updated}");
-    assert_eq!(updated.matches("-device usb-tablet").count(), 5, "trailing -device usb-tablet must survive in all 5 branches:\n{updated}");
-    assert_eq!(updated.matches("-device intel-hda").count(), 5, "preceding -device intel-hda must survive in all 5 branches:\n{updated}");
+    assert_eq!(
+        updated.matches("-usb").count(),
+        5,
+        "trailing -usb arg must survive in all 5 branches:\n{updated}"
+    );
+    assert_eq!(
+        updated.matches("-device usb-tablet").count(),
+        5,
+        "trailing -device usb-tablet must survive in all 5 branches:\n{updated}"
+    );
+    assert_eq!(
+        updated.matches("-device intel-hda").count(),
+        5,
+        "preceding -device intel-hda must survive in all 5 branches:\n{updated}"
+    );
 }
 
 #[test]
@@ -599,13 +883,25 @@ fn test_update_network_in_script_strips_when_model_none() {
     // leave each branch's qemu command syntactically valid (no dangling
     // backslash-continuations that would swallow `;;`).
     let vm = TestVmDir::new("issue38-none");
-    std::fs::write(vm.path().join("launch.sh"), fixture_launch_sh_five_branch_user_net()).unwrap();
+    std::fs::write(
+        vm.path().join("launch.sh"),
+        fixture_launch_sh_five_branch_user_net(),
+    )
+    .unwrap();
 
     update_network_in_script(vm.path(), "none", "user", None, &[], None).unwrap();
 
     let updated = std::fs::read_to_string(vm.path().join("launch.sh")).unwrap();
-    assert_eq!(updated.matches("-netdev").count(), 0, "no -netdev lines should remain:\n{updated}");
-    assert_eq!(updated.matches("virtio-net-pci").count(), 0, "no -device virtio-net-pci lines should remain:\n{updated}");
+    assert_eq!(
+        updated.matches("-netdev").count(),
+        0,
+        "no -netdev lines should remain:\n{updated}"
+    );
+    assert_eq!(
+        updated.matches("virtio-net-pci").count(),
+        0,
+        "no -device virtio-net-pci lines should remain:\n{updated}"
+    );
 
     // Every line that immediately precedes a `;;` terminator must end without
     // a trailing backslash, otherwise bash would parse `;;` as a continuation.
@@ -635,17 +931,15 @@ fn test_update_network_in_script_originally_no_network_falls_back() {
         .join("\n");
     std::fs::write(vm.path().join("launch.sh"), stripped).unwrap();
 
-    update_network_in_script(
-        vm.path(),
-        "virtio",
-        "bridge",
-        Some("qemubr0"),
-        &[],
-        None,
-    )
-    .unwrap();
+    update_network_in_script(vm.path(), "virtio", "bridge", Some("qemubr0"), &[], None).unwrap();
 
     let updated = std::fs::read_to_string(vm.path().join("launch.sh")).unwrap();
-    assert!(updated.contains("-netdev bridge,id=net0,br=qemubr0"), "fallback should still inject -netdev:\n{updated}");
-    assert!(updated.contains("-device virtio-net-pci,netdev=net0"), "fallback should still inject -device:\n{updated}");
+    assert!(
+        updated.contains("-netdev bridge,id=net0,br=qemubr0"),
+        "fallback should still inject -netdev:\n{updated}"
+    );
+    assert!(
+        updated.contains("-device virtio-net-pci,netdev=net0"),
+        "fallback should still inject -device:\n{updated}"
+    );
 }

--- a/src/vm/tests/discovery.rs
+++ b/src/vm/tests/discovery.rs
@@ -36,19 +36,40 @@ fn test_linux_display_names() {
     assert_eq!(format_os_display_name("linux-arch"), "Arch Linux (rolling)");
     assert_eq!(format_os_display_name("linux-ubuntu-2404"), "Ubuntu 2404");
     // SuSE naming
-    assert_eq!(format_os_display_name("linux-suse"), "openSUSE Tumbleweed (rolling)");
+    assert_eq!(
+        format_os_display_name("linux-suse"),
+        "openSUSE Tumbleweed (rolling)"
+    );
     assert_eq!(format_os_display_name("linux-suse-7"), "SuSE Linux 7");
-    assert_eq!(format_os_display_name("linux-opensuse-leap-15"), "openSUSE Leap 15");
+    assert_eq!(
+        format_os_display_name("linux-opensuse-leap-15"),
+        "openSUSE Leap 15"
+    );
 }
 
 #[test]
 fn test_linux_display_names_with_suffix() {
     // Rolling distros with numeric suffixes should display the same as originals
-    assert_eq!(format_os_display_name("linux-cachyos-2"), "CachyOS (rolling)");
-    assert_eq!(format_os_display_name("linux-cachyos-3"), "CachyOS (rolling)");
-    assert_eq!(format_os_display_name("linux-arch-2"), "Arch Linux (rolling)");
-    assert_eq!(format_os_display_name("linux-gentoo-2"), "Gentoo Linux (rolling)");
-    assert_eq!(format_os_display_name("linux-manjaro-3"), "Manjaro Linux (rolling)");
+    assert_eq!(
+        format_os_display_name("linux-cachyos-2"),
+        "CachyOS (rolling)"
+    );
+    assert_eq!(
+        format_os_display_name("linux-cachyos-3"),
+        "CachyOS (rolling)"
+    );
+    assert_eq!(
+        format_os_display_name("linux-arch-2"),
+        "Arch Linux (rolling)"
+    );
+    assert_eq!(
+        format_os_display_name("linux-gentoo-2"),
+        "Gentoo Linux (rolling)"
+    );
+    assert_eq!(
+        format_os_display_name("linux-manjaro-3"),
+        "Manjaro Linux (rolling)"
+    );
     // Versioned distros keep version numbers (which may look like suffixes)
     assert_eq!(format_os_display_name("linux-fedora-2"), "Fedora Linux 2");
     assert_eq!(format_os_display_name("linux-ubuntu-2"), "Ubuntu 2");

--- a/src/vm/tests/import.rs
+++ b/src/vm/tests/import.rs
@@ -223,6 +223,71 @@ fn test_convert_memory_to_kib() {
 }
 
 #[test]
+fn test_parse_libvirt_xml_name_falls_back_to_file_stem() {
+    // No <name> element: the VM name should derive from the config file stem.
+    let xml = r#"
+<domain type='qemu'>
+  <memory unit='MiB'>1024</memory>
+  <vcpu>1</vcpu>
+  <os>
+    <type arch='x86_64'>hvm</type>
+  </os>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+  </devices>
+</domain>
+"#;
+
+    let vm = parse_libvirt_xml_str(xml, Path::new("/etc/libvirt/qemu/my-domain.xml")).unwrap();
+    assert_eq!(vm.name, "my-domain");
+    // domain type 'qemu' is supported but not KVM.
+    assert!(!vm.qemu_config.enable_kvm);
+    assert_eq!(vm.qemu_config.cpu_model, None);
+    assert_eq!(vm.qemu_config.memory_mb, 1024);
+}
+
+#[test]
+fn test_parse_libvirt_xml_multiple_disks_skips_sourceless() {
+    // Three <disk> elements but the middle one has no <source>; it must be
+    // skipped so disk order and bus mapping stay aligned.
+    let xml = r#"
+<domain type='kvm'>
+  <name>multi-disk</name>
+  <memory unit='KiB'>1048576</memory>
+  <vcpu>2</vcpu>
+  <os>
+    <type arch='x86_64'>hvm</type>
+  </os>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type='file' device='disk'>
+      <source file='/images/a.qcow2'/>
+      <target dev='vda' bus='virtio'/>
+    </disk>
+    <disk type='file' device='cdrom'>
+      <target dev='sdb' bus='sata'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <source file='/images/c.qcow2'/>
+      <target dev='vdc' bus='scsi'/>
+    </disk>
+  </devices>
+</domain>
+"#;
+
+    let vm = parse_libvirt_xml_str(xml, Path::new("/test.xml")).unwrap();
+    assert_eq!(
+        vm.disk_paths,
+        vec![
+            PathBuf::from("/images/a.qcow2"),
+            PathBuf::from("/images/c.qcow2"),
+        ]
+    );
+    // disk_interface comes from the first disk's bus (virtio).
+    assert_eq!(vm.qemu_config.disk_interface, "virtio");
+}
+
+#[test]
 fn test_parse_libvirt_xml_with_tpm() {
     let xml = r#"
 <domain type='kvm'>

--- a/src/vm/tests/import.rs
+++ b/src/vm/tests/import.rs
@@ -131,11 +131,8 @@ boot="efi"
 tpm="on"
 "#;
 
-    let vm = parse_quickemu_conf_str(
-        conf,
-        Path::new("/home/user/quickemu/ubuntu-22.04.conf"),
-    )
-    .unwrap();
+    let vm =
+        parse_quickemu_conf_str(conf, Path::new("/home/user/quickemu/ubuntu-22.04.conf")).unwrap();
 
     assert_eq!(vm.name, "ubuntu-22.04");
     assert_eq!(vm.qemu_config.memory_mb, 4096);

--- a/src/vm/tests/launch_parser.rs
+++ b/src/vm/tests/launch_parser.rs
@@ -21,14 +21,8 @@ fn test_extract_emulator() {
 
 #[test]
 fn test_extract_vga() {
-    assert_eq!(
-        extract_vga("-vga cirrus -m 512"),
-        Some(VgaType::Cirrus)
-    );
-    assert_eq!(
-        extract_vga("-vga virtio"),
-        Some(VgaType::Virtio)
-    );
+    assert_eq!(extract_vga("-vga cirrus -m 512"), Some(VgaType::Cirrus));
+    assert_eq!(extract_vga("-vga virtio"), Some(VgaType::Virtio));
 }
 
 #[test]
@@ -63,14 +57,16 @@ fn test_extract_port_forwards() {
 
 #[test]
 fn test_extract_network_passt() {
-    let content = "qemu-system-x86_64 \\\n  -netdev passt,id=net0 \\\n  -device virtio-net-pci,netdev=net0";
+    let content =
+        "qemu-system-x86_64 \\\n  -netdev passt,id=net0 \\\n  -device virtio-net-pci,netdev=net0";
     let config = extract_network(content).unwrap();
     assert_eq!(config.backend, NetworkBackend::Passt);
 }
 
 #[test]
 fn test_extract_network_bridge() {
-    let content = "qemu-system-x86_64 \\\n  -netdev bridge,id=net0,br=virbr0 \\\n  -device e1000,netdev=net0";
+    let content =
+        "qemu-system-x86_64 \\\n  -netdev bridge,id=net0,br=virbr0 \\\n  -device e1000,netdev=net0";
     let config = extract_network(content).unwrap();
     assert_eq!(config.backend, NetworkBackend::Bridge("virbr0".to_string()));
     assert_eq!(config.bridge, Some("virbr0".to_string()));
@@ -177,7 +173,12 @@ qemu-system-m68k \
     let config = parse_launch_script(&script_path, content).unwrap();
     assert!(config.bios_path.is_some(), "Should have bios_path");
     assert!(
-        config.bios_path.as_ref().unwrap().to_string_lossy().contains("MacROM.bin"),
+        config
+            .bios_path
+            .as_ref()
+            .unwrap()
+            .to_string_lossy()
+            .contains("MacROM.bin"),
         "bios_path should contain MacROM.bin"
     );
     // Should NOT trigger UEFI detection

--- a/src/vm/tests/lifecycle.rs
+++ b/src/vm/tests/lifecycle.rs
@@ -132,11 +132,20 @@ fn test_insert_section_before_case_statement() {
     // Section must appear before the case statement
     let marker_pos = result.find(SHARED_FOLDERS_MARKER_START).unwrap();
     let case_pos = result.find("case \"$1\"").unwrap();
-    assert!(marker_pos < case_pos, "Section must be before case statement, got marker at {} and case at {}", marker_pos, case_pos);
+    assert!(
+        marker_pos < case_pos,
+        "Section must be before case statement, got marker at {} and case at {}",
+        marker_pos,
+        case_pos
+    );
 
     // Both QEMU commands should have $SHARED_FOLDERS_ARGS appended
     let count = result.matches("$SHARED_FOLDERS_ARGS").count();
-    assert_eq!(count, 2, "Expected 2 appended refs (one per QEMU command), got {}", count);
+    assert_eq!(
+        count, 2,
+        "Expected 2 appended refs (one per QEMU command), got {}",
+        count
+    );
 }
 
 #[test]
@@ -168,7 +177,10 @@ fn test_shell_escape_safe() {
 
 #[test]
 fn test_shell_escape_special() {
-    assert_eq!(shell_escape("/home/user/My Documents"), "'/home/user/My Documents'");
+    assert_eq!(
+        shell_escape("/home/user/My Documents"),
+        "'/home/user/My Documents'"
+    );
     assert_eq!(shell_escape("path with spaces"), "'path with spaces'");
 }
 
@@ -181,7 +193,9 @@ fn test_detect_qemu_processes_parsing() {
     let mut cmdlines = Vec::new();
     for line in output.lines() {
         let line = line.trim();
-        if line.is_empty() { continue; }
+        if line.is_empty() {
+            continue;
+        }
         if let Some(space_pos) = line.find(' ') {
             if let Ok(pid) = line[..space_pos].parse::<u32>() {
                 pids.push(pid);
@@ -234,7 +248,10 @@ fn test_parse_pci_section_with_multifunction() {
     );
     let args = parse_pci_section(&content);
     assert_eq!(args.len(), 1);
-    assert_eq!(args[0], "-device vfio-pci,host=0000:01:00.0,multifunction=on");
+    assert_eq!(
+        args[0],
+        "-device vfio-pci,host=0000:01:00.0,multifunction=on"
+    );
 }
 
 #[test]
@@ -260,6 +277,9 @@ fn test_parse_pci_section_with_vfio_bind_functions() {
     );
     let args = parse_pci_section(&content);
     assert_eq!(args.len(), 2);
-    assert_eq!(args[0], "-device vfio-pci,host=0000:10:00.0,multifunction=on");
+    assert_eq!(
+        args[0],
+        "-device vfio-pci,host=0000:10:00.0,multifunction=on"
+    );
     assert_eq!(args[1], "-device vfio-pci,host=0000:10:00.1");
 }

--- a/src/wizard_types.rs
+++ b/src/wizard_types.rs
@@ -189,6 +189,10 @@ impl WizardQemuConfig {
 }
 
 /// Custom OS entry for when user selects "Other"
+///
+/// Some fields below are `#[allow(dead_code)]`: they are captured by the entry
+/// form but not yet consumed, reserved for the planned "save custom OS to user
+/// metadata" feature. They are intentional, not dead.
 #[derive(Debug, Clone, Default)]
 pub struct CustomOsEntry {
     pub id: String,
@@ -246,6 +250,7 @@ pub struct CreateWizardState {
     pub qemu_config: WizardQemuConfig,
     pub auto_launch: bool,
     pub field_focus: usize,
+    // Reserved for planned scroll/category-aware OS picker UI; not read yet.
     #[allow(dead_code)]
     pub os_list_scroll: usize,
     pub os_filter: String,

--- a/src/wizard_types.rs
+++ b/src/wizard_types.rs
@@ -1,9 +1,9 @@
 //! Wizard and import state types, extracted from app.rs so they can be
 //! exposed via the library target without pulling in the TUI (ratatui/crossterm).
 
-use std::path::PathBuf;
-use anyhow::Result;
 use crate::vm::qemu_config::{PortForward, PortProtocol};
+use anyhow::Result;
+use std::path::PathBuf;
 
 /// Action to take with an existing disk when using it for a new VM
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -156,9 +156,10 @@ impl Default for WizardQemuConfig {
 impl WizardQemuConfig {
     /// Create from a QEMU profile
     pub fn from_profile(profile: &crate::metadata::QemuProfile) -> Self {
-        let gl_acceleration = profile.extra_args.iter().any(|arg|
-            arg.contains("virtio-vga-gl") || arg.contains("gl=on")
-        );
+        let gl_acceleration = profile
+            .extra_args
+            .iter()
+            .any(|arg| arg.contains("virtio-vga-gl") || arg.contains("gl=on"));
 
         Self {
             emulator: profile.emulator.clone(),
@@ -281,10 +282,7 @@ impl Default for CreateWizardState {
             os_list_scroll: 0,
             os_filter: String::new(),
             selected_category: 0,
-            expanded_categories: vec![
-                "windows".to_string(),
-                "linux".to_string(),
-            ],
+            expanded_categories: vec!["windows".to_string(), "linux".to_string()],
             os_list_selected: 0,
             error_message: None,
             editing_field: None,


### PR DESCRIPTION
## Context

Prep work to make the project releasable as **v1.0.0**. The codebase itself was already solid (consistent `anyhow` error handling, input validation, shell-escaping); the gaps were in release engineering. This PR closes them. No behavior changes for existing users.

## What's in here

- **CI quality gates** — new `.github/workflows/ci.yml` runs `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --locked`, and `cargo audit` on every push/PR. Previously the only workflow fired on tag push and just packaged — nothing gated regular commits.
- **Toolchain pin** — `rust-toolchain.toml` (stable + clippy/rustfmt); dropped the unenforced "Rust 1.70+" README claim.
- **Lint clean-up** — `#![warn(clippy::all)]`, all `-D warnings` findings fixed, whole tree `cargo fmt`-clean (the bulk fmt is isolated in its own commit). `clippy::collapsible_match` is allowed crate-wide with a documented rationale (TUI dispatch readability).
- **Test coverage** — new tests for `qemu-img` format-JSON parsing and `Config` load/save (round-trip, partial/malformed TOML) via new path-parameterized `Config::load_from`/`save_to`. (`cargo audit` was clean: 0 advisories.)
- **Import-parser refactor** — the ~360-line `parse_libvirt_xml_str` split into a `LibvirtParse` state struct + focused helpers. Behavior-preserving; existing import tests pass unchanged, plus new regression tests.
- **Docs** — crate-level public-API docs, module docs for `app`/`ui`, clarified intentional `dead_code`; `cargo doc` warning-free.
- **CHANGELOG** — v1.0.0 entry added.

## Verification

Local, matching the new CI gates:
- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets --locked -- -D warnings` ✅
- `cargo test --locked` ✅ (152 tests, up from 138)
- `cargo build --release --locked` ✅
- `cargo fetch --locked` ✅ (lockfile gate parity)
- `cargo doc --no-deps --lib` ✅ (no warnings)

## Note on the release

This PR does **not** cut the release. After merge + green CI on `main`, the version bump + tag + crates.io publish is done via `scripts/release.sh 1.0.0`, followed by the manual AUR update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)