### PR TITLE
Fix CI rustfmt gate on main

### DIFF
--- a/src/vm/single_gpu_scripts.rs
+++ b/src/vm/single_gpu_scripts.rs
@@ -1425,7 +1425,10 @@ mod tests {
     #[test]
     fn append_keeps_qmp_value_intact() {
         let qemu_cmd = "qemu-system-x86_64 \\\n        -m 2048 \\\n        -qmp \\\n        unix:$VM_DIR/qemu.sock,server=on,wait=off";
-        let result = append_passthrough_args(qemu_cmd, "-device vfio-pci,host=01:00.0,multifunction=on \\\n    -display none");
+        let result = append_passthrough_args(
+            qemu_cmd,
+            "-device vfio-pci,host=01:00.0,multifunction=on \\\n    -display none",
+        );
 
         // The QMP value must survive...
         assert!(

--- a/src/vm/tests/create.rs
+++ b/src/vm/tests/create.rs
@@ -631,7 +631,10 @@ fn test_spice_agent_channel_with_gl_acceleration() {
     let cmd = build_qemu_command_with_os(&config, "disk.qcow2", &InstallMedia::None, None, None);
 
     assert!(cmd.contains("-device virtio-vga-gl"), "GL device present");
-    assert!(cmd.contains("-display spice-app,gl=on"), "gl display present");
+    assert!(
+        cmd.contains("-display spice-app,gl=on"),
+        "gl display present"
+    );
     for arg in SPICE_AGENT_ARGS {
         assert!(cmd.contains(arg), "agent arg `{}` present with GL", arg);
     }
@@ -648,7 +651,10 @@ fn test_set_spice_agent_args_add_remove_roundtrip() {
     }
     let display_idx = enabled.find("-display gtk").unwrap();
     let agent_idx = enabled.find(SPICE_AGENT_ARGS[0]).unwrap();
-    assert!(agent_idx > display_idx, "agent args inserted after -display");
+    assert!(
+        agent_idx > display_idx,
+        "agent args inserted after -display"
+    );
 
     // Enabling again must not duplicate.
     let enabled_twice = set_spice_agent_args(&enabled, true);


### PR DESCRIPTION
## Summary

`main` is red on the **Check formatting** CI step (`cargo fmt --check`). The SPICE clipboard (#41) and single-GPU QMP (#48) test additions were merged unformatted — `cargo build`/`cargo test` don't run rustfmt, so the violations passed local checks but failed the CI fmt gate.

This applies `cargo fmt` to the two affected test files. No behavior change — only line reflowing of `assert!` / function-call arguments.

## Verification

All three CI gates pass locally:
- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 147 + 160 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)