### PR TITLE
Add configurable VM window size override

### DIFF
--- a/assets/metadata/settings_help.toml
+++ b/assets/metadata/settings_help.toml
@@ -41,6 +41,14 @@ description = """
 How VM windows are displayed. GTK: native look. SDL: lightweight. \
 Spice: best for remote access and Looking Glass."""
 
+[default_window_size]
+title = "Default Window Size"
+description = """
+Initial VM display size when launching, such as 1280x800 or 1920x1080. \
+Leave empty or enter none to use each VM's launch script default. \
+Applies to vm-curator generated launch scripts that use standard VGA, \
+virtio-vga, virtio-vga-gl, or QXL video devices."""
+
 [default_enable_kvm]
 title = "Enable KVM"
 description = """

--- a/src/app.rs
+++ b/src/app.rs
@@ -879,6 +879,7 @@ impl App {
             boot_mode: self.boot_mode.clone(),
             extra_args: Vec::new(),
             usb_devices,
+            window_size: self.config.default_window_size,
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,3 +1,4 @@
+use crate::vm::WindowSize;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -29,6 +30,9 @@ pub struct Config {
     pub default_disk_size_gb: u32,
     /// Default display backend (gtk, sdl, spice)
     pub default_display: String,
+    /// Default VM display size when launching (e.g. "1280x800"); None disables override
+    #[serde(default)]
+    pub default_window_size: Option<WindowSize>,
     /// Enable KVM acceleration by default
     pub default_enable_kvm: bool,
 
@@ -76,6 +80,7 @@ impl Default for Config {
             default_cpu_cores: 2,
             default_disk_size_gb: 64,
             default_display: "gtk".to_string(),
+            default_window_size: None,
             default_enable_kvm: true,
 
             // Behavior
@@ -170,6 +175,7 @@ mod tests {
             snapshot_prefix: "custom-prefix".to_string(),
             default_memory_mb: 8192,
             default_iso_path: Some(PathBuf::from("/tmp/isos")),
+            default_window_size: WindowSize::parse("1440x900"),
             single_gpu_enabled: true,
             ..Config::default()
         };
@@ -182,6 +188,7 @@ mod tests {
         assert_eq!(loaded.snapshot_prefix, "custom-prefix");
         assert_eq!(loaded.default_memory_mb, 8192);
         assert_eq!(loaded.default_iso_path, Some(PathBuf::from("/tmp/isos")));
+        assert_eq!(loaded.default_window_size, WindowSize::parse("1440x900"));
         assert!(loaded.single_gpu_enabled);
     }
 
@@ -200,6 +207,26 @@ mod tests {
             loaded.default_cpu_cores,
             Config::default().default_cpu_cores
         );
+    }
+
+    #[test]
+    fn window_size_serializes_as_string() {
+        let cfg = Config {
+            default_window_size: WindowSize::parse("1440x900"),
+            ..Config::default()
+        };
+
+        let content = toml::to_string_pretty(&cfg).unwrap();
+        assert!(content.contains("default_window_size = \"1440x900\""));
+    }
+
+    #[test]
+    fn load_from_invalid_window_size_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "default_window_size = \"tiny\"\n").unwrap();
+
+        assert!(Config::load_from(&path).is_err());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -332,6 +332,7 @@ fn cmd_launch(config: &Config, name: &str, install: bool, cdrom: Option<PathBuf>
         boot_mode,
         extra_args: Vec::new(),
         usb_devices: Vec::new(),
+        window_size: config.default_window_size,
     };
 
     println!("Launching {}...", vm.display_name());

--- a/src/ui/screens/settings.rs
+++ b/src/ui/screens/settings.rs
@@ -16,6 +16,7 @@ use crate::hardware::{
     MultiGpuPassthroughStatus, SingleGpuSupport,
 };
 use crate::vm::single_gpu_scripts::{run_system_setup, SystemSetupResult};
+use crate::vm::WindowSize;
 
 /// GPU passthrough validation result
 #[derive(Debug)]
@@ -34,6 +35,7 @@ pub enum SettingsItem {
     DefaultCpuCores,
     DefaultDiskSize,
     DefaultDisplay,
+    DefaultWindowSize,
     DefaultEnableKvm,
     ConfirmBeforeLaunch,
     // GPU Passthrough section header (not selectable, just a label)
@@ -74,6 +76,7 @@ impl SettingsItem {
             SettingsItem::DefaultCpuCores => "Default CPU Cores",
             SettingsItem::DefaultDiskSize => "Default Disk Size (GB)",
             SettingsItem::DefaultDisplay => "Default Display",
+            SettingsItem::DefaultWindowSize => "Default Window Size",
             SettingsItem::DefaultEnableKvm => "Enable KVM by Default",
             SettingsItem::ConfirmBeforeLaunch => "Confirm Before Launch",
             // GPU Passthrough
@@ -103,6 +106,10 @@ impl SettingsItem {
             SettingsItem::DefaultCpuCores => config.default_cpu_cores.to_string(),
             SettingsItem::DefaultDiskSize => config.default_disk_size_gb.to_string(),
             SettingsItem::DefaultDisplay => config.default_display.clone(),
+            SettingsItem::DefaultWindowSize => config
+                .default_window_size
+                .map(|size| size.to_string())
+                .unwrap_or_default(),
             SettingsItem::DefaultEnableKvm => bool_to_yes_no(config.default_enable_kvm),
             SettingsItem::ConfirmBeforeLaunch => bool_to_yes_no(config.confirm_before_launch),
             // GPU Passthrough
@@ -176,6 +183,7 @@ impl SettingsItem {
             SettingsItem::DefaultCpuCores => "default_cpu_cores",
             SettingsItem::DefaultDiskSize => "default_disk_size",
             SettingsItem::DefaultDisplay => "default_display",
+            SettingsItem::DefaultWindowSize => "default_window_size",
             SettingsItem::DefaultEnableKvm => "default_enable_kvm",
             SettingsItem::ConfirmBeforeLaunch => "confirm_before_launch",
             SettingsItem::GpuPassthroughHeader => "gpu_passthrough_header",
@@ -217,6 +225,7 @@ fn build_visible_items(config: &Config) -> Vec<VisibleItem> {
         make_visible(SettingsItem::DefaultCpuCores, 0),
         make_visible(SettingsItem::DefaultDiskSize, 0),
         make_visible(SettingsItem::DefaultDisplay, 0),
+        make_visible(SettingsItem::DefaultWindowSize, 0),
         make_visible(SettingsItem::DefaultEnableKvm, 0),
     ];
     items.push(make_visible(SettingsItem::ConfirmBeforeLaunch, 0));
@@ -893,6 +902,21 @@ fn cycle_setting(app: &mut App, item: SettingsItem) -> anyhow::Result<()> {
     Ok(())
 }
 
+const INVALID_WINDOW_SIZE_STATUS: &str = "Invalid size. Use WIDTHxHEIGHT, for example 1280x800.";
+
+fn parse_default_window_size_setting(
+    value: &str,
+) -> std::result::Result<Option<WindowSize>, &'static str> {
+    let value = value.trim();
+    if value.is_empty() || value.eq_ignore_ascii_case("none") || value.eq_ignore_ascii_case("off") {
+        Ok(None)
+    } else {
+        WindowSize::parse(value)
+            .map(Some)
+            .ok_or(INVALID_WINDOW_SIZE_STATUS)
+    }
+}
+
 /// Apply an edit to a setting
 fn apply_edit(app: &mut App, item: SettingsItem) -> anyhow::Result<()> {
     let value = app.settings_edit_buffer.trim();
@@ -974,6 +998,15 @@ fn apply_edit(app: &mut App, item: SettingsItem) -> anyhow::Result<()> {
         SettingsItem::DefaultDisplay => {
             app.config.default_display = value.to_string();
         }
+        SettingsItem::DefaultWindowSize => match parse_default_window_size_setting(value) {
+            Ok(size) => {
+                app.config.default_window_size = size;
+            }
+            Err(message) => {
+                app.set_status(message);
+                return Ok(());
+            }
+        },
         SettingsItem::MultiGpuIvshmemSize => {
             if let Ok(mb) = value.parse::<u32>() {
                 // Clamp to reasonable range (16-512 MB)
@@ -1038,4 +1071,35 @@ fn save_config(app: &mut App) -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_default_window_size_setting_accepts_clear_values() {
+        assert_eq!(parse_default_window_size_setting(""), Ok(None));
+        assert_eq!(parse_default_window_size_setting(" none "), Ok(None));
+        assert_eq!(parse_default_window_size_setting("OFF"), Ok(None));
+    }
+
+    #[test]
+    fn parse_default_window_size_setting_accepts_sizes() {
+        assert_eq!(
+            parse_default_window_size_setting(" 1920X1080 "),
+            Ok(Some(WindowSize {
+                width: 1920,
+                height: 1080
+            }))
+        );
+    }
+
+    #[test]
+    fn parse_default_window_size_setting_rejects_bad_sizes() {
+        assert_eq!(
+            parse_default_window_size_setting("100x100"),
+            Err(INVALID_WINDOW_SIZE_STATUS)
+        );
+    }
 }

--- a/src/vm/create.rs
+++ b/src/vm/create.rs
@@ -686,6 +686,62 @@ fi
     )
 }
 
+fn shell_array_literal(args: &[String]) -> String {
+    let mut literal = String::from("(");
+    for (index, arg) in args.iter().enumerate() {
+        if index > 0 {
+            literal.push(' ');
+        }
+        literal.push_str(&shell_escape(arg));
+    }
+    literal.push(')');
+    literal
+}
+
+fn video_args_for_config(config: &WizardQemuConfig) -> (Vec<String>, Option<&'static str>) {
+    if config.gl_acceleration && config.vga == "virtio" {
+        (
+            vec!["-device".to_string(), "virtio-vga-gl".to_string()],
+            Some("virtio-vga-gl"),
+        )
+    } else {
+        let override_device = match config.vga.as_str() {
+            "std" => Some("VGA"),
+            "virtio" => Some("virtio-vga"),
+            "qxl" => Some("qxl-vga"),
+            _ => None,
+        };
+        (
+            vec!["-vga".to_string(), config.vga.clone()],
+            override_device,
+        )
+    }
+}
+
+fn generate_video_args_setup(config: &WizardQemuConfig) -> String {
+    let (default_args, override_device) = video_args_for_config(config);
+    let override_device = override_device.unwrap_or("");
+
+    format!(
+        r#"# Optional vm-curator window-size override
+VM_CURATOR_VIDEO_DEVICE={}
+VM_CURATOR_VIDEO_ARGS={}
+if [[ -n "${{VM_CURATOR_WINDOW_SIZE:-}}" && -n "$VM_CURATOR_VIDEO_DEVICE" ]]; then
+    if [[ "$VM_CURATOR_WINDOW_SIZE" =~ ^([0-9]+)[xX]([0-9]+)$ ]]; then
+        VM_CURATOR_WIDTH="${{BASH_REMATCH[1]}}"
+        VM_CURATOR_HEIGHT="${{BASH_REMATCH[2]}}"
+        if (( VM_CURATOR_WIDTH >= 320 && VM_CURATOR_WIDTH <= 16384 && VM_CURATOR_HEIGHT >= 200 && VM_CURATOR_HEIGHT <= 16384 )); then
+            VM_CURATOR_VIDEO_ARGS=(-device "${{VM_CURATOR_VIDEO_DEVICE}},xres=${{VM_CURATOR_WIDTH}},yres=${{VM_CURATOR_HEIGHT}}")
+        fi
+    fi
+fi
+
+"#,
+        shell_escape(override_device),
+        shell_array_literal(&default_args)
+    )
+}
+
 /// Generate the launch.sh script content with OS profile awareness
 pub fn generate_launch_script_with_os(
     vm_name: &str,
@@ -768,6 +824,7 @@ pub fn generate_launch_script_with_os(
     }
 
     script.push('\n');
+    script.push_str(&generate_video_args_setup(config));
 
     // macOS OpenCore bootloader verification
     if is_intel_macos_vm && needs_uefi && config.bios_path.is_some() {
@@ -1219,13 +1276,8 @@ fn build_qemu_command_with_os(
         }
     }
 
-    // VGA / Graphics (escaped to prevent injection)
-    if config.gl_acceleration && config.vga == "virtio" {
-        // Use virtio-vga-gl for 3D acceleration
-        args.push("-device virtio-vga-gl".to_string());
-    } else {
-        args.push(format!("-vga {}", shell_escape(&config.vga)));
-    }
+    // VGA / Graphics. The generated script owns optional window-size overrides.
+    args.push("\"${VM_CURATOR_VIDEO_ARGS[@]}\"".to_string());
 
     // Display (with GL if enabled, escaped to prevent injection)
     if config.gl_acceleration {

--- a/src/vm/launch_parser.rs
+++ b/src/vm/launch_parser.rs
@@ -197,7 +197,7 @@ fn extract_vga(content: &str) -> Option<VgaType> {
             let rest = &line[idx + 5..];
             let vga: String = rest
                 .chars()
-                .take_while(|c| !c.is_whitespace() && *c != '\\')
+                .take_while(|c| !c.is_whitespace() && *c != '\\' && *c != ')')
                 .collect();
             if !vga.is_empty() {
                 return Some(VgaType::from_str(&vga));

--- a/src/vm/lifecycle.rs
+++ b/src/vm/lifecycle.rs
@@ -1,6 +1,8 @@
 use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
 use std::io::{BufRead, BufReader};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
 use std::thread;
@@ -33,6 +35,62 @@ pub struct LaunchOptions {
     pub boot_mode: BootMode,
     pub extra_args: Vec<String>,
     pub usb_devices: Vec<UsbPassthrough>,
+    pub window_size: Option<WindowSize>,
+}
+
+/// Requested VM display size.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WindowSize {
+    pub width: u32,
+    pub height: u32,
+}
+
+impl WindowSize {
+    pub fn parse(value: &str) -> Option<Self> {
+        let value = value.trim();
+        let (width, height) = value.split_once('x').or_else(|| value.split_once('X'))?;
+        let width = width.trim().parse::<u32>().ok()?;
+        let height = height.trim().parse::<u32>().ok()?;
+
+        if (320..=16384).contains(&width) && (200..=16384).contains(&height) {
+            Some(Self { width, height })
+        } else {
+            None
+        }
+    }
+}
+
+impl fmt::Display for WindowSize {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}x{}", self.width, self.height)
+    }
+}
+
+impl Serialize for WindowSize {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for WindowSize {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::parse(&value)
+            .ok_or_else(|| serde::de::Error::custom("expected window size in WIDTHxHEIGHT format"))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct VideoOverrideSpec {
+    default_flag: &'static str,
+    default_value: &'static str,
+    override_device: &'static str,
 }
 
 /// USB device for passthrough
@@ -67,6 +125,113 @@ impl UsbPassthrough {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LaunchInvocation {
+    program: String,
+    current_dir: PathBuf,
+    args: Vec<String>,
+    env: Vec<(String, Option<String>)>,
+}
+
+impl LaunchInvocation {
+    fn command(&self) -> Command {
+        let mut cmd = Command::new(&self.program);
+        cmd.current_dir(&self.current_dir).args(&self.args);
+        for (name, value) in &self.env {
+            if let Some(value) = value {
+                cmd.env(name, value);
+            } else {
+                cmd.env_remove(name);
+            }
+        }
+        cmd
+    }
+}
+
+fn build_launch_invocation(
+    vm: &DiscoveredVm,
+    options: &LaunchOptions,
+) -> std::result::Result<LaunchInvocation, String> {
+    let mut invocation = LaunchInvocation {
+        program: "bash".to_string(),
+        current_dir: vm.path.clone(),
+        args: vec![vm.launch_script.to_string_lossy().to_string()],
+        env: vec![(
+            "VM_CURATOR_WINDOW_SIZE".to_string(),
+            options.window_size.map(|size| size.to_string()),
+        )],
+    };
+
+    match &options.boot_mode {
+        BootMode::Normal => {}
+        BootMode::Install => {
+            invocation.args.push("--install".to_string());
+        }
+        BootMode::Cdrom(iso_path) => {
+            if !iso_path.exists() {
+                return Err(format!("ISO file not found: {}", iso_path.display()));
+            }
+            if !iso_path.is_file() {
+                return Err(format!("ISO path is not a file: {}", iso_path.display()));
+            }
+            invocation.args.push("--cdrom".to_string());
+            invocation.args.push(iso_path.to_string_lossy().to_string());
+        }
+        BootMode::Recovery(dmg_path) => {
+            if !dmg_path.exists() {
+                return Err(format!("Recovery image not found: {}", dmg_path.display()));
+            }
+            if !dmg_path.is_file() {
+                return Err(format!(
+                    "Recovery image path is not a file: {}",
+                    dmg_path.display()
+                ));
+            }
+            invocation.args.push("--recovery".to_string());
+            invocation.args.push(dmg_path.to_string_lossy().to_string());
+        }
+        BootMode::Floppy(floppy_path) => {
+            if !floppy_path.exists() {
+                return Err(format!("Floppy image not found: {}", floppy_path.display()));
+            }
+            if !floppy_path.is_file() {
+                return Err(format!(
+                    "Floppy path is not a file: {}",
+                    floppy_path.display()
+                ));
+            }
+            invocation.args.push("--floppy".to_string());
+            invocation
+                .args
+                .push(floppy_path.to_string_lossy().to_string());
+        }
+        BootMode::Network => {
+            invocation.args.push("--netboot".to_string());
+        }
+    }
+
+    invocation.args.extend(options.extra_args.clone());
+
+    if !options.usb_devices.is_empty() {
+        invocation.args.push("-usb".to_string());
+
+        let has_usb3 = options.usb_devices.iter().any(|d| d.is_usb3());
+        if has_usb3 {
+            invocation.args.push("-device".to_string());
+            invocation
+                .args
+                .push("qemu-xhci,id=xhci,p2=8,p3=8".to_string());
+        }
+
+        for usb in &options.usb_devices {
+            let bus = if usb.is_usb3() { Some("xhci.0") } else { None };
+            invocation.args.extend(usb.to_qemu_args(bus));
+        }
+    }
+
+    Ok(invocation)
+}
+
 /// Launch a VM and monitor for immediate errors
 ///
 /// This function spawns the VM process and monitors stderr for a brief period
@@ -75,106 +240,26 @@ impl UsbPassthrough {
 pub fn launch_vm_with_error_check(vm: &DiscoveredVm, options: &LaunchOptions) -> LaunchResult {
     let vm_name = vm.display_name();
 
-    let mut cmd = Command::new("bash");
-    cmd.current_dir(&vm.path);
+    let invocation = match build_launch_invocation(vm, options) {
+        Ok(invocation) => invocation,
+        Err(error) => {
+            return LaunchResult {
+                success: false,
+                error: Some(error),
+                vm_name,
+            };
+        }
+    };
 
-    let mut args = vec![vm.launch_script.to_string_lossy().to_string()];
-
-    match &options.boot_mode {
-        BootMode::Normal => {}
-        BootMode::Install => {
-            args.push("--install".to_string());
-        }
-        BootMode::Cdrom(iso_path) => {
-            // Validate ISO path exists before attempting to launch
-            if !iso_path.exists() {
-                return LaunchResult {
-                    success: false,
-                    error: Some(format!("ISO file not found: {}", iso_path.display())),
-                    vm_name,
-                };
-            }
-            if !iso_path.is_file() {
-                return LaunchResult {
-                    success: false,
-                    error: Some(format!("ISO path is not a file: {}", iso_path.display())),
-                    vm_name,
-                };
-            }
-            args.push("--cdrom".to_string());
-            args.push(iso_path.to_string_lossy().to_string());
-        }
-        BootMode::Recovery(dmg_path) => {
-            // Validate DMG path exists before attempting to launch
-            if !dmg_path.exists() {
-                return LaunchResult {
-                    success: false,
-                    error: Some(format!("Recovery image not found: {}", dmg_path.display())),
-                    vm_name,
-                };
-            }
-            if !dmg_path.is_file() {
-                return LaunchResult {
-                    success: false,
-                    error: Some(format!(
-                        "Recovery image path is not a file: {}",
-                        dmg_path.display()
-                    )),
-                    vm_name,
-                };
-            }
-            args.push("--recovery".to_string());
-            args.push(dmg_path.to_string_lossy().to_string());
-        }
-        BootMode::Floppy(floppy_path) => {
-            if !floppy_path.exists() {
-                return LaunchResult {
-                    success: false,
-                    error: Some(format!("Floppy image not found: {}", floppy_path.display())),
-                    vm_name,
-                };
-            }
-            if !floppy_path.is_file() {
-                return LaunchResult {
-                    success: false,
-                    error: Some(format!(
-                        "Floppy path is not a file: {}",
-                        floppy_path.display()
-                    )),
-                    vm_name,
-                };
-            }
-            args.push("--floppy".to_string());
-            args.push(floppy_path.to_string_lossy().to_string());
-        }
-        BootMode::Network => {
-            args.push("--netboot".to_string());
+    if options.window_size.is_some() {
+        if let Err(e) = ensure_window_size_override_in_script(&vm.launch_script) {
+            log::warn!(
+                "launch_vm_with_error_check: could not patch window-size override into launch.sh: {e}"
+            );
         }
     }
 
-    args.extend(options.extra_args.clone());
-
-    // Add USB passthrough arguments
-    if !options.usb_devices.is_empty() {
-        args.push("-usb".to_string());
-
-        // Check if any USB 3.0 devices are present
-        let has_usb3 = options.usb_devices.iter().any(|d| d.is_usb3());
-
-        // Add xHCI controller if USB 3.0 devices are present
-        if has_usb3 {
-            args.push("-device".to_string());
-            args.push("qemu-xhci,id=xhci,p2=8,p3=8".to_string());
-        }
-
-        // Add each USB device, attaching USB 3.0 devices to xHCI controller
-        for usb in &options.usb_devices {
-            let bus = if usb.is_usb3() { Some("xhci.0") } else { None };
-            args.extend(usb.to_qemu_args(bus));
-        }
-    }
-
-    cmd.args(&args);
+    let mut cmd = invocation.command();
 
     // Capture stderr to detect errors, but let stdout go to null
     cmd.stdin(Stdio::null())
@@ -319,8 +404,8 @@ pub fn launch_vm_sync(vm: &DiscoveredVm, options: &LaunchOptions) -> Result<()> 
 /// with -display dbus (session bus). Returns the child process PID on success.
 #[allow(dead_code)]
 pub fn launch_vm_dbus(vm: &DiscoveredVm) -> Result<u32> {
-    let tmp = vm.path.join(".launch_dbus_tmp.sh");
-    let _ = std::fs::remove_file(&tmp); // stale temp script from prior crash
+    let tmp = vm.path.join(".launch_dbus_override.sh");
+    let _ = std::fs::remove_file(&tmp); // stale override script from prior crash
     let _ = std::fs::remove_file(vm.path.join("qemu.sock")); // stale socket from unclean shutdown
 
     if let Err(e) = ensure_qmp_in_script(&vm.path) {
@@ -332,7 +417,7 @@ pub fn launch_vm_dbus(vm: &DiscoveredVm) -> Result<u32> {
 
     let modified = replace_display_for_dbus(&content, "-display dbus");
 
-    std::fs::write(&tmp, &modified).context("Failed to write temp launch script")?;
+    std::fs::write(&tmp, &modified).context("Failed to write D-Bus launch override script")?;
     use std::os::unix::fs::PermissionsExt;
     let _ = std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o755));
 
@@ -1237,6 +1322,205 @@ bind_vfio || exit 1
 
     let new_content = insert_args_section(&cleaned, &section, "$PCI_PASSTHROUGH_ARGS");
     std::fs::write(&vm.launch_script, new_content).context("Failed to write launch script")?;
+    Ok(())
+}
+
+// ── Window size launch override ─────────────────────────────────────────────
+const WINDOW_SIZE_MARKER_START: &str = "# >>> Window size override (managed by vm-curator) >>>";
+const WINDOW_SIZE_MARKER_END: &str = "# <<< Window size override (managed by vm-curator) <<<";
+const VIDEO_ARGS_ARRAY_REF: &str = r#""${VM_CURATOR_VIDEO_ARGS[@]}""#;
+
+fn shell_quote(value: &str) -> String {
+    if value
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/' | ',' | '='))
+    {
+        value.to_string()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
+}
+
+fn strip_matching_quotes(value: &str) -> &str {
+    if value.len() >= 2
+        && ((value.starts_with('"') && value.ends_with('"'))
+            || (value.starts_with('\'') && value.ends_with('\'')))
+    {
+        &value[1..value.len() - 1]
+    } else {
+        value
+    }
+}
+
+fn parse_supported_video_arg_line(line: &str) -> Option<VideoOverrideSpec> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+
+    let command = trimmed.strip_suffix('\\').unwrap_or(trimmed).trim_end();
+
+    if let Some(rest) = command.strip_prefix("-vga ") {
+        let mut parts = rest.split_whitespace();
+        let vga = strip_matching_quotes(parts.next()?);
+        if parts.next().is_some() {
+            return None;
+        }
+
+        let (default_value, override_device) = match vga {
+            "std" => ("std", "VGA"),
+            "virtio" => ("virtio", "virtio-vga"),
+            "qxl" => ("qxl", "qxl-vga"),
+            _ => return None,
+        };
+
+        return Some(VideoOverrideSpec {
+            default_flag: "-vga",
+            default_value,
+            override_device,
+        });
+    }
+
+    if let Some(rest) = command.strip_prefix("-device ") {
+        let mut parts = rest.split_whitespace();
+        let device = strip_matching_quotes(parts.next()?);
+        if parts.next().is_some() {
+            return None;
+        }
+
+        let (default_value, override_device) = match device {
+            "VGA" => ("VGA", "VGA"),
+            "virtio-vga" => ("virtio-vga", "virtio-vga"),
+            "virtio-vga-gl" => ("virtio-vga-gl", "virtio-vga-gl"),
+            "qxl-vga" => ("qxl-vga", "qxl-vga"),
+            _ => return None,
+        };
+
+        return Some(VideoOverrideSpec {
+            default_flag: "-device",
+            default_value,
+            override_device,
+        });
+    }
+
+    None
+}
+
+fn window_size_setup_block(spec: &VideoOverrideSpec) -> String {
+    format!(
+        r#"{WINDOW_SIZE_MARKER_START}
+VM_CURATOR_VIDEO_DEVICE={}
+VM_CURATOR_VIDEO_ARGS={}
+if [[ -n "${{VM_CURATOR_WINDOW_SIZE:-}}" && -n "$VM_CURATOR_VIDEO_DEVICE" ]]; then
+    if [[ "$VM_CURATOR_WINDOW_SIZE" =~ ^([0-9]+)[xX]([0-9]+)$ ]]; then
+        VM_CURATOR_WIDTH="${{BASH_REMATCH[1]}}"
+        VM_CURATOR_HEIGHT="${{BASH_REMATCH[2]}}"
+        if (( VM_CURATOR_WIDTH >= 320 && VM_CURATOR_WIDTH <= 16384 && VM_CURATOR_HEIGHT >= 200 && VM_CURATOR_HEIGHT <= 16384 )); then
+            VM_CURATOR_VIDEO_ARGS=(-device "${{VM_CURATOR_VIDEO_DEVICE}},xres=${{VM_CURATOR_WIDTH}},yres=${{VM_CURATOR_HEIGHT}}")
+        fi
+    fi
+fi
+{WINDOW_SIZE_MARKER_END}"#,
+        shell_quote(spec.override_device),
+        shell_array_literal(spec)
+    )
+}
+
+fn shell_array_literal(spec: &VideoOverrideSpec) -> String {
+    format!(
+        "({} {})",
+        shell_quote(spec.default_flag),
+        shell_quote(spec.default_value)
+    )
+}
+
+fn push_video_args_reference_line(output: &mut String, line: &str) {
+    let indent_len = line.len() - line.trim_start().len();
+    let indent = &line[..indent_len];
+    let has_continuation = line.trim_end().ends_with('\\');
+    output.push_str(indent);
+    output.push_str(VIDEO_ARGS_ARRAY_REF);
+    if has_continuation {
+        output.push_str(" \\");
+    }
+}
+
+fn patch_window_size_override(content: &str) -> Option<String> {
+    if content.contains("VM_CURATOR_VIDEO_ARGS") {
+        return None;
+    }
+
+    let mut first_case_line = None;
+    let mut first_qemu_line = None;
+    let mut first_spec = None;
+    let mut matching_line_indices = Vec::new();
+
+    for (index, line) in content.lines().enumerate() {
+        if first_case_line.is_none() && line.trim_start().starts_with("case ") {
+            first_case_line = Some(index);
+        }
+        if first_qemu_line.is_none() && line.contains("qemu-system") {
+            first_qemu_line = Some(index);
+        }
+
+        if let Some(spec) = parse_supported_video_arg_line(line) {
+            if let Some(existing) = first_spec {
+                if spec != existing {
+                    return None;
+                }
+            } else {
+                first_spec = Some(spec);
+            }
+            matching_line_indices.push(index);
+        }
+    }
+
+    let first_spec = first_spec?;
+    let insert_before = first_case_line.or(first_qemu_line)?;
+
+    let setup_block = window_size_setup_block(&first_spec);
+    let mut matching_line_indices = matching_line_indices.into_iter().peekable();
+    let mut patched = String::with_capacity(content.len() + setup_block.len() + 1);
+    let mut wrote_line = false;
+
+    for (index, line) in content.lines().enumerate() {
+        if index == insert_before {
+            if wrote_line {
+                patched.push('\n');
+            }
+            patched.push_str(&setup_block);
+            wrote_line = true;
+        }
+
+        if wrote_line {
+            patched.push('\n');
+        }
+
+        if matches!(matching_line_indices.peek(), Some(line_index) if *line_index == index) {
+            matching_line_indices.next();
+            push_video_args_reference_line(&mut patched, line);
+        } else {
+            patched.push_str(line);
+        }
+        wrote_line = true;
+    }
+
+    if content.ends_with('\n') {
+        patched.push('\n');
+    }
+    Some(patched)
+}
+
+fn ensure_window_size_override_in_script(script_path: &Path) -> Result<()> {
+    let content = std::fs::read_to_string(script_path)
+        .with_context(|| format!("Failed to read launch script: {}", script_path.display()))?;
+
+    let Some(patched) = patch_window_size_override(&content) else {
+        return Ok(());
+    };
+
+    std::fs::write(script_path, patched)
+        .with_context(|| format!("Failed to write launch script: {}", script_path.display()))?;
     Ok(())
 }
 

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -15,6 +15,7 @@ pub use lifecycle::{
     detect_qemu_processes, force_stop_vm, launch_vm_sync, launch_vm_with_error_check,
     load_pci_passthrough, load_shared_folders, load_usb_passthrough, save_shared_folders,
     save_usb_passthrough, stop_vm_by_pid, LaunchOptions, QemuProcess, SharedFolder, UsbPassthrough,
+    WindowSize,
 };
 pub use qemu_config::{BootMode, QemuConfig};
 pub use single_gpu_scripts::generate_single_gpu_scripts;

--- a/src/vm/tests/create.rs
+++ b/src/vm/tests/create.rs
@@ -65,6 +65,101 @@ fn test_generate_launch_script() {
     assert!(script.contains("--install"));
     assert!(script.contains("--cdrom"));
     assert!(script.contains("--recovery"));
+    assert!(script.contains("VM_CURATOR_WINDOW_SIZE"));
+    assert!(script.contains("VM_CURATOR_VIDEO_ARGS=(-vga std)"));
+    assert!(script.contains("\"${VM_CURATOR_VIDEO_ARGS[@]}\""));
+}
+
+#[test]
+fn test_generate_video_args_setup_overrides_supported_vga() {
+    let config = WizardQemuConfig {
+        vga: "virtio".to_string(),
+        ..WizardQemuConfig::default()
+    };
+    let setup = generate_video_args_setup(&config);
+
+    assert!(setup.contains("VM_CURATOR_VIDEO_DEVICE=virtio-vga"));
+    assert!(setup.contains("VM_CURATOR_VIDEO_ARGS=(-vga virtio)"));
+    assert!(
+        setup.contains(
+            "VM_CURATOR_VIDEO_ARGS=(-device \"${VM_CURATOR_VIDEO_DEVICE},xres=${VM_CURATOR_WIDTH},yres=${VM_CURATOR_HEIGHT}\")"
+        ),
+        "{setup}"
+    );
+}
+
+#[test]
+fn test_generate_video_args_setup_keeps_unsupported_vga_without_override_device() {
+    let config = WizardQemuConfig {
+        vga: "cirrus".to_string(),
+        ..WizardQemuConfig::default()
+    };
+    let setup = generate_video_args_setup(&config);
+
+    assert!(setup.contains("VM_CURATOR_VIDEO_DEVICE=\n"));
+    assert!(setup.contains("VM_CURATOR_VIDEO_ARGS=(-vga cirrus)"));
+}
+
+#[test]
+fn test_generate_video_args_setup_uses_gl_device_when_enabled() {
+    let config = WizardQemuConfig {
+        vga: "virtio".to_string(),
+        gl_acceleration: true,
+        ..WizardQemuConfig::default()
+    };
+    let setup = generate_video_args_setup(&config);
+
+    assert!(setup.contains("VM_CURATOR_VIDEO_DEVICE=virtio-vga-gl"));
+    assert!(setup.contains("VM_CURATOR_VIDEO_ARGS=(-device virtio-vga-gl)"));
+}
+
+fn eval_video_args_setup(setup: &str, window_size: Option<&str>) -> Vec<String> {
+    let script = format!("{setup}\nprintf '%s\\n' \"${{VM_CURATOR_VIDEO_ARGS[@]}}\"\n");
+    let mut command = std::process::Command::new("bash");
+    command.arg("-c").arg(script);
+    if let Some(window_size) = window_size {
+        command.env("VM_CURATOR_WINDOW_SIZE", window_size);
+    } else {
+        command.env_remove("VM_CURATOR_WINDOW_SIZE");
+    }
+
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    String::from_utf8(output.stdout)
+        .unwrap()
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+#[test]
+fn test_generate_video_args_setup_runtime_override_behavior() {
+    let config = WizardQemuConfig {
+        vga: "virtio".to_string(),
+        ..WizardQemuConfig::default()
+    };
+    let setup = generate_video_args_setup(&config);
+
+    assert_eq!(
+        eval_video_args_setup(&setup, Some("1600x900")),
+        vec![
+            "-device".to_string(),
+            "virtio-vga,xres=1600,yres=900".to_string()
+        ]
+    );
+    assert_eq!(
+        eval_video_args_setup(&setup, Some("100x100")),
+        vec!["-vga".to_string(), "virtio".to_string()]
+    );
+    assert_eq!(
+        eval_video_args_setup(&setup, None),
+        vec!["-vga".to_string(), "virtio".to_string()]
+    );
 }
 
 #[test]
@@ -100,7 +195,7 @@ fn test_build_qemu_command_basic() {
     assert!(cmd.contains("-enable-kvm"));
     assert!(cmd.contains("-m 2048M"));
     assert!(cmd.contains("-smp 2"));
-    assert!(cmd.contains("-vga std"));
+    assert!(cmd.contains("\"${VM_CURATOR_VIDEO_ARGS[@]}\""));
     assert!(cmd.contains("-display gtk"));
     assert!(cmd.contains("-device e1000"));
     assert!(cmd.contains("-usb"));
@@ -777,8 +872,10 @@ fn test_spice_agent_channel_with_gl_acceleration() {
         ..WizardQemuConfig::default()
     };
     let cmd = build_qemu_command_with_os(&config, "disk.qcow2", &InstallMedia::None, None, None);
+    let setup = generate_video_args_setup(&config);
 
-    assert!(cmd.contains("-device virtio-vga-gl"), "GL device present");
+    assert!(cmd.contains("\"${VM_CURATOR_VIDEO_ARGS[@]}\""));
+    assert!(setup.contains("VM_CURATOR_VIDEO_ARGS=(-device virtio-vga-gl)"));
     assert!(
         cmd.contains("-display spice-app,gl=on"),
         "gl display present"

--- a/src/vm/tests/launch_parser.rs
+++ b/src/vm/tests/launch_parser.rs
@@ -23,6 +23,10 @@ fn test_extract_emulator() {
 fn test_extract_vga() {
     assert_eq!(extract_vga("-vga cirrus -m 512"), Some(VgaType::Cirrus));
     assert_eq!(extract_vga("-vga virtio"), Some(VgaType::Virtio));
+    assert_eq!(
+        extract_vga("VM_CURATOR_VIDEO_ARGS=(-vga std)"),
+        Some(VgaType::Std)
+    );
 }
 
 #[test]

--- a/src/vm/tests/lifecycle.rs
+++ b/src/vm/tests/lifecycle.rs
@@ -20,6 +20,301 @@ fn test_replace_display_for_dbus_strips_spice_agent_channel() {
 }
 
 #[test]
+fn test_window_size_parse_accepts_common_format() {
+    assert_eq!(
+        WindowSize::parse(" 1440x900 "),
+        Some(WindowSize {
+            width: 1440,
+            height: 900,
+        })
+    );
+    assert_eq!(
+        WindowSize::parse("1920X1080"),
+        Some(WindowSize {
+            width: 1920,
+            height: 1080,
+        })
+    );
+}
+
+#[test]
+fn test_window_size_parse_rejects_invalid_values() {
+    assert_eq!(WindowSize::parse("1440"), None);
+    assert_eq!(WindowSize::parse("1440x"), None);
+    assert_eq!(WindowSize::parse("100x100"), None);
+}
+
+fn test_vm(vm_dir: &std::path::Path) -> DiscoveredVm {
+    DiscoveredVm {
+        id: "test-vm".to_string(),
+        path: vm_dir.to_path_buf(),
+        launch_script: vm_dir.join("launch.sh"),
+        config: crate::vm::QemuConfig::default(),
+        custom_name: None,
+        os_profile: None,
+        notes: None,
+    }
+}
+
+#[test]
+fn test_build_launch_invocation_sets_window_size_env() {
+    let dir = tempfile::tempdir().unwrap();
+    let vm = test_vm(dir.path());
+    let options = LaunchOptions {
+        window_size: WindowSize::parse("1440x900"),
+        extra_args: vec!["--dry-run".to_string()],
+        ..LaunchOptions::default()
+    };
+
+    let invocation = build_launch_invocation(&vm, &options).unwrap();
+
+    assert_eq!(invocation.program, "bash");
+    assert_eq!(invocation.current_dir, vm.path);
+    assert_eq!(
+        invocation.args[0],
+        vm.launch_script.to_string_lossy().to_string()
+    );
+    assert!(invocation.args.contains(&"--dry-run".to_string()));
+    assert_eq!(
+        invocation.env,
+        vec![(
+            "VM_CURATOR_WINDOW_SIZE".to_string(),
+            Some("1440x900".to_string())
+        )]
+    );
+}
+
+#[test]
+fn test_build_launch_invocation_removes_window_size_env_when_unset() {
+    let dir = tempfile::tempdir().unwrap();
+    let vm = test_vm(dir.path());
+
+    let invocation = build_launch_invocation(&vm, &LaunchOptions::default()).unwrap();
+
+    assert_eq!(
+        invocation.env,
+        vec![("VM_CURATOR_WINDOW_SIZE".to_string(), None)]
+    );
+}
+
+#[test]
+fn test_build_launch_invocation_validates_boot_media_before_spawning() {
+    let dir = tempfile::tempdir().unwrap();
+    let vm = test_vm(dir.path());
+    let options = LaunchOptions {
+        boot_mode: BootMode::Cdrom(dir.path().join("missing.iso")),
+        ..LaunchOptions::default()
+    };
+
+    let err = build_launch_invocation(&vm, &options).unwrap_err();
+
+    assert!(err.contains("ISO file not found"));
+}
+
+#[test]
+fn test_patch_window_size_override_migrates_existing_vga_script() {
+    let script = r#"#!/bin/bash
+VM_DIR="$(dirname "$(readlink -f "$0")")"
+DISK="$VM_DIR/test.qcow2"
+
+case "$1" in
+    "")
+        qemu-system-x86_64 \
+        -m 2048M \
+        -vga std \
+        -display gtk
+        ;;
+esac
+"#;
+    let expected = r#"#!/bin/bash
+VM_DIR="$(dirname "$(readlink -f "$0")")"
+DISK="$VM_DIR/test.qcow2"
+
+# >>> Window size override (managed by vm-curator) >>>
+VM_CURATOR_VIDEO_DEVICE=VGA
+VM_CURATOR_VIDEO_ARGS=(-vga std)
+if [[ -n "${VM_CURATOR_WINDOW_SIZE:-}" && -n "$VM_CURATOR_VIDEO_DEVICE" ]]; then
+    if [[ "$VM_CURATOR_WINDOW_SIZE" =~ ^([0-9]+)[xX]([0-9]+)$ ]]; then
+        VM_CURATOR_WIDTH="${BASH_REMATCH[1]}"
+        VM_CURATOR_HEIGHT="${BASH_REMATCH[2]}"
+        if (( VM_CURATOR_WIDTH >= 320 && VM_CURATOR_WIDTH <= 16384 && VM_CURATOR_HEIGHT >= 200 && VM_CURATOR_HEIGHT <= 16384 )); then
+            VM_CURATOR_VIDEO_ARGS=(-device "${VM_CURATOR_VIDEO_DEVICE},xres=${VM_CURATOR_WIDTH},yres=${VM_CURATOR_HEIGHT}")
+        fi
+    fi
+fi
+# <<< Window size override (managed by vm-curator) <<<
+case "$1" in
+    "")
+        qemu-system-x86_64 \
+        -m 2048M \
+        "${VM_CURATOR_VIDEO_ARGS[@]}" \
+        -display gtk
+        ;;
+esac
+"#;
+
+    let patched = patch_window_size_override(script).expect("vga script should be patchable");
+
+    assert_eq!(patched, expected);
+    assert!(patch_window_size_override(&patched).is_none());
+}
+
+#[test]
+fn test_patch_window_size_override_migrates_existing_gl_device_script() {
+    let script = r#"#!/bin/bash
+qemu-system-x86_64 \
+    -device virtio-vga-gl \
+    -display gtk,gl=on
+"#;
+    let expected = r#"#!/bin/bash
+# >>> Window size override (managed by vm-curator) >>>
+VM_CURATOR_VIDEO_DEVICE=virtio-vga-gl
+VM_CURATOR_VIDEO_ARGS=(-device virtio-vga-gl)
+if [[ -n "${VM_CURATOR_WINDOW_SIZE:-}" && -n "$VM_CURATOR_VIDEO_DEVICE" ]]; then
+    if [[ "$VM_CURATOR_WINDOW_SIZE" =~ ^([0-9]+)[xX]([0-9]+)$ ]]; then
+        VM_CURATOR_WIDTH="${BASH_REMATCH[1]}"
+        VM_CURATOR_HEIGHT="${BASH_REMATCH[2]}"
+        if (( VM_CURATOR_WIDTH >= 320 && VM_CURATOR_WIDTH <= 16384 && VM_CURATOR_HEIGHT >= 200 && VM_CURATOR_HEIGHT <= 16384 )); then
+            VM_CURATOR_VIDEO_ARGS=(-device "${VM_CURATOR_VIDEO_DEVICE},xres=${VM_CURATOR_WIDTH},yres=${VM_CURATOR_HEIGHT}")
+        fi
+    fi
+fi
+# <<< Window size override (managed by vm-curator) <<<
+qemu-system-x86_64 \
+    "${VM_CURATOR_VIDEO_ARGS[@]}" \
+    -display gtk,gl=on
+"#;
+
+    let patched =
+        patch_window_size_override(script).expect("virtio-vga-gl script should be patchable");
+
+    assert_eq!(patched, expected);
+    assert!(patch_window_size_override(&patched).is_none());
+}
+
+#[test]
+fn test_patch_window_size_override_leaves_unsupported_or_mixed_video_unchanged() {
+    let unsupported = r#"#!/bin/bash
+qemu-system-x86_64 \
+    -vga cirrus \
+    -display gtk
+"#;
+    assert!(patch_window_size_override(unsupported).is_none());
+
+    let mixed = r#"#!/bin/bash
+case "$1" in
+    --install)
+        qemu-system-x86_64 \
+        -vga std
+        ;;
+    "")
+        qemu-system-x86_64 \
+        -vga virtio
+        ;;
+esac
+"#;
+    assert!(patch_window_size_override(mixed).is_none());
+}
+
+#[test]
+fn test_parse_supported_video_arg_line_parses_supported_video_forms() {
+    let cases = [
+        ("-vga std", "-vga", "std", "VGA"),
+        ("        -vga virtio \\", "-vga", "virtio", "virtio-vga"),
+        ("-vga 'qxl'", "-vga", "qxl", "qxl-vga"),
+        ("-device VGA", "-device", "VGA", "VGA"),
+        (
+            "    -device virtio-vga \\",
+            "-device",
+            "virtio-vga",
+            "virtio-vga",
+        ),
+        (
+            "-device \"virtio-vga-gl\"",
+            "-device",
+            "virtio-vga-gl",
+            "virtio-vga-gl",
+        ),
+        ("-device 'qxl-vga'", "-device", "qxl-vga", "qxl-vga"),
+    ];
+
+    for (line, default_flag, default_value, override_device) in cases {
+        let spec = parse_supported_video_arg_line(line)
+            .unwrap_or_else(|| panic!("expected supported video arg line: {line}"));
+
+        assert_eq!(spec.default_flag, default_flag);
+        assert_eq!(spec.default_value, default_value);
+        assert_eq!(spec.override_device, override_device);
+    }
+}
+
+#[test]
+fn test_parse_supported_video_arg_line_rejects_unsupported_forms() {
+    for line in [
+        "",
+        "   ",
+        "# -vga std",
+        "-vga cirrus",
+        "-vga std extra",
+        "-device cirrus-vga",
+        "-device virtio-vga,hostmem=256M",
+        "-device virtio-vga extra",
+    ] {
+        assert!(
+            parse_supported_video_arg_line(line).is_none(),
+            "expected unsupported video arg line: {line}"
+        );
+    }
+}
+
+#[test]
+fn test_ensure_window_size_override_in_script_writes_patched_script() {
+    let script = r#"#!/bin/bash
+qemu-system-x86_64 \
+    -vga std \
+    -display gtk
+"#;
+    let expected = patch_window_size_override(script).expect("vga script should be patchable");
+    let dir = tempfile::tempdir().expect("create temp dir for launch script");
+    let script_path = dir.path().join("launch.sh");
+    std::fs::write(&script_path, script).expect("write launch script fixture");
+
+    ensure_window_size_override_in_script(&script_path).expect("patch launch script on disk");
+
+    let patched = std::fs::read_to_string(&script_path).expect("read patched launch script");
+    assert_eq!(patched, expected);
+}
+
+#[test]
+fn test_ensure_window_size_override_in_script_leaves_unsupported_script_unchanged() {
+    let script = r#"#!/bin/bash
+qemu-system-x86_64 \
+    -vga cirrus \
+    -display gtk
+"#;
+    let dir = tempfile::tempdir().expect("create temp dir for launch script");
+    let script_path = dir.path().join("launch.sh");
+    std::fs::write(&script_path, script).expect("write launch script fixture");
+
+    ensure_window_size_override_in_script(&script_path)
+        .expect("leave unsupported script unchanged");
+
+    let actual = std::fs::read_to_string(&script_path).expect("read launch script");
+    assert_eq!(actual, script);
+}
+
+#[test]
+fn test_ensure_window_size_override_in_script_reports_missing_script() {
+    let dir = tempfile::tempdir().expect("create temp dir for launch script");
+    let script_path = dir.path().join("missing-launch.sh");
+
+    let err = ensure_window_size_override_in_script(&script_path)
+        .expect_err("missing launch script should return an error");
+
+    assert!(err.to_string().contains("Failed to read launch script"));
+}
+
+#[test]
 fn test_generate_shared_folders_section_empty() {
     let section = generate_shared_folders_section(&[], "virtio-9p-pci");
     assert!(section.is_empty());


### PR DESCRIPTION
## Summary

- add an optional default window size setting in WIDTHxHEIGHT format
- pass the configured size to VM launch scripts through the environment
- generate and migrate supported VGA/device launch scripts while leaving unsupported or mixed video setups unchanged
- cover configuration, settings UI, script generation, migration, and launch behavior

Split from #57 for separate evaluation as requested.

## Testing

- cargo fmt --all -- --check
- cargo test