### PR TITLE
ci: stop publishing appimagetool as a release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: appimage
-          path: "*.AppImage"
+          # Scope to our artifact so the downloaded appimagetool-x86_64.AppImage
+          # build tool isn't published as a release asset.
+          path: "vm-curator-*.AppImage"
 
   release:
     needs: [build-linux, build-appimage]


### PR DESCRIPTION
## Problem

The v1.0.0 GitHub release shipped a stray `appimagetool-x86_64.AppImage` asset alongside the real `vm-curator-v1.0.0-x86_64.AppImage`. The `build-appimage` job downloads `appimagetool-x86_64.AppImage` into the workspace to build the AppImage, and the upload step then globbed `path: "*.AppImage"` — which matched both files.

## Fix

Scope the upload glob to `vm-curator-*.AppImage` so only our artifact is published.

## Notes
- One-line workflow change; no effect on the binary, deb, rpm, or tarball assets.
- Takes effect on the next release tag. The stray asset already attached to the v1.0.0 release can be deleted separately (`gh release delete-asset v1.0.0 appimagetool-x86_64.AppImage`) if desired — not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)