### PR TITLE
fix: detach consoles before GPU unload to stop APU host power-off (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-**v1.2.0**
+**Unreleased**
 - **Fix Host Hang / Power-Off in Single-GPU Passthrough on APUs** (#61): Launching the generated `single-gpu-start.sh` could hard-hang or power the machine off entirely — reported on a Ryzen 7735U (Radeon 680M) mini PC. The script stopped the display manager and unloaded the GPU driver while fbcon was still rendering the active TTY through the GPU; the silent `modprobe -r` failure then led to force-unbinding an in-use driver, which AMD APUs in particular do not survive.
   - The start script now detaches the framebuffer virtual consoles (`/sys/class/vtconsole/*/bind`) and the generic EFI/simple framebuffer before unloading the GPU driver — the standard single-GPU passthrough sequence that was missing.
   - If the GPU driver still refuses to unload, the script aborts gracefully (cleanup restores the display) instead of force-unbinding an in-use driver.
   - Cleanup skips the PCI remove/rescan teardown when the GPU never left its original driver (the abort path), and both cleanup and `single-gpu-restore.sh` reattach the EFI framebuffer and virtual consoles so the TTY comes back.
   - Integrated GPUs (APUs) are now detected (best-effort, via a known AMD APU device-ID list plus Intel's fixed `00:02.0` iGPU address) and flagged with a prominent warning in the Single GPU Setup screen and the generated script header: APU passthrough is best-effort, and guest video requires a vBIOS extracted from that machine's own BIOS image.
+
+**v1.2.0**
 - **Security: bump `quick-xml` to 0.41** (RUSTSEC-2026-0194, RUSTSEC-2026-0195): resolves two high-severity advisories (quadratic-time duplicate-attribute check and unbounded namespace-declaration allocation) in the libvirt-XML import parser. Also bumps `anyhow` to 1.0.103.
 - **Fix Windows 11 TPM 2.0 Detection on Fedora** (#42): Windows 11 VMs created with TPM enabled failed the installer's "PC must support TPM 2.0" check on Fedora 44, because vm-curator selected the 2M `OVMF_CODE.secboot.fd` firmware, which does not expose TPM 2.0 correctly.
   - OVMF firmware is now chosen as a matched CODE+VARS **pair** (`find_ovmf_firmware`), preferring 4M builds — including Fedora's qcow2-format firmware (`OVMF_CODE_4M.secboot.qcow2`) — over 2M, with the 2M variants kept only as a last-resort fallback. Picking CODE and VARS from one pair guarantees they always agree in size and on-disk format.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 **v1.2.0**
+- **Fix Host Hang / Power-Off in Single-GPU Passthrough on APUs** (#61): Launching the generated `single-gpu-start.sh` could hard-hang or power the machine off entirely — reported on a Ryzen 7735U (Radeon 680M) mini PC. The script stopped the display manager and unloaded the GPU driver while fbcon was still rendering the active TTY through the GPU; the silent `modprobe -r` failure then led to force-unbinding an in-use driver, which AMD APUs in particular do not survive.
+  - The start script now detaches the framebuffer virtual consoles (`/sys/class/vtconsole/*/bind`) and the generic EFI/simple framebuffer before unloading the GPU driver — the standard single-GPU passthrough sequence that was missing.
+  - If the GPU driver still refuses to unload, the script aborts gracefully (cleanup restores the display) instead of force-unbinding an in-use driver.
+  - Cleanup skips the PCI remove/rescan teardown when the GPU never left its original driver (the abort path), and both cleanup and `single-gpu-restore.sh` reattach the EFI framebuffer and virtual consoles so the TTY comes back.
+  - Integrated GPUs (APUs) are now detected (best-effort, via a known AMD APU device-ID list plus Intel's fixed `00:02.0` iGPU address) and flagged with a prominent warning in the Single GPU Setup screen and the generated script header: APU passthrough is best-effort, and guest video requires a vBIOS extracted from that machine's own BIOS image.
 - **Security: bump `quick-xml` to 0.41** (RUSTSEC-2026-0194, RUSTSEC-2026-0195): resolves two high-severity advisories (quadratic-time duplicate-attribute check and unbounded namespace-declaration allocation) in the libvirt-XML import parser. Also bumps `anyhow` to 1.0.103.
 - **Fix Windows 11 TPM 2.0 Detection on Fedora** (#42): Windows 11 VMs created with TPM enabled failed the installer's "PC must support TPM 2.0" check on Fedora 44, because vm-curator selected the 2M `OVMF_CODE.secboot.fd` firmware, which does not expose TPM 2.0 correctly.
   - OVMF firmware is now chosen as a matched CODE+VARS **pair** (`find_ovmf_firmware`), preferring 4M builds — including Fedora's qcow2-format firmware (`OVMF_CODE_4M.secboot.qcow2`) — over 2M, with the 2M variants kept only as a last-resort fallback. Picking CODE and VARS from one pair guarantees they always agree in size and on-disk format.

--- a/src/hardware/pci.rs
+++ b/src/hardware/pci.rs
@@ -49,6 +49,30 @@ pub mod class_codes {
     pub const INSTRUMENTATION: u32 = 0x130000;
 }
 
+/// Known AMD APU (integrated GPU) PCI device IDs, Carrizo through Strix Point.
+/// Used by [`PciDevice::is_integrated_gpu`] to warn before single-GPU
+/// passthrough of an iGPU. Best-effort: an APU missing from this list simply
+/// produces no warning.
+const AMD_APU_DEVICE_IDS: &[u16] = &[
+    0x9874, // Carrizo
+    0x98e4, // Stoney Ridge
+    0x15dd, // Raven Ridge (Vega 8/11)
+    0x15d8, // Picasso
+    0x1636, // Renoir
+    0x164c, // Lucienne
+    0x1638, // Cezanne
+    0x15e7, // Barcelo
+    0x163f, // Van Gogh (Steam Deck)
+    0x1435, // Sephiroth (Steam Deck OLED)
+    0x1681, // Rembrandt (Radeon 680M/660M)
+    0x1506, // Mendocino
+    0x164e, // Raphael (Ryzen 7000 desktop iGPU)
+    0x13c0, // Granite Ridge (Ryzen 9000 desktop iGPU)
+    0x15bf, // Phoenix / Hawk Point (Radeon 780M)
+    0x15c8, // Phoenix2 (Radeon 760M)
+    0x150e, // Strix Point (Radeon 890M)
+];
+
 /// Represents a PCI device discovered on the system
 #[derive(Debug, Clone)]
 pub struct PciDevice {
@@ -157,6 +181,27 @@ impl PciDevice {
     /// Check if this is an Intel device
     pub fn is_intel(&self) -> bool {
         self.vendor_id == 0x8086
+    }
+
+    /// Best-effort check whether this GPU is an integrated GPU (APU/iGPU).
+    ///
+    /// Integrated GPUs are far riskier for single-GPU passthrough: they have no
+    /// FLR, unbinding them can hard-hang or power off the host (issue #61), and
+    /// guest video usually needs a vBIOS carved out of the machine's own BIOS
+    /// image. Detection fails open — an unrecognized device produces no warning.
+    pub fn is_integrated_gpu(&self) -> bool {
+        if !self.is_gpu() {
+            return false;
+        }
+        // Intel iGPUs always sit at 00:02.0; discrete Arc cards live behind a
+        // PCIe root port at another address.
+        if self.is_intel() {
+            return self.address.ends_with(":00:02.0");
+        }
+        if self.is_amd() {
+            return AMD_APU_DEVICE_IDS.contains(&self.device_id);
+        }
+        false
     }
 
     /// Get a display string for this device

--- a/src/hardware/tests/pci.rs
+++ b/src/hardware/tests/pci.rs
@@ -80,3 +80,42 @@ fn test_generate_passthrough_args() {
     assert!(!args[1].contains("x-vga")); // No x-vga (incompatible with modern NVIDIA)
     assert!(!args[3].contains("x-vga")); // Audio device also no x-vga
 }
+
+/// Helper for is_integrated_gpu tests
+fn gpu_device(address: &str, vendor_id: u16, device_id: u16) -> PciDevice {
+    PciDevice {
+        address: address.to_string(),
+        vendor_id,
+        device_id,
+        class_code: 0x030000,
+        vendor_name: String::new(),
+        device_name: String::new(),
+        driver: None,
+        iommu_group: Some(1),
+        is_boot_vga: true,
+        subsystem_vendor_id: 0,
+        subsystem_device_id: 0,
+    }
+}
+
+#[test]
+fn integrated_gpu_detection() {
+    // Known AMD APUs (issue #61 reporter's Rembrandt 680M among them)
+    assert!(gpu_device("0000:e4:00.0", 0x1002, 0x1681).is_integrated_gpu());
+    assert!(gpu_device("0000:04:00.0", 0x1002, 0x15bf).is_integrated_gpu());
+
+    // AMD discrete cards are not flagged
+    assert!(!gpu_device("0000:03:00.0", 0x1002, 0x744c).is_integrated_gpu());
+
+    // Intel iGPU always sits at 00:02.0; Arc dGPUs live elsewhere
+    assert!(gpu_device("0000:00:02.0", 0x8086, 0x9a49).is_integrated_gpu());
+    assert!(!gpu_device("0000:03:00.0", 0x8086, 0x56a0).is_integrated_gpu());
+
+    // NVIDIA is never integrated
+    assert!(!gpu_device("0000:01:00.0", 0x10de, 0x2684).is_integrated_gpu());
+
+    // A non-GPU AMD device with a coincidental APU device ID is not flagged
+    let mut audio = gpu_device("0000:e4:00.1", 0x1002, 0x1681);
+    audio.class_code = 0x040300;
+    assert!(!audio.is_integrated_gpu());
+}

--- a/src/ui/screens/single_gpu_setup.rs
+++ b/src/ui/screens/single_gpu_setup.rs
@@ -227,15 +227,23 @@ fn render_gpu_info(app: &App, frame: &mut Frame, area: Rect) {
             Span::styled(rom_text, Style::default().fg(rom_color)),
         ]));
 
-        // AMD-specific guidance: AMD GPUs usually need a clean vBIOS to output video
-        if config.gpu.is_amd() && config.gpu_rom.is_none() {
+        // Integrated GPUs (APUs) are the riskiest case: unbinding them can hang
+        // or power off the host, and guest video needs a vBIOS from the
+        // machine's own BIOS image (#61).
+        if config.gpu.is_integrated_gpu() {
+            lines.push(Line::styled(
+                "  WARNING: Integrated GPU (APU) — passthrough is best-effort and",
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            ));
+            lines.push(Line::styled(
+                "  may hang the host. A vBIOS from YOUR OWN BIOS image is required.",
+                Style::default().fg(Color::Red),
+            ));
+        } else if config.gpu.is_amd() && config.gpu_rom.is_none() {
+            // AMD-specific guidance: AMD GPUs usually need a clean vBIOS to output video
             lines.push(Line::styled(
                 "  AMD GPU: no video without a vBIOS ROM is common. Press [r] to set one.",
                 Style::default().fg(Color::Yellow),
-            ));
-            lines.push(Line::styled(
-                "  Integrated (APU) GPUs are often unsupported for passthrough.",
-                Style::default().fg(Color::DarkGray),
             ));
         }
     } else {

--- a/src/vm/single_gpu_scripts.rs
+++ b/src/vm/single_gpu_scripts.rs
@@ -310,6 +310,17 @@ fn generate_start_script(vm: &DiscoveredVm, config: &SingleGpuConfig) -> Result<
         &pci_passthrough_args,
     )?;
 
+    // Extra header warning for integrated GPUs (APUs), the riskiest case (#61)
+    let apu_warning = if config.gpu.is_integrated_gpu() {
+        r#"#
+# WARNING: This GPU appears to be an integrated GPU (APU). APU passthrough is
+# best-effort: it may fail, hang, or power off the host, and guest video
+# requires a vBIOS extracted from THIS machine's own BIOS image (issue #61).
+"#
+    } else {
+        ""
+    };
+
     // Generate variable definitions
     let variable_defs = generate_variable_definitions(vm, &components);
 
@@ -366,7 +377,7 @@ start_tpm
 # AMD GPUs frequently produce NO video in the guest unless a clean vBIOS ROM is
 # supplied via romfile= (set it in the Single GPU Setup screen with [r]).
 # Integrated (APU) GPUs are often unsupported for passthrough. See issue #44.
-
+{apu_warning}
 set -e
 
 # ============================================================================
@@ -412,14 +423,8 @@ fi
 # Cleanup Function
 # ============================================================================
 
-cleanup() {{
-    local exit_code=$?
-    echo ""
-    echo "Cleaning up and restoring display..."
-
-    # Kill any lingering QEMU processes for this VM
-    pkill -f "qemu.*$VM_NAME" 2>/dev/null || true
-{tpm_cleanup}
+# Return the GPU to its original driver via PCI remove+rescan
+rebind_gpu() {{
     # Unbind from vfio-pci using PCI remove+rescan pattern
     if [[ -e "/sys/bus/pci/devices/$GPU_ADDR" ]]; then
         echo "Removing GPU from PCI bus..."
@@ -454,6 +459,37 @@ cleanup() {{
         echo "Manual bind to $ORIGINAL_DRIVER..."
         echo "$GPU_ADDR" > /sys/bus/pci/drivers/$ORIGINAL_DRIVER/bind 2>/dev/null || true
     fi
+}}
+
+cleanup() {{
+    local exit_code=$?
+    echo ""
+    echo "Cleaning up and restoring display..."
+
+    # Kill any lingering QEMU processes for this VM
+    pkill -f "qemu.*$VM_NAME" 2>/dev/null || true
+{tpm_cleanup}
+    # If the GPU never left its original driver (the abort path), skip the
+    # PCI remove/rescan teardown — removing an in-use GPU from the bus risks
+    # the same hard hang we are avoiding (issue #61).
+    gpu_driver=""
+    if [[ -e "/sys/bus/pci/devices/$GPU_ADDR/driver" ]]; then
+        gpu_driver=$(basename "$(readlink "/sys/bus/pci/devices/$GPU_ADDR/driver")")
+    fi
+
+    if [[ "$gpu_driver" == "$ORIGINAL_DRIVER" ]]; then
+        echo "GPU is still bound to $ORIGINAL_DRIVER; skipping PCI rebind."
+    else
+        rebind_gpu
+    fi
+
+    # Reattach the EFI framebuffer and virtual consoles (issue #61)
+    echo "efi-framebuffer.0" > /sys/bus/platform/drivers/efi-framebuffer/bind 2>/dev/null || true
+    for vtcon in /sys/class/vtconsole/vtcon*; do
+        if grep -q "frame buffer" "$vtcon/name" 2>/dev/null; then
+            echo 1 > "$vtcon/bind" 2>/dev/null || true
+        fi
+    done
 
     # Restart display manager
     echo "Starting display manager..."
@@ -491,14 +527,34 @@ for proc in Xorg Xwayland gnome-shell kwin_wayland plasmashell sway hyprland; do
 done
 sleep 2
 
+# Detach virtual consoles from the GPU framebuffer. Unloading the GPU driver
+# while fbcon still renders the active TTY through it can hard-hang or even
+# power off the machine — especially on AMD APUs (issue #61).
+echo "Detaching virtual consoles from GPU framebuffer..."
+for vtcon in /sys/class/vtconsole/vtcon*; do
+    if grep -q "frame buffer" "$vtcon/name" 2>/dev/null; then
+        echo 0 > "$vtcon/bind" 2>/dev/null || true
+    fi
+done
+
+# Unbind the generic EFI/simple framebuffer if still present
+echo "efi-framebuffer.0" > /sys/bus/platform/drivers/efi-framebuffer/unbind 2>/dev/null || true
+echo "simple-framebuffer.0" > /sys/bus/platform/drivers/simple-framebuffer/unbind 2>/dev/null || true
+sleep 1
+
 # Unload driver modules
 {unload_modules_cmd}
 
-# Verify driver is unloaded
+# The GPU driver must have released the device by now. Force-unbinding a
+# driver that is still in use can hard-hang or power off the machine
+# (issue #61), so abort gracefully instead — the cleanup trap restores
+# the display.
 if [[ -e "/sys/bus/pci/devices/$GPU_ADDR/driver" ]]; then
-    current_driver=$(basename $(readlink /sys/bus/pci/devices/$GPU_ADDR/driver))
+    current_driver=$(basename "$(readlink "/sys/bus/pci/devices/$GPU_ADDR/driver")")
     if [[ "$current_driver" != "vfio-pci" ]]; then
-        echo "$GPU_ADDR" > /sys/bus/pci/drivers/$current_driver/unbind 2>/dev/null || true
+        echo "ERROR: GPU is still bound to '$current_driver' — driver did not unload."
+        echo "Something is still using the GPU. Aborting and restoring the display."
+        exit 1
     fi
 fi
 
@@ -575,6 +631,7 @@ echo "VM has exited."
         display_manager = display_manager,
         extra_pci_addrs = extra_pci_addrs_str,
         variable_defs = variable_defs,
+        apu_warning = apu_warning,
         tpm_functions = tpm_functions,
         tpm_cleanup = if components.has_tpm {
             r#"
@@ -914,6 +971,14 @@ if [[ -n "$ORIGINAL_DRIVER" ]] && [[ "$ORIGINAL_DRIVER" != "vfio-pci" ]]; then
         echo "$GPU_ADDR" > /sys/bus/pci/drivers/$ORIGINAL_DRIVER/bind 2>/dev/null || true
     fi
 fi
+
+# Reattach the EFI framebuffer and virtual consoles (issue #61)
+echo "efi-framebuffer.0" > /sys/bus/platform/drivers/efi-framebuffer/bind 2>/dev/null || true
+for vtcon in /sys/class/vtconsole/vtcon*; do
+    if grep -q "frame buffer" "$vtcon/name" 2>/dev/null; then
+        echo 1 > "$vtcon/bind" 2>/dev/null || true
+    fi
+done
 
 # Restart display manager
 echo "Starting display manager..."
@@ -1627,6 +1692,91 @@ mod tests {
             gpu_passthrough_device(&amd_gpu_config(Some(String::new()))),
             expected
         );
+    }
+
+    /// Build a minimal VM directory with a parseable launch.sh
+    fn test_vm(dir: &Path) -> DiscoveredVm {
+        let launch = dir.join("launch.sh");
+        fs::write(
+            &launch,
+            "#!/bin/bash\nqemu-system-x86_64 \\\n    -machine q35,accel=kvm \\\n    -m 4096 \\\n    -display sdl,gl=on \\\n    -device virtio-net-pci,netdev=net0\n",
+        )
+        .unwrap();
+        DiscoveredVm {
+            id: "test-vm".to_string(),
+            path: dir.to_path_buf(),
+            launch_script: launch,
+            config: Default::default(),
+            custom_name: None,
+            os_profile: None,
+            notes: None,
+        }
+    }
+
+    /// Regression test for issue #61: the start script must detach fbcon and the
+    /// generic framebuffers before unloading the GPU driver — unloading while
+    /// fbcon still renders the active TTY through the GPU can hard-hang or power
+    /// off the host, especially on AMD APUs.
+    #[test]
+    fn start_script_detaches_consoles_before_driver_unload() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vm = test_vm(tmp.path());
+        let script = generate_start_script(&vm, &amd_gpu_config(None)).unwrap();
+
+        let detach = script
+            .find("echo 0 > \"$vtcon/bind\"")
+            .expect("vtcon detach missing");
+        let efifb = script
+            .find("efi-framebuffer/unbind 2>")
+            .expect("efifb unbind missing");
+        let unload = script
+            .find("modprobe -r amdgpu")
+            .expect("driver unload missing");
+        assert!(detach < unload, "consoles must detach before driver unload");
+        assert!(efifb < unload, "efifb must unbind before driver unload");
+    }
+
+    /// Issue #61: a GPU driver that refuses to unload must abort the script
+    /// (letting the cleanup trap restore the display), never be force-unbound.
+    #[test]
+    fn start_script_aborts_instead_of_force_unbinding_gpu() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vm = test_vm(tmp.path());
+        let script = generate_start_script(&vm, &amd_gpu_config(None)).unwrap();
+
+        assert!(script.contains("driver did not unload"));
+        assert!(
+            !script.contains("echo \"$GPU_ADDR\" > /sys/bus/pci/drivers/$current_driver/unbind")
+        );
+        // The abort path must also skip the PCI remove/rescan teardown in cleanup.
+        assert!(script.contains("skipping PCI rebind"));
+    }
+
+    /// Issue #61: cleanup and the emergency restore script must reattach the
+    /// EFI framebuffer and virtual consoles so the TTY comes back.
+    #[test]
+    fn scripts_reattach_consoles_on_restore() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vm = test_vm(tmp.path());
+        let cfg = amd_gpu_config(None);
+
+        let start = generate_start_script(&vm, &cfg).unwrap();
+        assert!(start.contains("echo 1 > \"$vtcon/bind\""));
+        assert!(start.contains("efi-framebuffer/bind 2>"));
+
+        let restore = generate_restore_script(&vm, &cfg);
+        assert!(restore.contains("echo 1 > \"$vtcon/bind\""));
+        assert!(restore.contains("efi-framebuffer/bind 2>"));
+    }
+
+    /// Integrated GPUs (the amd_gpu_config fixture is a Rembrandt 680M APU)
+    /// get an extra header warning in the generated start script.
+    #[test]
+    fn start_script_warns_for_integrated_gpu() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vm = test_vm(tmp.path());
+        let script = generate_start_script(&vm, &amd_gpu_config(None)).unwrap();
+        assert!(script.contains("integrated GPU (APU)"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes the host hard-hang / complete power-off reported in #61 when launching single-GPU passthrough on an AMD APU (Ryzen 7735U / Radeon 680M).

## Root cause

The generated `single-gpu-start.sh` stopped the display manager and immediately tried to unload the GPU driver — but fbcon was still rendering the active TTY through the GPU, so `modprobe -r amdgpu` failed (silently, masked by `|| true`) and the script fell through to force-unbinding the in-use driver via sysfs. Yanking the driver out from under an active framebuffer is something AMD APUs in particular do not survive: the machine hard-hangs or powers off, exactly as reported. The standard vtconsole/EFI-framebuffer detach step used by every reference single-GPU passthrough hook was missing.

## Changes

- **Detach consoles before driver unload**: unbind framebuffer virtual consoles (`/sys/class/vtconsole/*/bind`) and the generic `efi-framebuffer`/`simple-framebuffer` platform devices before `modprobe -r`, and reattach them in the cleanup trap and in `single-gpu-restore.sh`.
- **Fail safe instead of force-unbinding**: if the GPU driver still refuses to unload, the script now aborts with a clear error and lets the cleanup trap restore the display, instead of force-unbinding an in-use driver.
- **Guard cleanup**: the PCI remove/rescan teardown is skipped when the GPU never left its original driver (the abort path) — removing an in-use GPU from the bus risks the same hang; teardown moved into a `rebind_gpu()` function called only when the GPU was actually handed to vfio-pci.
- **APU guardrail**: new best-effort `PciDevice::is_integrated_gpu()` (known AMD APU device-ID list, Carrizo→Strix Point; Intel iGPUs via the fixed `00:02.0` address). Integrated GPUs get a prominent red warning in the Single GPU Setup screen and an extra header warning in the generated script: APU passthrough is best-effort, may hang the host, and needs a vBIOS extracted from that machine's own BIOS image.

## Testing

- 5 new regression tests generate the full start/restore scripts and assert: consoles detach before driver unload, no GPU force-unbind remains, abort path present, consoles reattach in both cleanup and restore, and the APU header warning appears. Plus `is_integrated_gpu()` coverage (Rembrandt/Phoenix flagged; discrete AMD/Intel Arc/NVIDIA not; non-GPU with coincidental ID not).
- Generated both scripts for a Rembrandt-680M fixture and validated with `bash -n`; also verified the #58 (emulated-VGA strip) and #48 (QMP continuation) behaviors are preserved in the output.
- `cargo fmt --check`, `cargo clippy --all-targets`, full test suite (178 passing).

Fixes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)