### PR TITLE
Fix launch-script persistence and UEFI disk boot priority

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -864,21 +864,10 @@ impl App {
 
     /// Get launch options based on current state
     pub fn get_launch_options(&self) -> LaunchOptions {
-        let usb_devices = self
-            .selected_usb_devices
-            .iter()
-            .filter_map(|&i| self.usb_devices.get(i))
-            .map(|d| crate::vm::UsbPassthrough {
-                vendor_id: d.vendor_id,
-                product_id: d.product_id,
-                usb_version: d.usb_version,
-            })
-            .collect();
-
         LaunchOptions {
             boot_mode: self.boot_mode.clone(),
             extra_args: Vec::new(),
-            usb_devices,
+            usb_devices: Vec::new(),
         }
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1723,8 +1723,17 @@ fn confirm_save_and_exit(app: &mut App, kind: UnsavedKind) {
         UnsavedKind::Pci => screens::pci_passthrough::save_selection_and_report(app),
         UnsavedKind::SharedFolders => screens::shared_folders::save_selection_and_report(app),
     }
+
+    let save_failed = match kind {
+        UnsavedKind::Usb => app.usb_selection_dirty(),
+        UnsavedKind::Pci => app.pci_selection_dirty(),
+        UnsavedKind::SharedFolders => app.shared_folders_dirty(),
+    };
+
     app.pop_screen(); // close the confirm dialog
-    exit_management_screen(app, kind);
+    if !save_failed {
+        exit_management_screen(app, kind);
+    }
 }
 
 /// Pop a management screen, restoring the parent menu cursor the same way each

--- a/src/ui/screens/shared_folders.rs
+++ b/src/ui/screens/shared_folders.rs
@@ -306,13 +306,38 @@ pub(crate) fn save_selection_and_report(app: &mut App) {
         match result {
             Ok(()) => {
                 app.reload_selected_vm_script();
-                if count > 0 {
-                    app.set_status(format!("Saved {} shared folder(s) to launch.sh", count));
+
+                let mut status_msg = if count > 0 {
+                    format!("Saved {} shared folder(s) to launch.sh", count)
                 } else {
-                    app.set_status("Cleared shared folders from launch.sh");
+                    "Cleared shared folders from launch.sh".to_string()
+                };
+
+                // Regenerate single-GPU scripts if they exist so their copied
+                // QEMU command stays in sync with launch.sh.
+                if let Some(vm) = app.selected_vm() {
+                    let regen_result = if let Some(config) = app.single_gpu_config.as_ref() {
+                        crate::vm::single_gpu_scripts::regenerate_if_exists(vm, config)
+                    } else {
+                        crate::vm::single_gpu_scripts::regenerate_from_saved_config(vm)
+                    };
+
+                    match regen_result {
+                        Ok(true) => {
+                            status_msg.push_str("; single-GPU scripts regenerated");
+                        }
+                        Ok(false) => {}
+                        Err(e) => {
+                            status_msg.push_str(&format!(
+                                "; warning: failed to regenerate single-GPU scripts: {}",
+                                e
+                            ));
+                        }
+                    }
                 }
                 // Saved state is now the baseline; no unsaved changes remain.
                 app.snapshot_shared_folders_baseline();
+                app.set_status(status_msg);
             }
             Err(e) => {
                 app.set_status(format!("Error saving shared folders: {}", e));

--- a/src/vm/create.rs
+++ b/src/vm/create.rs
@@ -933,12 +933,13 @@ fi
         script.push_str("        start_tpm\n");
     }
 
-    let floppy_cmd = build_qemu_command_with_os(
+    let floppy_cmd = build_qemu_command_with_os_impl(
         config,
         disk_filename,
         &InstallMedia::None,
         os_profile,
         Some("\"$2\""),
+        true,
     );
     script.push_str(&format!("        {}\n", floppy_cmd));
     script.push_str("        ;;\n");
@@ -990,12 +991,32 @@ fn build_qemu_command_with_os(
     os_profile: Option<&str>,
     floppy_path: Option<&str>,
 ) -> String {
+    build_qemu_command_with_os_impl(
+        config,
+        disk_filename,
+        install_media,
+        os_profile,
+        floppy_path,
+        false,
+    )
+}
+
+fn build_qemu_command_with_os_impl(
+    config: &WizardQemuConfig,
+    disk_filename: &str,
+    install_media: &InstallMedia,
+    os_profile: Option<&str>,
+    floppy_path: Option<&str>,
+    boot_from_floppy: bool,
+) -> String {
     let mut args: Vec<String> = Vec::new();
 
     let is_windows = is_windows_10_or_11(os_profile);
     let is_intel_macos_vm = is_intel_macos(os_profile, &config.emulator);
     let needs_tpm = config.tpm || is_windows_11(os_profile);
     let needs_uefi = config.uefi || is_windows_11(os_profile);
+    let normal_uefi_disk_boot =
+        needs_uefi && matches!(install_media, InstallMedia::None) && !boot_from_floppy;
 
     // Emulator
     args.push(config.emulator.clone());
@@ -1078,6 +1099,7 @@ fn build_qemu_command_with_os(
     // but on Q35 machines, if=ide routes through the AHCI controller (giving SATA behavior)
     let disk_format = disk_format_for_filename(disk_filename);
     let machine_name = config.machine.as_deref().unwrap_or("");
+    let mut disk_has_bootindex = false;
     match machine_name {
         "q800" => {
             // q800: explicit SCSI device attachment for built-in ESP controller
@@ -1121,6 +1143,10 @@ fn build_qemu_command_with_os(
                 } else {
                     &config.disk_interface
                 };
+                if normal_uefi_disk_boot && disk_if == "virtio" {
+                    args.push("-global virtio-blk-pci.bootindex=0".to_string());
+                    disk_has_bootindex = true;
+                }
                 args.push(format!(
                     "-drive file=\"$DISK\",format={},if={},index=0,media=disk",
                     disk_format,
@@ -1210,12 +1236,25 @@ fn build_qemu_command_with_os(
     // Floppy disk image
     if let Some(floppy_ref) = floppy_path {
         args.push(format!("-fda {}", floppy_ref));
-        // When floppy is present with ISO, boot from floppy (which accesses CD)
-        if matches!(install_media, InstallMedia::Iso(_)) {
+        if boot_from_floppy && matches!(install_media, InstallMedia::None) {
+            args.push("-boot a".to_string());
+        } else if matches!(install_media, InstallMedia::Iso(_)) {
+            // When floppy is present with ISO, boot from floppy (which accesses CD)
             // Replace the -boot d we just added with -boot a
             if let Some(pos) = args.iter().position(|a| a == "-boot d") {
                 args[pos] = "-boot a".to_string();
             }
+        }
+    }
+
+    // OVMF can preserve guest-controlled NVRAM boot entries. For normal UEFI
+    // launches, explicitly constrain booting to the disk so stale PXE/HTTP
+    // entries do not delay every boot.
+    if normal_uefi_disk_boot {
+        if disk_has_bootindex {
+            args.push("-boot strict=on".to_string());
+        } else {
+            args.push("-boot order=c,strict=on".to_string());
         }
     }
 

--- a/src/vm/lifecycle.rs
+++ b/src/vm/lifecycle.rs
@@ -866,6 +866,7 @@ fn extract_hex_value(s: &str, prefix: &str) -> Option<u16> {
 // Shared Folders section markers
 const SHARED_FOLDERS_MARKER_START: &str = "# >>> Shared Folders (managed by vm-curator) >>>";
 const SHARED_FOLDERS_MARKER_END: &str = "# <<< Shared Folders <<<";
+const SHARED_FOLDERS_ARGS_REF: &str = "\"${SHARED_FOLDERS_ARGS[@]}\"";
 
 /// A shared folder configuration for virtio-9p host-to-guest file sharing
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -936,10 +937,7 @@ fn remove_shared_folders_section(content: &str) -> String {
             continue;
         }
         if !in_section {
-            let cleaned_line = line
-                .replace(" $SHARED_FOLDERS_ARGS", "")
-                .replace("$SHARED_FOLDERS_ARGS ", "")
-                .replace("$SHARED_FOLDERS_ARGS", "");
+            let cleaned_line = remove_shared_folders_arg_ref(line);
             result.push_str(&cleaned_line);
             result.push('\n');
         }
@@ -953,6 +951,24 @@ fn remove_shared_folders_section(content: &str) -> String {
     result
 }
 
+fn remove_shared_folders_arg_ref(line: &str) -> String {
+    let mut cleaned = line.to_string();
+    for var_ref in [
+        " \"${SHARED_FOLDERS_ARGS[@]}\"",
+        "\"${SHARED_FOLDERS_ARGS[@]}\" ",
+        "\"${SHARED_FOLDERS_ARGS[@]}\"",
+        " ${SHARED_FOLDERS_ARGS[@]}",
+        "${SHARED_FOLDERS_ARGS[@]} ",
+        "${SHARED_FOLDERS_ARGS[@]}",
+        " $SHARED_FOLDERS_ARGS",
+        "$SHARED_FOLDERS_ARGS ",
+        "$SHARED_FOLDERS_ARGS",
+    ] {
+        cleaned = cleaned.replace(var_ref, "");
+    }
+    cleaned
+}
+
 fn generate_shared_folders_section(folders: &[SharedFolder], device_name: &str) -> String {
     if folders.is_empty() {
         return String::new();
@@ -961,22 +977,30 @@ fn generate_shared_folders_section(folders: &[SharedFolder], device_name: &str) 
     let mut section = String::new();
     section.push_str(SHARED_FOLDERS_MARKER_START);
     section.push('\n');
-    section.push_str("SHARED_FOLDERS_ARGS=\"");
+    section.push_str("SHARED_FOLDERS_ARGS=(\n");
 
     for (i, folder) in folders.iter().enumerate() {
         let id = format!("fsdev{}", i);
-        let escaped_path = shell_escape(&folder.host_path);
+        let fsdev_arg = format!(
+            "local,id={},path={},security_model=mapped-xattr",
+            id, folder.host_path
+        );
+        let device_arg = format!(
+            "{},fsdev={},mount_tag={}",
+            device_name, id, folder.mount_tag
+        );
 
-        if i > 0 {
-            section.push(' ');
-        }
-        section.push_str(&format!(
-            "-fsdev local,id={},path={},security_model=mapped-xattr -device {},fsdev={},mount_tag={}",
-            id, escaped_path, device_name, id, folder.mount_tag
-        ));
+        section.push_str("    -fsdev\n");
+        section.push_str("    ");
+        section.push_str(&shell_escape(&fsdev_arg));
+        section.push('\n');
+        section.push_str("    -device\n");
+        section.push_str("    ");
+        section.push_str(&shell_escape(&device_arg));
+        section.push('\n');
     }
 
-    section.push_str("\"\n");
+    section.push_str(")\n");
     section.push_str(SHARED_FOLDERS_MARKER_END);
     section.push('\n');
 
@@ -984,12 +1008,14 @@ fn generate_shared_folders_section(folders: &[SharedFolder], device_name: &str) 
 }
 
 fn insert_shared_folders_section(content: &str, section: &str) -> String {
-    insert_args_section(content, section, "$SHARED_FOLDERS_ARGS")
+    insert_args_section(content, section, SHARED_FOLDERS_ARGS_REF)
 }
 
 fn parse_shared_folders_section(content: &str) -> Vec<SharedFolder> {
     let mut folders = Vec::new();
     let mut in_section = false;
+    let mut in_array = false;
+    let mut array_lines = Vec::new();
 
     for line in content.lines() {
         if line.trim() == SHARED_FOLDERS_MARKER_START {
@@ -1000,27 +1026,246 @@ fn parse_shared_folders_section(content: &str) -> Vec<SharedFolder> {
             in_section = false;
             continue;
         }
-        if in_section && line.contains("SHARED_FOLDERS_ARGS=") {
-            // Parse -fsdev local,id=...,path=...,security_model=... -device ...,mount_tag=...
-            // Split on "-fsdev " to get each folder pair
-            for part in line.split("-fsdev ") {
-                if !part.contains("path=") {
-                    continue;
-                }
-                let host_path = extract_path_value(part);
-                let mount_tag = extract_simple_value(part, "mount_tag=");
+        if !in_section {
+            continue;
+        }
 
-                if let (Some(path), Some(tag)) = (host_path, mount_tag) {
-                    folders.push(SharedFolder {
-                        host_path: path,
-                        mount_tag: tag,
-                    });
+        let trimmed = line.trim();
+        if in_array {
+            if let Some(before_end) = strip_array_closing_paren(line) {
+                if !before_end.trim().is_empty() {
+                    array_lines.push(before_end.trim().to_string());
+                }
+                folders.extend(parse_shared_folders_array_lines(&array_lines));
+                array_lines.clear();
+                in_array = false;
+            } else {
+                array_lines.push(line.to_string());
+            }
+            continue;
+        }
+
+        if let Some(after_start) = trimmed.strip_prefix("SHARED_FOLDERS_ARGS=(") {
+            let inline = after_start.trim();
+            if let Some(before_end) = strip_array_closing_paren(inline) {
+                if !before_end.trim().is_empty() {
+                    array_lines.push(before_end.trim().to_string());
+                }
+                folders.extend(parse_shared_folders_array_lines(&array_lines));
+                array_lines.clear();
+            } else {
+                if !inline.is_empty() {
+                    array_lines.push(inline.to_string());
+                }
+                in_array = true;
+            }
+            continue;
+        }
+
+        if line.contains("SHARED_FOLDERS_ARGS=") {
+            folders.extend(parse_shared_folders_legacy_line(line));
+        }
+    }
+
+    if in_array {
+        folders.extend(parse_shared_folders_array_lines(&array_lines));
+    }
+
+    folders
+}
+
+fn strip_array_closing_paren(line: &str) -> Option<&str> {
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Quote {
+        None,
+        Single,
+        Double,
+    }
+
+    let line = line.trim_end();
+    let mut quote = Quote::None;
+    let mut escaped = false;
+    let mut close_idx = None;
+
+    for (idx, c) in line.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        match quote {
+            Quote::None => match c {
+                '\\' => escaped = true,
+                '\'' => quote = Quote::Single,
+                '"' => quote = Quote::Double,
+                ')' => close_idx = Some(idx),
+                _ => {}
+            },
+            Quote::Single => {
+                if c == '\'' {
+                    quote = Quote::None;
+                }
+            }
+            Quote::Double => match c {
+                '\\' => escaped = true,
+                '"' => quote = Quote::None,
+                _ => {}
+            },
+        }
+    }
+
+    if quote != Quote::None {
+        return None;
+    }
+
+    let close_idx = close_idx?;
+    let trailing = line[close_idx + 1..].trim();
+    if trailing.is_empty() || trailing.starts_with('#') {
+        Some(line[..close_idx].trim_end())
+    } else {
+        None
+    }
+}
+
+fn parse_shared_folders_legacy_line(line: &str) -> Vec<SharedFolder> {
+    let mut folders = Vec::new();
+
+    // Legacy scalar format:
+    // SHARED_FOLDERS_ARGS="-fsdev local,id=...,path=...,security_model=... -device ...,mount_tag=..."
+    for part in line.split("-fsdev ") {
+        if !part.contains("path=") {
+            continue;
+        }
+        let host_path = extract_path_value(part);
+        let mount_tag = extract_simple_value(part, "mount_tag=");
+
+        if let (Some(path), Some(tag)) = (host_path, mount_tag) {
+            folders.push(SharedFolder {
+                host_path: path,
+                mount_tag: tag,
+            });
+        }
+    }
+
+    folders
+}
+
+fn parse_shared_folders_array_lines(lines: &[String]) -> Vec<SharedFolder> {
+    let mut tokens = Vec::new();
+    for line in lines {
+        tokens.extend(parse_shell_words(line));
+    }
+    parse_shared_folder_tokens(&tokens)
+}
+
+fn parse_shared_folder_tokens(tokens: &[String]) -> Vec<SharedFolder> {
+    let mut folders = Vec::new();
+    let mut i = 0;
+
+    while i < tokens.len() {
+        if tokens[i] != "-fsdev" {
+            i += 1;
+            continue;
+        }
+
+        let Some(fsdev_arg) = tokens.get(i + 1) else {
+            break;
+        };
+
+        let mut mount_tag = None;
+        let mut j = i + 2;
+        while j + 1 < tokens.len() {
+            if tokens[j] == "-fsdev" {
+                break;
+            }
+            if tokens[j] == "-device" {
+                mount_tag = extract_simple_value(&tokens[j + 1], "mount_tag=");
+                break;
+            }
+            j += 1;
+        }
+
+        if let (Some(path), Some(tag)) = (extract_path_value(fsdev_arg), mount_tag) {
+            folders.push(SharedFolder {
+                host_path: path,
+                mount_tag: tag,
+            });
+        }
+
+        i += 2;
+    }
+
+    folders
+}
+
+fn parse_shell_words(line: &str) -> Vec<String> {
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Quote {
+        None,
+        Single,
+        Double,
+    }
+
+    let mut words = Vec::new();
+    let mut current = String::new();
+    let mut in_word = false;
+    let mut quote = Quote::None;
+    let mut chars = line.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        match quote {
+            Quote::None => match c {
+                c if c.is_whitespace() => {
+                    if in_word {
+                        words.push(std::mem::take(&mut current));
+                        in_word = false;
+                    }
+                }
+                '\'' => {
+                    quote = Quote::Single;
+                    in_word = true;
+                }
+                '"' => {
+                    quote = Quote::Double;
+                    in_word = true;
+                }
+                '\\' => {
+                    if let Some(next) = chars.next() {
+                        current.push(next);
+                        in_word = true;
+                    }
+                }
+                _ => {
+                    current.push(c);
+                    in_word = true;
+                }
+            },
+            Quote::Single => {
+                if c == '\'' {
+                    quote = Quote::None;
+                } else {
+                    current.push(c);
+                }
+            }
+            Quote::Double => {
+                if c == '"' {
+                    quote = Quote::None;
+                } else if c == '\\' {
+                    if let Some(next) = chars.next() {
+                        current.push(next);
+                    }
+                } else {
+                    current.push(c);
                 }
             }
         }
     }
 
-    folders
+    if in_word {
+        words.push(current);
+    }
+
+    words
 }
 
 /// Extract a path value from a -fsdev argument, handling shell quoting
@@ -1048,8 +1293,14 @@ fn extract_path_value(s: &str) -> Option<String> {
         }
         Some(result)
     } else {
-        // Unquoted path: ends at comma or space
-        let end = rest.find([',', ' ', '"']).unwrap_or(rest.len());
+        // Unquoted path in the array format can contain spaces because the
+        // whole fsdev option is one shell array element. It ends at the next
+        // QEMU fsdev option key.
+        let end = rest
+            .find(",security_model=")
+            .or_else(|| rest.find(",readonly="))
+            .or_else(|| rest.find([',', '"']))
+            .unwrap_or(rest.len());
         Some(rest[..end].to_string())
     }
 }

--- a/src/vm/lifecycle.rs
+++ b/src/vm/lifecycle.rs
@@ -32,6 +32,8 @@ fn path_to_str(path: &Path) -> Result<&str> {
 pub struct LaunchOptions {
     pub boot_mode: BootMode,
     pub extra_args: Vec<String>,
+    /// USB passthrough is persisted in the VM's launch script. Runtime devices
+    /// are ignored so QEMU flags are not passed to the script as shell options.
     pub usb_devices: Vec<UsbPassthrough>,
 }
 
@@ -44,23 +46,6 @@ pub struct UsbPassthrough {
 }
 
 impl UsbPassthrough {
-    /// Generate QEMU device arguments for this USB device
-    /// If `bus` is provided, attach to that specific bus (e.g., "xhci.0" for USB 3.0)
-    pub fn to_qemu_args(&self, bus: Option<&str>) -> Vec<String> {
-        let device_spec = if let Some(bus_name) = bus {
-            format!(
-                "usb-host,bus={},vendorid=0x{:04x},productid=0x{:04x}",
-                bus_name, self.vendor_id, self.product_id
-            )
-        } else {
-            format!(
-                "usb-host,vendorid=0x{:04x},productid=0x{:04x}",
-                self.vendor_id, self.product_id
-            )
-        };
-        vec!["-device".to_string(), device_spec]
-    }
-
     /// Check if this device is USB 3.0 or higher
     pub fn is_usb3(&self) -> bool {
         self.usb_version.is_usb3()
@@ -154,24 +139,10 @@ pub fn launch_vm_with_error_check(vm: &DiscoveredVm, options: &LaunchOptions) ->
 
     args.extend(options.extra_args.clone());
 
-    // Add USB passthrough arguments
     if !options.usb_devices.is_empty() {
-        args.push("-usb".to_string());
-
-        // Check if any USB 3.0 devices are present
-        let has_usb3 = options.usb_devices.iter().any(|d| d.is_usb3());
-
-        // Add xHCI controller if USB 3.0 devices are present
-        if has_usb3 {
-            args.push("-device".to_string());
-            args.push("qemu-xhci,id=xhci,p2=8,p3=8".to_string());
-        }
-
-        // Add each USB device, attaching USB 3.0 devices to xHCI controller
-        for usb in &options.usb_devices {
-            let bus = if usb.is_usb3() { Some("xhci.0") } else { None };
-            args.extend(usb.to_qemu_args(bus));
-        }
+        log::warn!(
+            "Ignoring LaunchOptions::usb_devices; save USB passthrough to launch.sh before launching"
+        );
     }
 
     cmd.args(&args);

--- a/src/vm/single_gpu_scripts.rs
+++ b/src/vm/single_gpu_scripts.rs
@@ -112,6 +112,8 @@ struct LaunchScriptComponents {
     has_uefi: bool,
     /// SMBIOS_OPTS array definition
     smbios_opts: Option<String>,
+    /// Shared folders QEMU args array/scalar definition
+    shared_folders_args: Option<String>,
 }
 
 /// Parse the launch.sh script to extract important components
@@ -131,6 +133,28 @@ fn parse_launch_script(content: &str) -> LaunchScriptComponents {
         // Check for ISO variable
         if trimmed.starts_with("ISO=") {
             components.iso_var = Some(trimmed.to_string());
+        }
+
+        // Check for shared folders args (new multi-line array, or legacy scalar)
+        if trimmed.starts_with("SHARED_FOLDERS_ARGS=(") {
+            let mut shared_block = String::new();
+            shared_block.push_str(lines[i]);
+            shared_block.push('\n');
+
+            if !line_closes_shell_array(lines[i]) {
+                i += 1;
+                while i < lines.len() {
+                    shared_block.push_str(lines[i]);
+                    shared_block.push('\n');
+                    if line_closes_shell_array(lines[i]) {
+                        break;
+                    }
+                    i += 1;
+                }
+            }
+            components.shared_folders_args = Some(shared_block);
+        } else if trimmed.starts_with("SHARED_FOLDERS_ARGS=") {
+            components.shared_folders_args = Some(trimmed.to_string());
         }
 
         // Check for OVMF paths
@@ -190,6 +214,57 @@ fn parse_launch_script(content: &str) -> LaunchScriptComponents {
     }
 
     components
+}
+
+fn line_closes_shell_array(line: &str) -> bool {
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Quote {
+        None,
+        Single,
+        Double,
+    }
+
+    let line = line.trim_end();
+    let mut quote = Quote::None;
+    let mut escaped = false;
+    let mut close_idx = None;
+
+    for (idx, c) in line.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        match quote {
+            Quote::None => match c {
+                '\\' => escaped = true,
+                '\'' => quote = Quote::Single,
+                '"' => quote = Quote::Double,
+                ')' => close_idx = Some(idx),
+                _ => {}
+            },
+            Quote::Single => {
+                if c == '\'' {
+                    quote = Quote::None;
+                }
+            }
+            Quote::Double => match c {
+                '\\' => escaped = true,
+                '"' => quote = Quote::None,
+                _ => {}
+            },
+        }
+    }
+
+    if quote != Quote::None {
+        return false;
+    }
+
+    let Some(close_idx) = close_idx else {
+        return false;
+    };
+    let trailing = line[close_idx + 1..].trim();
+    trailing.is_empty() || trailing.starts_with('#')
 }
 
 /// Extract a quoted value from a variable assignment
@@ -690,10 +765,24 @@ fn generate_variable_definitions(vm: &DiscoveredVm, components: &LaunchScriptCom
         vars.push(smbios.clone());
     }
 
+    // Add shared folder args if present.
+    if let Some(ref shared_folders) = components.shared_folders_args {
+        vars.push(shared_folders.trim_end().to_string());
+    }
+
     if vars.is_empty() {
         String::new()
     } else {
         vars.join("\n") + "\n"
+    }
+}
+
+fn shared_folders_args_ref(components: &LaunchScriptComponents) -> Option<&'static str> {
+    let args = components.shared_folders_args.as_deref()?;
+    if args.trim_start().starts_with("SHARED_FOLDERS_ARGS=(") {
+        Some(r#""${SHARED_FOLDERS_ARGS[@]}""#)
+    } else {
+        Some("$SHARED_FOLDERS_ARGS")
     }
 }
 
@@ -1506,6 +1595,15 @@ fn generate_basic_qemu_command(
         ));
     }
 
+    // Add shared folders.
+    if let Some(shared_ref) = shared_folders_args_ref(components) {
+        cmd.push_str(&format!(
+            r#" \
+    {}"#,
+            shared_ref
+        ));
+    }
+
     // Boot from disk
     cmd.push_str(
         r#" \
@@ -1804,5 +1902,84 @@ mod tests {
     fn setup_script_disables_idle_d3() {
         let script = generate_interactive_setup_script("amdgpu");
         assert!(script.contains("options vfio_pci disable_vga=1 disable_idle_d3=1"));
+    }
+
+    #[test]
+    fn parse_launch_script_preserves_shared_folders_array() {
+        let script = r#"#!/bin/bash
+# >>> Shared Folders (managed by vm-curator) >>>
+SHARED_FOLDERS_ARGS=(
+    -fsdev
+    'local,id=fsdev0,path=/home/user/My Documents,security_model=mapped-xattr'
+    -device
+    'virtio-9p-pci,fsdev=fsdev0,mount_tag=host_my_documents'
+)
+# <<< Shared Folders <<<
+qemu-system-x86_64 "${SHARED_FOLDERS_ARGS[@]}"
+"#;
+
+        let components = parse_launch_script(script);
+        let shared = components
+            .shared_folders_args
+            .as_deref()
+            .expect("shared folder args should be extracted");
+        assert!(shared.contains("SHARED_FOLDERS_ARGS=("));
+        assert!(shared.contains("path=/home/user/My Documents"));
+
+        let dir = tempfile::tempdir().unwrap();
+        let vm = DiscoveredVm {
+            id: "test-vm".to_string(),
+            path: dir.path().to_path_buf(),
+            launch_script: dir.path().join("launch.sh"),
+            config: crate::vm::QemuConfig::default(),
+            custom_name: None,
+            os_profile: None,
+            notes: None,
+        };
+
+        let vars = generate_variable_definitions(&vm, &components);
+        assert!(vars.contains("SHARED_FOLDERS_ARGS=("));
+        assert!(vars.contains("path=/home/user/My Documents"));
+    }
+
+    #[test]
+    fn parse_launch_script_stops_shared_folders_array_on_final_arg_line_close() {
+        let script = r#"#!/bin/bash
+# >>> Shared Folders (managed by vm-curator) >>>
+SHARED_FOLDERS_ARGS=(
+    -fsdev
+    'local,id=fsdev0,path=/home/user/My Documents,security_model=mapped-xattr'
+    -device
+    'virtio-9p-pci,fsdev=fsdev0,mount_tag=host_my_documents' )
+# <<< Shared Folders <<<
+qemu-system-x86_64 "${SHARED_FOLDERS_ARGS[@]}"
+echo after
+"#;
+
+        let components = parse_launch_script(script);
+        let shared = components
+            .shared_folders_args
+            .as_deref()
+            .expect("shared folder args should be extracted");
+        assert!(shared.contains("SHARED_FOLDERS_ARGS=("));
+        assert!(shared.contains("mount_tag=host_my_documents"));
+        assert!(!shared.contains("# <<< Shared Folders <<<"));
+        assert!(!shared.contains("qemu-system-x86_64"));
+        assert!(!shared.contains("echo after"));
+
+        let dir = tempfile::tempdir().unwrap();
+        let vm = DiscoveredVm {
+            id: "test-vm".to_string(),
+            path: dir.path().to_path_buf(),
+            launch_script: dir.path().join("launch.sh"),
+            config: crate::vm::QemuConfig::default(),
+            custom_name: None,
+            os_profile: None,
+            notes: None,
+        };
+
+        let vars = generate_variable_definitions(&vm, &components);
+        assert!(!vars.contains("qemu-system-x86_64"));
+        assert!(!vars.contains("echo after"));
     }
 }

--- a/src/vm/tests/create.rs
+++ b/src/vm/tests/create.rs
@@ -118,6 +118,86 @@ fn test_build_qemu_command_with_cdrom() {
 }
 
 #[test]
+fn test_build_qemu_command_uefi_normal_boot_prefers_disk() {
+    let config = WizardQemuConfig {
+        uefi: true,
+        disk_interface: "virtio".to_string(),
+        ..WizardQemuConfig::default()
+    };
+
+    let cmd = build_qemu_command_with_os(&config, "disk.qcow2", &InstallMedia::None, None, None);
+
+    assert!(cmd.contains("-drive if=pflash,format=raw,file=\"$OVMF_VARS\""));
+    assert!(cmd.contains("-global virtio-blk-pci.bootindex=0"));
+    assert!(cmd.contains("-drive file=\"$DISK\",format=qcow2,if=virtio,index=0,media=disk"));
+    assert!(cmd.contains("-boot strict=on"));
+    assert!(!cmd.contains("-boot order=c,strict=on"));
+}
+
+#[test]
+fn test_build_qemu_command_uefi_normal_boot_with_attached_floppy_prefers_disk() {
+    let config = WizardQemuConfig {
+        uefi: true,
+        disk_interface: "virtio".to_string(),
+        ..WizardQemuConfig::default()
+    };
+
+    let cmd = build_qemu_command_with_os(
+        &config,
+        "disk.qcow2",
+        &InstallMedia::None,
+        None,
+        Some("\"$FLOPPY\""),
+    );
+
+    assert!(cmd.contains("-fda \"$FLOPPY\""));
+    assert!(cmd.contains("-global virtio-blk-pci.bootindex=0"));
+    assert!(cmd.contains("-boot strict=on"));
+    assert!(!cmd.contains("-boot a"));
+}
+
+#[test]
+fn test_build_qemu_command_uefi_explicit_floppy_boot_does_not_force_disk() {
+    let config = WizardQemuConfig {
+        uefi: true,
+        disk_interface: "virtio".to_string(),
+        ..WizardQemuConfig::default()
+    };
+
+    let cmd = build_qemu_command_with_os_impl(
+        &config,
+        "disk.qcow2",
+        &InstallMedia::None,
+        None,
+        Some("\"$2\""),
+        true,
+    );
+
+    assert!(cmd.contains("-fda \"$2\""));
+    assert!(cmd.contains("-boot a"));
+    assert!(!cmd.contains("-global virtio-blk-pci.bootindex=0"));
+    assert!(!cmd.contains("-boot strict=on"));
+    assert!(!cmd.contains("-boot order=c,strict=on"));
+}
+
+#[test]
+fn test_build_qemu_command_uefi_cdrom_still_prefers_cdrom() {
+    let config = WizardQemuConfig {
+        uefi: true,
+        disk_interface: "virtio".to_string(),
+        ..WizardQemuConfig::default()
+    };
+
+    let cmd =
+        build_qemu_command_with_os(&config, "disk.qcow2", &InstallMedia::Iso(None), None, None);
+
+    assert!(cmd.contains("-boot d"));
+    assert!(!cmd.contains("-global virtio-blk-pci.bootindex=0"));
+    assert!(!cmd.contains("-boot order=c,strict=on"));
+    assert!(!cmd.contains("-boot strict=on"));
+}
+
+#[test]
 fn test_generate_network_args_user_with_portfwd() {
     let forwards = vec![
         PortForward {
@@ -424,6 +504,33 @@ fn test_generate_launch_script_iso_unchanged() {
         script.contains("-boot d"),
         "Install mode should boot from CD-ROM"
     );
+}
+
+#[test]
+fn test_generate_launch_script_uefi_with_floppy_keeps_normal_disk_boot() {
+    let config = WizardQemuConfig {
+        uefi: true,
+        disk_interface: "virtio".to_string(),
+        ..WizardQemuConfig::default()
+    };
+    let script = generate_launch_script_with_os(
+        "Linux VM",
+        "disk.qcow2",
+        None,
+        false,
+        &config,
+        None,
+        Some(Path::new("/tmp/boot.img")),
+    );
+
+    assert!(script.contains("FLOPPY=/tmp/boot.img"));
+    assert_eq!(
+        script.matches("-global virtio-blk-pci.bootindex=0").count(),
+        1
+    );
+    assert_eq!(script.matches("-boot strict=on").count(), 1);
+    assert!(script.contains("-fda \"$FLOPPY\""));
+    assert!(script.contains("-boot a"));
 }
 
 fn existing_disk_state(

--- a/src/vm/tests/lifecycle.rs
+++ b/src/vm/tests/lifecycle.rs
@@ -34,6 +34,7 @@ fn test_generate_shared_folders_section_single() {
     let section = generate_shared_folders_section(&folders, "virtio-9p-pci");
     assert!(section.contains(SHARED_FOLDERS_MARKER_START));
     assert!(section.contains(SHARED_FOLDERS_MARKER_END));
+    assert!(section.contains("SHARED_FOLDERS_ARGS=("));
     assert!(section.contains("path=/home/user/Documents"));
     assert!(section.contains("mount_tag=host_documents"));
     assert!(section.contains("virtio-9p-pci"));
@@ -77,7 +78,8 @@ fn test_generate_shared_folders_section_path_with_spaces() {
         mount_tag: "host_my_documents".to_string(),
     }];
     let section = generate_shared_folders_section(&folders, "virtio-9p-pci");
-    assert!(section.contains("'/home/user/My Documents'"));
+    assert!(section.contains("path=/home/user/My Documents"));
+    assert!(section.contains("SHARED_FOLDERS_ARGS=("));
 }
 
 #[test]
@@ -96,6 +98,30 @@ fn test_parse_shared_folders_section() {
 fn test_parse_shared_folders_section_quoted_path() {
     let content = format!(
         "{}\nSHARED_FOLDERS_ARGS=\"-fsdev local,id=fsdev0,path='/home/user/My Documents',security_model=mapped-xattr -device virtio-9p-pci,fsdev=fsdev0,mount_tag=host_my_documents\"\n{}\n",
+        SHARED_FOLDERS_MARKER_START, SHARED_FOLDERS_MARKER_END
+    );
+    let folders = parse_shared_folders_section(&content);
+    assert_eq!(folders.len(), 1);
+    assert_eq!(folders[0].host_path, "/home/user/My Documents");
+    assert_eq!(folders[0].mount_tag, "host_my_documents");
+}
+
+#[test]
+fn test_parse_shared_folders_section_array() {
+    let content = format!(
+        "{}\nSHARED_FOLDERS_ARGS=(\n    -fsdev\n    'local,id=fsdev0,path=/home/user/My Documents,security_model=mapped-xattr'\n    -device\n    'virtio-9p-pci,fsdev=fsdev0,mount_tag=host_my_documents'\n)\n{}\n",
+        SHARED_FOLDERS_MARKER_START, SHARED_FOLDERS_MARKER_END
+    );
+    let folders = parse_shared_folders_section(&content);
+    assert_eq!(folders.len(), 1);
+    assert_eq!(folders[0].host_path, "/home/user/My Documents");
+    assert_eq!(folders[0].mount_tag, "host_my_documents");
+}
+
+#[test]
+fn test_parse_shared_folders_section_array_closes_on_final_arg_line() {
+    let content = format!(
+        "{}\nSHARED_FOLDERS_ARGS=(\n    -fsdev\n    'local,id=fsdev0,path=/home/user/My Documents,security_model=mapped-xattr'\n    -device\n    'virtio-9p-pci,fsdev=fsdev0,mount_tag=host_my_documents' )\n{}\nqemu-system-x86_64 \"${{SHARED_FOLDERS_ARGS[@]}}\"\n",
         SHARED_FOLDERS_MARKER_START, SHARED_FOLDERS_MARKER_END
     );
     let folders = parse_shared_folders_section(&content);
@@ -130,10 +156,14 @@ fn test_remove_shared_folders_section() {
 #[test]
 fn test_insert_shared_folders_section_simple() {
     let content = "#!/bin/bash\nqemu-system-x86_64 -m 2048\n";
-    let section = "# >>> Shared Folders (managed by vm-curator) >>>\nSHARED_FOLDERS_ARGS=\"-fsdev local,id=fsdev0,path=/tmp,security_model=mapped-xattr -device virtio-9p-pci,fsdev=fsdev0,mount_tag=host_tmp\"\n# <<< Shared Folders <<<\n";
-    let result = insert_shared_folders_section(content, section);
+    let folders = vec![SharedFolder {
+        host_path: "/tmp".to_string(),
+        mount_tag: "host_tmp".to_string(),
+    }];
+    let section = generate_shared_folders_section(&folders, "virtio-9p-pci");
+    let result = insert_shared_folders_section(content, &section);
     assert!(result.contains(SHARED_FOLDERS_MARKER_START));
-    assert!(result.contains("$SHARED_FOLDERS_ARGS"));
+    assert!(result.contains(SHARED_FOLDERS_ARGS_REF));
     // Section should appear before QEMU command
     let marker_pos = result.find(SHARED_FOLDERS_MARKER_START).unwrap();
     let qemu_pos = result.find("qemu-system-x86_64").unwrap();
@@ -158,8 +188,8 @@ fn test_insert_section_before_case_statement() {
         case_pos
     );
 
-    // Both QEMU commands should have $SHARED_FOLDERS_ARGS appended
-    let count = result.matches("$SHARED_FOLDERS_ARGS").count();
+    // Both QEMU commands should have the shared-folder array expansion appended.
+    let count = result.matches(SHARED_FOLDERS_ARGS_REF).count();
     assert_eq!(
         count, 2,
         "Expected 2 appended refs (one per QEMU command), got {}",
@@ -186,6 +216,50 @@ fn test_roundtrip_shared_folders() {
     assert_eq!(parsed[0].mount_tag, "host_documents");
     assert_eq!(parsed[1].host_path, "/home/user/My Pictures");
     assert_eq!(parsed[1].mount_tag, "host_my_pictures");
+}
+
+#[test]
+fn test_shared_folders_array_survives_shell_expansion() {
+    let folders = vec![SharedFolder {
+        host_path: "/home/user/O'Brien Documents".to_string(),
+        mount_tag: "host_obrien_documents".to_string(),
+    }];
+    let section = generate_shared_folders_section(&folders, "virtio-9p-pci");
+    let script = format!(
+        "{}\nset -- qemu-system-x86_64 {}\nprintf '%s\\0' \"$@\"\n",
+        section, SHARED_FOLDERS_ARGS_REF
+    );
+
+    let output = std::process::Command::new("bash")
+        .arg("-c")
+        .arg(script)
+        .output()
+        .expect("bash should run shared-folder expansion test");
+
+    assert!(
+        output.status.success(),
+        "bash failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let args: Vec<String> = output
+        .stdout
+        .split(|b| *b == 0)
+        .filter(|part| !part.is_empty())
+        .map(|part| String::from_utf8(part.to_vec()).unwrap())
+        .collect();
+
+    assert_eq!(
+        args,
+        vec![
+            "qemu-system-x86_64".to_string(),
+            "-fsdev".to_string(),
+            "local,id=fsdev0,path=/home/user/O'Brien Documents,security_model=mapped-xattr"
+                .to_string(),
+            "-device".to_string(),
+            "virtio-9p-pci,fsdev=fsdev0,mount_tag=host_obrien_documents".to_string(),
+        ]
+    );
 }
 
 #[test]

--- a/src/vm/tests/lifecycle.rs
+++ b/src/vm/tests/lifecycle.rs
@@ -19,6 +19,73 @@ fn test_replace_display_for_dbus_strips_spice_agent_channel() {
     assert!(dbus.contains("-display dbus"), "display swapped to dbus");
 }
 
+fn test_vm(vm_dir: &std::path::Path) -> DiscoveredVm {
+    DiscoveredVm {
+        id: "test-vm".to_string(),
+        path: vm_dir.to_path_buf(),
+        launch_script: vm_dir.join("launch.sh"),
+        config: crate::vm::QemuConfig::default(),
+        custom_name: None,
+        os_profile: None,
+        notes: None,
+    }
+}
+
+#[test]
+fn test_save_usb_passthrough_persists_in_launch_script() {
+    let dir = tempfile::tempdir().unwrap();
+    let vm = test_vm(dir.path());
+    std::fs::write(
+        &vm.launch_script,
+        "#!/bin/bash\nqemu-system-x86_64 -m 2048\n",
+    )
+    .unwrap();
+    let devices = vec![UsbPassthrough {
+        vendor_id: 0x413c,
+        product_id: 0x2113,
+        usb_version: crate::hardware::UsbVersion::Usb2,
+    }];
+
+    save_usb_passthrough(&vm, &devices).unwrap();
+
+    let script = std::fs::read_to_string(&vm.launch_script).unwrap();
+    assert!(script.contains(USB_MARKER_START));
+    assert!(script.contains("USB_PASSTHROUGH_ARGS=\"-usb"));
+    assert!(script.contains("vendorid=0x413c,productid=0x2113"));
+    assert!(script.contains("qemu-system-x86_64 -m 2048 $USB_PASSTHROUGH_ARGS"));
+
+    let loaded = load_usb_passthrough(&vm);
+    assert_eq!(loaded.len(), 1);
+    assert_eq!(loaded[0].vendor_id, 0x413c);
+    assert_eq!(loaded[0].product_id, 0x2113);
+}
+
+#[test]
+fn test_save_usb_passthrough_persists_usb3_controller() {
+    let dir = tempfile::tempdir().unwrap();
+    let vm = test_vm(dir.path());
+    std::fs::write(
+        &vm.launch_script,
+        "#!/bin/bash\nqemu-system-x86_64 -m 2048\n",
+    )
+    .unwrap();
+    let devices = vec![UsbPassthrough {
+        vendor_id: 0x413c,
+        product_id: 0x2113,
+        usb_version: crate::hardware::UsbVersion::Usb3,
+    }];
+
+    save_usb_passthrough(&vm, &devices).unwrap();
+
+    let script = std::fs::read_to_string(&vm.launch_script).unwrap();
+    assert!(script.contains("-device qemu-xhci,id=xhci,p2=8,p3=8"));
+    assert!(script.contains("usb-host,bus=xhci.0,vendorid=0x413c,productid=0x2113"));
+    assert_eq!(
+        load_usb_passthrough(&vm)[0].usb_version,
+        crate::hardware::UsbVersion::Usb3
+    );
+}
+
 #[test]
 fn test_generate_shared_folders_section_empty() {
     let section = generate_shared_folders_section(&[], "virtio-9p-pci");

--- a/src/vm/tests/lifecycle.rs
+++ b/src/vm/tests/lifecycle.rs
@@ -265,6 +265,47 @@ fn test_insert_section_before_case_statement() {
 }
 
 #[test]
+fn test_save_shared_folders_preserves_uefi_disk_boot_order() {
+    let dir = tempfile::tempdir().unwrap();
+    let vm = test_vm(dir.path());
+    std::fs::write(
+        &vm.launch_script,
+        r#"#!/bin/bash
+VM_DIR="$(dirname "$(readlink -f "$0")")"
+DISK="$VM_DIR/linux.raw"
+OVMF_VARS="$VM_DIR/OVMF_VARS.fd"
+case "$1" in
+    "")
+        qemu-system-x86_64 \
+        -drive if=pflash,format=raw,file="$OVMF_VARS" \
+        -global virtio-blk-pci.bootindex=0 \
+        -drive file="$DISK",format=raw,if=virtio,index=0,media=disk \
+        -boot strict=on \
+        -qmp \
+        unix:$VM_DIR/qemu.sock,server=on,wait=off
+        ;;
+esac
+"#,
+    )
+    .unwrap();
+    let folders = vec![SharedFolder {
+        host_path: "/home/user/shared".to_string(),
+        mount_tag: "host_shared".to_string(),
+    }];
+
+    save_shared_folders(&vm, &folders).unwrap();
+
+    let script = std::fs::read_to_string(&vm.launch_script).unwrap();
+    assert_eq!(
+        script.matches("-global virtio-blk-pci.bootindex=0").count(),
+        1
+    );
+    assert_eq!(script.matches("-boot strict=on").count(), 1);
+    assert!(script.contains("-drive file=\"$DISK\",format=raw,if=virtio,index=0,media=disk"));
+    assert!(script.contains("\"${SHARED_FOLDERS_ARGS[@]}\""));
+}
+
+#[test]
 fn test_roundtrip_shared_folders() {
     let folders = vec![
         SharedFolder {


### PR DESCRIPTION
## Summary

- preserve shared-folder arguments safely, including paths with spaces and quotes
- persist USB passthrough in launch scripts and keep single-GPU scripts in sync
- prefer the virtio disk for normal UEFI boots without overriding install or floppy boots
- keep management screens open when saving fails

Split from #57 as requested.

## Testing

- cargo fmt --all -- --check
- cargo test