### PR TITLE
fix: allow typing 'q' while editing a Settings value

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -528,6 +528,7 @@ fn handle_key(app: &mut App, key: KeyEvent) -> Result<()> {
                 | Screen::NetworkSettings
                 | Screen::ImportWizard
         )
+        && !(matches!(app.screen, Screen::Settings) && app.settings_editing)
     {
         app.should_quit = true;
         return Ok(());


### PR DESCRIPTION
Fixes #72.

## Problem
Typing any value containing `q` (e.g. a path like `~/qemu-vms`) into the **VM Library Path** or **Default ISO Path** fields in Settings immediately quit the application.

## Root cause
The global q/Q quit handler in `src/ui/mod.rs` exempts screens that accept free text (Search, TextInput, EditNotes, NetworkSettings, …), but `Screen::Settings` was missing from the list — even though the Settings screen has an inline edit mode that appends typed characters to `settings_edit_buffer`. The global check ran first and quit the app before the keystroke reached the buffer.

## Fix
Exempt the Settings screen from the global quit key only while `settings_editing` is active. `q` still quits when just browsing the settings list.

Also audited the other screens for the same gap: `CreateWizardDownload` is the only other non-exempt overlay, and it accepts no free-text input (Esc only), so no further changes needed.

## Testing
- `cargo test`: 194 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)