### PR TITLE
Support raw disk image creation and import

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A fast and friendly Rust TUI for managing desktop QEMU/KVM virtual machines — 
 - 120+ pre-configured OS profiles with optimal QEMU settings (Windows, macOS, Linux, BSD, Unix, retro, and more)
 - Automatic UEFI firmware detection across Linux distributions (Arch, Debian, Fedora, NixOS, etc.)
 - ISO file browser for selecting installation media
-- Configurable disk size, memory, CPU cores, and QEMU options with direct text editing and size suffixes (e.g., "8GB")
+- Configurable disk size/format, memory, CPU cores, and QEMU options with direct text editing and size suffixes (e.g., "8GB")
 - Use existing disk images (copy or move) instead of creating new ones
 - Support for custom OS entries with user metadata
 

--- a/assets/metadata/settings_help.toml
+++ b/assets/metadata/settings_help.toml
@@ -32,8 +32,8 @@ core count minus 1-2 for host stability."""
 [default_disk_size]
 title = "Default Disk Size"
 description = """
-Virtual disk size (in GB). Disks use qcow2 format and grow as needed, \
-so larger sizes don't immediately use space."""
+Virtual disk size (in GB). New VMs default to qcow2, and you can switch \
+the disk format to raw in the creation wizard."""
 
 [default_display]
 title = "Default Display"

--- a/src/app.rs
+++ b/src/app.rs
@@ -230,6 +230,8 @@ pub struct App {
     pub shared_folders_help: SharedFoldersHelpStore,
     /// VM creation wizard state
     pub wizard_state: Option<CreateWizardState>,
+    /// Selected disk image format for the VM creation wizard
+    pub create_wizard_disk_format: DiskImageFormat,
     /// VM import wizard state
     pub import_state: Option<ImportWizardState>,
     /// Settings screen selected item
@@ -431,6 +433,7 @@ impl App {
             settings_help,
             shared_folders_help,
             wizard_state: None,
+            create_wizard_disk_format: DiskImageFormat::default(),
             import_state: None,
             settings_selected: 0,
             settings_editing: false,
@@ -966,7 +969,9 @@ impl App {
         let extensions: &[&str] = match mode {
             FileBrowserMode::Iso => &[".iso", ".ISO"],
             FileBrowserMode::RecoveryImage => &[".dmg", ".DMG", ".qcow2", ".QCOW2"],
-            FileBrowserMode::Disk => &[".qcow2", ".QCOW2", ".qcow", ".QCOW"],
+            FileBrowserMode::Disk => &[
+                ".qcow2", ".QCOW2", ".qcow", ".QCOW", ".raw", ".RAW", ".img", ".IMG",
+            ],
             FileBrowserMode::Directory => &[],
             FileBrowserMode::ImportConfig => &[".xml", ".XML", ".conf"],
             FileBrowserMode::Bios => &[
@@ -1186,6 +1191,7 @@ impl App {
 
     /// Start the VM creation wizard
     pub fn start_create_wizard(&mut self) {
+        self.create_wizard_disk_format = DiskImageFormat::default();
         let state = CreateWizardState {
             disk_size_gb: self.config.default_disk_size_gb,
             qemu_config: WizardQemuConfig {

--- a/src/commands/qemu_img.rs
+++ b/src/commands/qemu_img.rs
@@ -14,9 +14,14 @@ fn path_to_str(path: &Path) -> Result<&str> {
 
 /// Create a new qcow2 disk image
 pub fn create_disk(path: &Path, size: &str) -> Result<()> {
+    create_disk_with_format(path, "qcow2", size)
+}
+
+/// Create a new disk image in the requested qemu-img format
+pub fn create_disk_with_format(path: &Path, format: &str, size: &str) -> Result<()> {
     let path_str = path_to_str(path)?;
     let output = Command::new("qemu-img")
-        .args(["create", "-f", "qcow2", path_str, size])
+        .args(["create", "-f", format, path_str, size])
         .output()
         .context("Failed to run qemu-img create")?;
 

--- a/src/ui/screens/create_wizard.rs
+++ b/src/ui/screens/create_wizard.rs
@@ -10,9 +10,11 @@ use ratatui::{
     widgets::{Block, Borders, Clear, Paragraph, Wrap},
 };
 
-use crate::app::{App, WizardField, WizardQemuConfig, WizardStep};
+use crate::app::{
+    App, DiskAction, DiskImageFormat, FileBrowserMode, WizardField, WizardQemuConfig, WizardStep,
+};
 use crate::metadata::QemuProfileStore;
-use crate::vm::create_vm;
+use crate::vm::create::create_vm_with_disk_format;
 
 /// Parse a size string with optional suffix (KB, MB, GB, case-insensitive)
 /// Returns value normalized to target unit.
@@ -1516,8 +1518,10 @@ fn render_step_configure_disk(app: &App, frame: &mut Frame, area: Rect) {
             "[Enter] Done  [Backspace] Delete  [0-9] Enter size"
         } else if state.field_focus == 0 {
             "[←/→] Toggle mode  [j/k] Navigate  [Enter] Next  [Esc] Back"
-        } else {
+        } else if state.field_focus == 1 {
             "[Tab] Edit size  [←/→] Adjust  [Enter] Next  [Esc] Back"
+        } else {
+            "[←/→] Toggle format  [j/k] Navigate  [Enter] Next  [Esc] Back"
         }
     };
     let help = Paragraph::new(help_text)
@@ -1534,6 +1538,8 @@ fn render_new_disk_mode(app: &App, frame: &mut Frame, area: Rect) {
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(3), // Disk size input
+            Constraint::Length(1), // Spacer
+            Constraint::Length(1), // Disk format toggle
             Constraint::Length(1), // Spacer
             Constraint::Min(5),    // Disk info
         ])
@@ -1582,6 +1588,46 @@ fn render_new_disk_mode(app: &App, frame: &mut Frame, area: Rect) {
         .block(size_block);
     frame.render_widget(size_text, sub_chunks[0]);
 
+    let format_focused = state.field_focus == 2;
+    let disk_format = app.create_wizard_disk_format;
+    let qcow2_style = if matches!(disk_format, DiskImageFormat::Qcow2) {
+        Style::default()
+            .fg(Color::Green)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    let raw_style = if matches!(disk_format, DiskImageFormat::Raw) {
+        Style::default()
+            .fg(Color::Green)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    let prefix = if format_focused { "> " } else { "  " };
+    let format_line = Line::from(vec![
+        Span::styled(
+            prefix,
+            if format_focused {
+                Style::default().fg(Color::Yellow)
+            } else {
+                Style::default()
+            },
+        ),
+        Span::styled("Format: ", Style::default().fg(Color::Yellow)),
+        Span::styled("[ ", Style::default()),
+        Span::styled("qcow2", qcow2_style),
+        Span::styled(" ] [ ", Style::default()),
+        Span::styled("raw", raw_style),
+        Span::styled(" ]", Style::default()),
+        if format_focused {
+            Span::styled("  [←/→] toggle", Style::default().fg(Color::DarkGray))
+        } else {
+            Span::raw("")
+        },
+    ]);
+    frame.render_widget(Paragraph::new(format_line), sub_chunks[2]);
+
     // Disk info box
     let info_block = Block::default()
         .title(" Disk Info ")
@@ -1590,18 +1636,18 @@ fn render_new_disk_mode(app: &App, frame: &mut Frame, area: Rect) {
 
     let disk_path = app
         .wizard_vm_path()
-        .map(|p| p.join(format!("{}.qcow2", state.folder_name)))
+        .map(|p| p.join(format!("{}.{}", state.folder_name, disk_format.extension())))
         .map(|p| p.display().to_string())
-        .unwrap_or_else(|| "~/vm-space/<vm-name>/<vm-name>.qcow2".to_string());
+        .unwrap_or_else(|| format!("~/vm-space/<vm-name>/<vm-name>.{}", disk_format.extension()));
 
     let info_text = vec![
         Line::from(vec![
             Span::styled("Format: ", Style::default().fg(Color::Yellow)),
-            Span::raw("qcow2 (copy-on-write, snapshots supported)"),
+            Span::raw(disk_format.description()),
         ]),
         Line::from(vec![
             Span::styled("Type: ", Style::default().fg(Color::Yellow)),
-            Span::raw("Expandable (only uses space as needed)"),
+            Span::raw(disk_format.storage_description()),
         ]),
         Line::from(vec![
             Span::styled("Location: ", Style::default().fg(Color::Yellow)),
@@ -1612,13 +1658,11 @@ fn render_new_disk_mode(app: &App, frame: &mut Frame, area: Rect) {
     let info = Paragraph::new(info_text)
         .block(info_block)
         .wrap(Wrap { trim: false });
-    frame.render_widget(info, sub_chunks[2]);
+    frame.render_widget(info, sub_chunks[4]);
 }
 
 /// Render the "Use Existing" disk mode content
 fn render_existing_disk_mode(app: &App, frame: &mut Frame, area: Rect) {
-    use crate::app::DiskAction;
-
     let state = app.wizard_state.as_ref().unwrap();
 
     let sub_chunks = Layout::default()
@@ -1660,13 +1704,11 @@ fn render_existing_disk_mode(app: &App, frame: &mut Frame, area: Rect) {
         Paragraph::new(display).style(Style::default().fg(Color::Green))
     } else {
         let prefix = if browse_focused { "> " } else { "  " };
-        Paragraph::new(format!("{}( ) Browse for qcow2 disk file...", prefix)).style(
-            if browse_focused {
-                Style::default().fg(Color::Yellow)
-            } else {
-                Style::default().fg(Color::White)
-            },
-        )
+        Paragraph::new(format!("{}( ) Browse for disk image...", prefix)).style(if browse_focused {
+            Style::default().fg(Color::Yellow)
+        } else {
+            Style::default().fg(Color::White)
+        })
     };
     frame.render_widget(browse_text, browse_inner);
 
@@ -1709,7 +1751,7 @@ fn render_existing_disk_mode(app: &App, frame: &mut Frame, area: Rect) {
 
     // Note about renaming
     let note_text = format!(
-        "Note: The disk will be renamed to {}.qcow2",
+        "Note: The disk will be renamed to match its detected format under {}",
         state.folder_name
     );
     let note = Paragraph::new(note_text).style(Style::default().fg(Color::DarkGray));
@@ -1717,8 +1759,6 @@ fn render_existing_disk_mode(app: &App, frame: &mut Frame, area: Rect) {
 }
 
 fn handle_step_configure_disk(app: &mut App, key: KeyEvent) -> Result<()> {
-    use crate::app::{DiskAction, FileBrowserMode};
-
     let (editing, use_existing, field_focus) = app
         .wizard_state
         .as_ref()
@@ -1786,7 +1826,7 @@ fn handle_step_configure_disk(app: &mut App, key: KeyEvent) -> Result<()> {
         }
         KeyCode::Char('j') | KeyCode::Down => {
             if let Some(ref mut state) = app.wizard_state {
-                let max_focus = if state.use_existing_disk { 2 } else { 1 };
+                let max_focus = 2;
                 if state.field_focus < max_focus {
                     state.field_focus += 1;
                 }
@@ -1813,6 +1853,10 @@ fn handle_step_configure_disk(app: &mut App, key: KeyEvent) -> Result<()> {
                         } else {
                             state.disk_size_gb = (state.disk_size_gb + 8).min(10000);
                         }
+                    }
+                    2 if !state.use_existing_disk => {
+                        // Toggle new disk image format
+                        app.create_wizard_disk_format = app.create_wizard_disk_format.toggle();
                     }
                     2 if state.use_existing_disk => {
                         // Toggle copy/move action
@@ -3322,31 +3366,51 @@ fn render_step_confirm(app: &App, frame: &mut Frame, area: Rect) {
         .as_ref()
         .map(|p| p.display().to_string())
         .unwrap_or_else(|| "None".to_string());
+    let disk_summary = if state.use_existing_disk {
+        let action = match state.existing_disk_action {
+            DiskAction::Copy => "copy",
+            DiskAction::Move => "move",
+        };
+        let format = state
+            .existing_disk_path
+            .as_deref()
+            .and_then(DiskImageFormat::from_path)
+            .map(|format| format.label())
+            .unwrap_or("detected");
+        format!("existing disk ({action}, {format})")
+    } else {
+        format!(
+            "{} GB {}",
+            state.disk_size_gb,
+            app.create_wizard_disk_format.summary()
+        )
+    };
 
     let config = &state.qemu_config;
 
-    let mut lines = Vec::new();
-    lines.push(Line::from(vec![
-        Span::styled("VM Name:        ", Style::default().fg(Color::Yellow)),
-        Span::raw(&state.vm_name),
-    ]));
-    lines.push(Line::from(vec![
-        Span::styled("Folder:         ", Style::default().fg(Color::Yellow)),
-        Span::raw(vm_path),
-    ]));
-    lines.push(Line::from(vec![
-        Span::styled("OS Type:        ", Style::default().fg(Color::Yellow)),
-        Span::raw(os_name),
-    ]));
-    lines.push(Line::from(""));
-    lines.push(Line::from(vec![
-        Span::styled("Disk:           ", Style::default().fg(Color::Yellow)),
-        Span::raw(format!("{} GB qcow2 (expandable)", state.disk_size_gb)),
-    ]));
-    lines.push(Line::from(vec![
-        Span::styled("ISO:            ", Style::default().fg(Color::Yellow)),
-        Span::raw(iso_str),
-    ]));
+    let mut lines = vec![
+        Line::from(vec![
+            Span::styled("VM Name:        ", Style::default().fg(Color::Yellow)),
+            Span::raw(&state.vm_name),
+        ]),
+        Line::from(vec![
+            Span::styled("Folder:         ", Style::default().fg(Color::Yellow)),
+            Span::raw(vm_path),
+        ]),
+        Line::from(vec![
+            Span::styled("OS Type:        ", Style::default().fg(Color::Yellow)),
+            Span::raw(os_name),
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("Disk:           ", Style::default().fg(Color::Yellow)),
+            Span::raw(disk_summary),
+        ]),
+        Line::from(vec![
+            Span::styled("ISO:            ", Style::default().fg(Color::Yellow)),
+            Span::raw(iso_str),
+        ]),
+    ];
     if let Some(ref floppy_path) = state.floppy_path {
         lines.push(Line::from(vec![
             Span::styled("Floppy:         ", Style::default().fg(Color::Yellow)),
@@ -3470,7 +3534,7 @@ fn handle_step_confirm(app: &mut App, key: KeyEvent) -> Result<()> {
             let state = app.wizard_state.as_ref().unwrap().clone();
             let vm_name = state.vm_name.clone();
 
-            match create_vm(&library_path, &state) {
+            match create_vm_with_disk_format(&library_path, &state, app.create_wizard_disk_format) {
                 Ok(created) => {
                     // Cancel wizard first (closes screens)
                     app.cancel_wizard();

--- a/src/vm/create.rs
+++ b/src/vm/create.rs
@@ -25,7 +25,7 @@ fn shell_escape(s: &str) -> String {
 
 use crate::commands::qemu_img;
 use crate::vm::qemu_config::{PortForward, PortProtocol};
-use crate::wizard_types::{CreateWizardState, DiskAction, WizardQemuConfig};
+use crate::wizard_types::{CreateWizardState, DiskAction, DiskImageFormat, WizardQemuConfig};
 
 /// Install media type for QEMU command generation
 pub enum InstallMedia<'a> {
@@ -195,7 +195,17 @@ pub struct CreatedVm {
 }
 
 /// Create a new VM from wizard state
+#[allow(dead_code)]
 pub fn create_vm(library_path: &Path, state: &CreateWizardState) -> Result<CreatedVm> {
+    create_vm_with_disk_format(library_path, state, DiskImageFormat::Qcow2)
+}
+
+/// Create a new VM from wizard state using the requested new-disk format.
+pub fn create_vm_with_disk_format(
+    library_path: &Path,
+    state: &CreateWizardState,
+    new_disk_format: DiskImageFormat,
+) -> Result<CreatedVm> {
     // Validate inputs
     if state.vm_name.trim().is_empty() {
         bail!("VM name cannot be empty");
@@ -205,32 +215,38 @@ pub fn create_vm(library_path: &Path, state: &CreateWizardState) -> Result<Creat
     }
 
     // Validate disk configuration
-    if state.use_existing_disk {
-        if state.existing_disk_path.is_none() {
+    let existing_disk_path = if state.use_existing_disk {
+        let Some(path) = state.existing_disk_path.as_ref() else {
             bail!("No existing disk selected");
-        }
-        let path = state.existing_disk_path.as_ref().unwrap();
+        };
         if !path.exists() {
             bail!("Selected disk does not exist: {}", path.display());
         }
-    } else if state.disk_size_gb == 0 {
-        bail!("Disk size must be greater than 0");
-    }
+        Some(path)
+    } else {
+        if state.disk_size_gb == 0 {
+            bail!("Disk size must be greater than 0");
+        }
+        None
+    };
 
     // Create VM directory
     let vm_dir = create_vm_directory(library_path, &state.folder_name)?;
 
     // Create or copy/move disk image
-    let disk_filename = format!("{}.qcow2", state.folder_name);
-    let disk_path = if state.use_existing_disk {
+    let disk_format = existing_disk_path
+        .map(|path| detect_existing_disk_image_format(path))
+        .unwrap_or(new_disk_format);
+    let disk_filename = format!("{}.{}", state.folder_name, disk_format.extension());
+    let disk_path = if let Some(existing_disk_path) = existing_disk_path {
         handle_existing_disk(
             &vm_dir,
             &disk_filename,
-            state.existing_disk_path.as_ref().unwrap(),
+            existing_disk_path,
             &state.existing_disk_action,
         )?
     } else {
-        create_disk_image(&vm_dir, &disk_filename, state.disk_size_gb)?
+        create_disk_image_with_format(&vm_dir, &disk_filename, state.disk_size_gb, disk_format)?
     };
 
     // Copy BIOS/ROM file to VM directory if provided
@@ -271,6 +287,14 @@ pub fn create_vm(library_path: &Path, state: &CreateWizardState) -> Result<Creat
         launch_script: launch_script_path,
         disk_image: disk_path,
     })
+}
+
+pub(crate) fn detect_existing_disk_image_format(path: &Path) -> DiskImageFormat {
+    qemu_img::detect_disk_format(path)
+        .as_deref()
+        .and_then(DiskImageFormat::from_qemu_format)
+        .or_else(|| DiskImageFormat::from_path(path))
+        .unwrap_or(DiskImageFormat::Qcow2)
 }
 
 /// Handle an existing disk by copying or moving it to the VM directory
@@ -368,13 +392,29 @@ pub fn create_vm_directory(library_path: &Path, folder_name: &str) -> Result<Pat
     Ok(vm_dir)
 }
 
-/// Create a new qcow2 disk image
+/// Create a new qcow2 disk image.
+#[allow(dead_code)]
 pub fn create_disk_image(vm_dir: &Path, filename: &str, size_gb: u32) -> Result<PathBuf> {
+    create_disk_image_with_format(vm_dir, filename, size_gb, DiskImageFormat::Qcow2)
+}
+
+/// Create a new disk image in the requested format.
+pub fn create_disk_image_with_format(
+    vm_dir: &Path,
+    filename: &str,
+    size_gb: u32,
+    disk_format: DiskImageFormat,
+) -> Result<PathBuf> {
     let disk_path = vm_dir.join(filename);
     let size_str = format!("{}G", size_gb);
 
-    qemu_img::create_disk(&disk_path, &size_str)
-        .with_context(|| format!("Failed to create disk image: {}", disk_path.display()))?;
+    let result = match disk_format {
+        DiskImageFormat::Qcow2 => qemu_img::create_disk(&disk_path, &size_str),
+        DiskImageFormat::Raw => {
+            qemu_img::create_disk_with_format(&disk_path, disk_format.as_str(), &size_str)
+        }
+    };
+    result.with_context(|| format!("Failed to create disk image: {}", disk_path.display()))?;
 
     Ok(disk_path)
 }
@@ -837,10 +877,16 @@ pub(crate) const SPICE_AGENT_ARGS: &[&str] = &[
     "-device virtserialport,chardev=spicechannel0,name=com.redhat.spice.0",
 ];
 
+fn disk_format_for_filename(disk_filename: &str) -> &'static str {
+    DiskImageFormat::from_path(Path::new(disk_filename))
+        .unwrap_or(DiskImageFormat::Qcow2)
+        .as_str()
+}
+
 /// Build the QEMU command string with OS-awareness
 fn build_qemu_command_with_os(
     config: &WizardQemuConfig,
-    _disk_filename: &str,
+    disk_filename: &str,
     install_media: &InstallMedia,
     os_profile: Option<&str>,
     floppy_path: Option<&str>,
@@ -931,16 +977,23 @@ fn build_qemu_command_with_os(
     // Disk (interface escaped to prevent injection)
     // Map "sata" to "ide" for backwards compatibility — QEMU doesn't support if=sata,
     // but on Q35 machines, if=ide routes through the AHCI controller (giving SATA behavior)
+    let disk_format = disk_format_for_filename(disk_filename);
     let machine_name = config.machine.as_deref().unwrap_or("");
     match machine_name {
         "q800" => {
             // q800: explicit SCSI device attachment for built-in ESP controller
-            args.push("-drive file=\"$DISK\",format=qcow2,if=none,id=hd0".to_string());
+            args.push(format!(
+                "-drive file=\"$DISK\",format={},if=none,id=hd0",
+                disk_format
+            ));
             args.push("-device scsi-hd,drive=hd0".to_string());
         }
         "mac99" => {
             // mac99: explicit IDE device attachment with bus specification
-            args.push("-drive file=\"$DISK\",format=qcow2,if=none,id=hd0".to_string());
+            args.push(format!(
+                "-drive file=\"$DISK\",format={},if=none,id=hd0",
+                disk_format
+            ));
             args.push("-device ide-hd,drive=hd0,bus=ide.0".to_string());
         }
         _ => {
@@ -958,7 +1011,10 @@ fn build_qemu_command_with_os(
                 } else {
                     "sata.0"
                 };
-                args.push("-drive file=\"$DISK\",format=qcow2,if=none,id=maindisk".to_string());
+                args.push(format!(
+                    "-drive file=\"$DISK\",format={},if=none,id=maindisk",
+                    disk_format
+                ));
                 args.push(format!("-device ide-hd,drive=maindisk,bus={}", disk_bus));
             } else {
                 let disk_if = if config.disk_interface == "sata" {
@@ -967,7 +1023,8 @@ fn build_qemu_command_with_os(
                     &config.disk_interface
                 };
                 args.push(format!(
-                    "-drive file=\"$DISK\",format=qcow2,if={},index=0,media=disk",
+                    "-drive file=\"$DISK\",format={},if={},index=0,media=disk",
+                    disk_format,
                     shell_escape(disk_if)
                 ));
             }

--- a/src/vm/import.rs
+++ b/src/vm/import.rs
@@ -711,7 +711,8 @@ pub fn execute_import(
     disk_action: ImportDiskAction,
 ) -> Result<PathBuf> {
     use crate::vm::create::{
-        create_vm_directory, generate_launch_script_with_os, write_launch_script, write_vm_metadata,
+        create_vm_directory, detect_existing_disk_image_format, generate_launch_script_with_os,
+        write_launch_script, write_vm_metadata,
     };
 
     let vm_dir = create_vm_directory(library_path, folder_name)?;
@@ -723,10 +724,11 @@ pub fn execute_import(
             continue;
         }
 
+        let disk_format = detect_existing_disk_image_format(disk_path);
         let disk_filename = if i == 0 {
-            format!("{}.qcow2", folder_name)
+            format!("{}.{}", folder_name, disk_format.extension())
         } else {
-            format!("{}-disk{}.qcow2", folder_name, i + 1)
+            format!("{}-disk{}.{}", folder_name, i + 1, disk_format.extension())
         };
 
         let dest = vm_dir.join(&disk_filename);

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -8,6 +8,7 @@ pub mod qemu_config;
 pub mod single_gpu_scripts;
 pub mod snapshot;
 
+#[allow(unused_imports)]
 pub use create::create_vm;
 pub use discovery::{discover_vms, group_vms_by_category, DiscoveredVm};
 pub use lifecycle::{

--- a/src/vm/tests/create.rs
+++ b/src/vm/tests/create.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::wizard_types::CreateWizardState;
+use crate::wizard_types::{CreateWizardState, DiskAction};
 
 #[test]
 fn test_shell_escape_safe_strings() {
@@ -259,6 +259,33 @@ fn test_build_qemu_command_without_bios() {
 }
 
 #[test]
+fn test_build_qemu_command_with_raw_disk() {
+    let config = WizardQemuConfig::default();
+    let cmd = build_qemu_command_with_os(&config, "disk.raw", &InstallMedia::None, None, None);
+
+    assert!(
+        cmd.contains("-drive file=\"$DISK\",format=raw,if=ide,index=0,media=disk"),
+        "Should use raw disk format, got:\n{}",
+        cmd
+    );
+    assert!(
+        !cmd.contains("format=qcow2,if=ide,index=0,media=disk"),
+        "Should not hardcode qcow2 for raw disks, got:\n{}",
+        cmd
+    );
+}
+
+#[test]
+fn test_generate_launch_script_with_raw_disk() {
+    let config = WizardQemuConfig::default();
+    let script =
+        generate_launch_script_with_os("Raw VM", "raw-vm.raw", None, false, &config, None, None);
+
+    assert!(script.contains("DISK=\"$VM_DIR/raw-vm.raw\""));
+    assert!(script.contains("format=raw,if=ide,index=0,media=disk"));
+}
+
+#[test]
 fn test_generate_launch_script_with_rom() {
     let config = WizardQemuConfig {
         emulator: "qemu-system-m68k".to_string(),
@@ -397,6 +424,127 @@ fn test_generate_launch_script_iso_unchanged() {
         script.contains("-boot d"),
         "Install mode should boot from CD-ROM"
     );
+}
+
+fn existing_disk_state(
+    source: PathBuf,
+    action: DiskAction,
+    folder_name: &str,
+) -> CreateWizardState {
+    CreateWizardState {
+        vm_name: format!("{folder_name} display"),
+        folder_name: folder_name.to_string(),
+        use_existing_disk: true,
+        existing_disk_path: Some(source),
+        existing_disk_action: action,
+        ..CreateWizardState::default()
+    }
+}
+
+#[test]
+fn test_create_vm_requires_existing_disk_path() -> Result<()> {
+    let library = tempfile::tempdir()?;
+    let state = CreateWizardState {
+        vm_name: "Missing disk".to_string(),
+        folder_name: "missing-disk".to_string(),
+        use_existing_disk: true,
+        existing_disk_path: None,
+        ..CreateWizardState::default()
+    };
+
+    let err = create_vm(library.path(), &state).expect_err("missing disk path should fail");
+
+    assert_eq!(err.to_string(), "No existing disk selected");
+    assert!(!library.path().join("missing-disk").exists());
+    Ok(())
+}
+
+#[test]
+fn test_create_vm_rejects_missing_existing_disk_file() -> Result<()> {
+    let library = tempfile::tempdir()?;
+    let missing_disk = library.path().join("missing.raw");
+    let state = existing_disk_state(missing_disk.clone(), DiskAction::Copy, "missing-file");
+
+    let err = create_vm(library.path(), &state).expect_err("missing disk file should fail");
+
+    assert!(
+        err.to_string().contains(&format!(
+            "Selected disk does not exist: {}",
+            missing_disk.display()
+        )),
+        "unexpected error: {err}"
+    );
+    assert!(!library.path().join("missing-file").exists());
+    Ok(())
+}
+
+#[test]
+fn test_create_vm_copies_existing_raw_disk() -> Result<()> {
+    let library = tempfile::tempdir()?;
+    let source = library.path().join("source.raw");
+    let disk_bytes = b"raw disk fixture";
+    std::fs::write(&source, disk_bytes)?;
+
+    let state = existing_disk_state(source.clone(), DiskAction::Copy, "copy-vm");
+    let created = create_vm(library.path(), &state)?;
+
+    assert_eq!(
+        created.disk_image,
+        library.path().join("copy-vm").join("copy-vm.raw")
+    );
+    assert_eq!(std::fs::read(&created.disk_image)?, disk_bytes);
+    assert_eq!(std::fs::read(&source)?, disk_bytes);
+
+    let script = std::fs::read_to_string(&created.launch_script)?;
+    assert!(script.contains("DISK=\"$VM_DIR/copy-vm.raw\""));
+    assert!(script.contains("format=raw,if=ide,index=0,media=disk"));
+    Ok(())
+}
+
+#[test]
+fn test_create_vm_treats_existing_img_disk_as_raw() -> Result<()> {
+    let library = tempfile::tempdir()?;
+    let source = library.path().join("source.img");
+    let disk_bytes = b"img raw disk fixture";
+    std::fs::write(&source, disk_bytes)?;
+
+    let state = existing_disk_state(source.clone(), DiskAction::Copy, "img-vm");
+    let created = create_vm(library.path(), &state)?;
+
+    assert_eq!(
+        created.disk_image,
+        library.path().join("img-vm").join("img-vm.raw")
+    );
+    assert_eq!(std::fs::read(&created.disk_image)?, disk_bytes);
+    assert_eq!(std::fs::read(&source)?, disk_bytes);
+
+    let script = std::fs::read_to_string(&created.launch_script)?;
+    assert!(script.contains("DISK=\"$VM_DIR/img-vm.raw\""));
+    assert!(script.contains("format=raw,if=ide,index=0,media=disk"));
+    Ok(())
+}
+
+#[test]
+fn test_create_vm_moves_existing_raw_disk() -> Result<()> {
+    let library = tempfile::tempdir()?;
+    let source = library.path().join("source.raw");
+    let disk_bytes = b"raw disk fixture to move";
+    std::fs::write(&source, disk_bytes)?;
+
+    let state = existing_disk_state(source.clone(), DiskAction::Move, "move-vm");
+    let created = create_vm(library.path(), &state)?;
+
+    assert_eq!(
+        created.disk_image,
+        library.path().join("move-vm").join("move-vm.raw")
+    );
+    assert_eq!(std::fs::read(&created.disk_image)?, disk_bytes);
+    assert!(!source.exists());
+
+    let script = std::fs::read_to_string(&created.launch_script)?;
+    assert!(script.contains("DISK=\"$VM_DIR/move-vm.raw\""));
+    assert!(script.contains("format=raw,if=ide,index=0,media=disk"));
+    Ok(())
 }
 
 // === macOS-specific tests ===

--- a/src/vm/tests/import.rs
+++ b/src/vm/tests/import.rs
@@ -312,3 +312,40 @@ fn test_parse_libvirt_xml_with_tpm() {
     assert!(vm.qemu_config.uefi);
     assert_eq!(vm.qemu_config.memory_mb, 4096);
 }
+
+#[test]
+fn test_execute_import_preserves_raw_img_disk_format() -> Result<()> {
+    let source_dir = tempfile::tempdir()?;
+    let library = tempfile::tempdir()?;
+    let source_disk = source_dir.path().join("source.img");
+    let disk_bytes = b"raw image fixture";
+    std::fs::write(&source_disk, disk_bytes)?;
+
+    let vm = ImportableVm {
+        name: "Imported Raw".to_string(),
+        config_path: source_dir.path().join("raw.conf"),
+        source: ImportSource::Quickemu,
+        qemu_config: WizardQemuConfig::default(),
+        disk_paths: vec![source_disk.clone()],
+        detected_os_profile: None,
+        import_notes: Vec::new(),
+        disks_readable: vec![true],
+    };
+
+    let vm_dir = execute_import(
+        library.path(),
+        &vm,
+        "Imported Raw",
+        "imported-raw",
+        ImportDiskAction::Copy,
+    )?;
+    let imported_disk = vm_dir.join("imported-raw.raw");
+
+    assert_eq!(std::fs::read(&imported_disk)?, disk_bytes);
+    assert_eq!(std::fs::read(&source_disk)?, disk_bytes);
+
+    let launch_script = std::fs::read_to_string(vm_dir.join("launch.sh"))?;
+    assert!(launch_script.contains("DISK=\"$VM_DIR/imported-raw.raw\""));
+    assert!(launch_script.contains("format=raw,if=ide,index=0,media=disk"));
+    Ok(())
+}

--- a/src/wizard_types.rs
+++ b/src/wizard_types.rs
@@ -3,7 +3,107 @@
 
 use crate::vm::qemu_config::{PortForward, PortProtocol};
 use anyhow::Result;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+/// Disk image format to create for new VMs
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DiskImageFormat {
+    #[default]
+    Qcow2,
+    Raw,
+}
+
+impl DiskImageFormat {
+    /// Format name accepted by `qemu-img`.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Qcow2 => "qcow2",
+            Self::Raw => "raw",
+        }
+    }
+
+    /// File extension used for newly-created or imported disks.
+    #[must_use]
+    pub fn extension(self) -> &'static str {
+        match self {
+            Self::Qcow2 => "qcow2",
+            Self::Raw => "raw",
+        }
+    }
+
+    /// Short label for compact UI summaries.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Qcow2 => "qcow2",
+            Self::Raw => "raw",
+        }
+    }
+
+    /// Human-readable description for format selection UI.
+    #[must_use]
+    pub fn description(self) -> &'static str {
+        match self {
+            Self::Qcow2 => "qcow2 (copy-on-write, snapshots supported)",
+            Self::Raw => "raw (plain disk image, no snapshots)",
+        }
+    }
+
+    /// Human-readable storage behavior summary.
+    #[must_use]
+    pub fn storage_description(self) -> &'static str {
+        match self {
+            Self::Qcow2 => "Expandable (only uses space as needed)",
+            Self::Raw => "Plain sparse file (guest sees full size)",
+        }
+    }
+
+    /// Compact summary for confirmation screens.
+    #[must_use]
+    pub fn summary(self) -> &'static str {
+        match self {
+            Self::Qcow2 => "qcow2 (expandable)",
+            Self::Raw => "raw (no snapshots)",
+        }
+    }
+
+    /// Alternate between the supported creation formats.
+    #[must_use]
+    pub fn toggle(self) -> Self {
+        match self {
+            Self::Qcow2 => Self::Raw,
+            Self::Raw => Self::Qcow2,
+        }
+    }
+
+    /// Map a `qemu-img info` format string into a supported wizard format.
+    #[must_use]
+    pub fn from_qemu_format(format: &str) -> Option<Self> {
+        match format.to_lowercase().as_str() {
+            "qcow2" | "qcow" => Some(Self::Qcow2),
+            "raw" => Some(Self::Raw),
+            _ => None,
+        }
+    }
+
+    /// Infer the disk format from a path extension.
+    #[must_use]
+    pub fn from_path(path: &Path) -> Option<Self> {
+        path.extension()
+            .and_then(|ext| ext.to_str())
+            .and_then(Self::from_extension)
+    }
+
+    #[must_use]
+    fn from_extension(ext: &str) -> Option<Self> {
+        match ext.to_lowercase().as_str() {
+            "qcow2" | "qcow" => Some(Self::Qcow2),
+            "raw" | "img" => Some(Self::Raw),
+            _ => None,
+        }
+    }
+}
 
 /// Action to take with an existing disk when using it for a new VM
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -506,5 +606,57 @@ impl Default for ImportWizardState {
             editing_name: false,
             warnings_acknowledged: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disk_image_format_strings_match_qemu_and_filenames() {
+        assert_eq!(DiskImageFormat::Qcow2.as_str(), "qcow2");
+        assert_eq!(DiskImageFormat::Qcow2.extension(), "qcow2");
+        assert_eq!(DiskImageFormat::Raw.as_str(), "raw");
+        assert_eq!(DiskImageFormat::Raw.extension(), "raw");
+    }
+
+    #[test]
+    fn disk_image_format_toggles_between_supported_formats() {
+        assert_eq!(DiskImageFormat::Qcow2.toggle(), DiskImageFormat::Raw);
+        assert_eq!(DiskImageFormat::Raw.toggle(), DiskImageFormat::Qcow2);
+    }
+
+    #[test]
+    fn disk_image_format_parses_qemu_formats_case_insensitively() {
+        assert_eq!(
+            DiskImageFormat::from_qemu_format("QCOW2"),
+            Some(DiskImageFormat::Qcow2)
+        );
+        assert_eq!(
+            DiskImageFormat::from_qemu_format("qcow"),
+            Some(DiskImageFormat::Qcow2)
+        );
+        assert_eq!(
+            DiskImageFormat::from_qemu_format("RAW"),
+            Some(DiskImageFormat::Raw)
+        );
+        assert_eq!(DiskImageFormat::from_qemu_format("vmdk"), None);
+    }
+
+    #[test]
+    fn disk_image_format_parses_supported_extensions() {
+        assert_eq!(
+            DiskImageFormat::from_path(Path::new("/vms/debian.QCOW2")),
+            Some(DiskImageFormat::Qcow2)
+        );
+        assert_eq!(
+            DiskImageFormat::from_path(Path::new("/vms/debian.img")),
+            Some(DiskImageFormat::Raw)
+        );
+        assert_eq!(
+            DiskImageFormat::from_path(Path::new("/vms/debian.vmdk")),
+            None
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add qcow2/raw disk format selection to the VM creation wizard
- Create raw disk images through qemu-img when selected
- Detect existing/imported disk formats and preserve them in generated disk filenames
- Generate launch scripts with the correct QEMU `format=` argument
- Expand disk browsing to include `.raw` and `.img` files
- Add tests for raw disk creation, existing disk handling, import handling, and format parsing

## Testing

- `cargo fmt --check`
- `cargo test`