### PR TITLE
feat: per-VM Hide KVM toggle for single-GPU passthrough

### DIFF
--- a/src/hardware/single_gpu.rs
+++ b/src/hardware/single_gpu.rs
@@ -109,6 +109,10 @@ pub struct SingleGpuConfig {
     /// Optional path to a GPU vBIOS ROM, emitted as `romfile=` on the passed-through
     /// GPU. Frequently required for AMD single-GPU passthrough to produce video (#44).
     pub gpu_rom: Option<String>,
+    /// Hide the hypervisor from the guest (`kvm=off,hv_vendor_id=...` on `-cpu`).
+    /// NVIDIA drivers historically refused to run in a VM without this; modern AMD
+    /// (RDNA3/4) Windows drivers black-screen or Code 43 without it too (#71).
+    pub hide_kvm: bool,
 }
 
 impl SingleGpuConfig {
@@ -119,6 +123,7 @@ impl SingleGpuConfig {
         let original_driver = detect_gpu_driver(&gpu);
         let display_manager = detect_display_manager();
 
+        let hide_kvm = default_hide_kvm(&gpu);
         Self {
             gpu,
             audio,
@@ -126,6 +131,7 @@ impl SingleGpuConfig {
             original_driver,
             display_manager,
             gpu_rom: None,
+            hide_kvm,
         }
     }
 
@@ -137,6 +143,12 @@ impl SingleGpuConfig {
         }
         addrs
     }
+}
+
+/// Default for [`SingleGpuConfig::hide_kvm`]: on for NVIDIA and AMD GPUs, whose
+/// Windows drivers misbehave when they detect a hypervisor (#71).
+fn default_hide_kvm(gpu: &PciDevice) -> bool {
+    gpu.is_nvidia() || gpu.is_amd()
 }
 
 /// Detect the currently running display manager
@@ -393,6 +405,7 @@ pub fn save_config(vm_path: &Path, config: &SingleGpuConfig) -> anyhow::Result<(
     if let Some(ref rom) = config.gpu_rom {
         content.push_str(&format!("gpu_rom = \"{}\"\n", rom.replace('"', "\\\"")));
     }
+    content.push_str(&format!("hide_kvm = {}\n", config.hide_kvm));
 
     fs::write(&config_path, content)?;
     Ok(())
@@ -430,6 +443,7 @@ pub fn load_config(vm_path: &Path) -> Option<SingleGpuConfig> {
     let mut original_driver = String::new();
     let mut display_manager = String::new();
     let mut gpu_rom: Option<String> = None;
+    let mut hide_kvm: Option<bool> = None;
 
     let mut current_section = "";
 
@@ -476,6 +490,7 @@ pub fn load_config(vm_path: &Path) -> Option<SingleGpuConfig> {
                     "original_driver" => original_driver = value.to_string(),
                     "display_manager" => display_manager = value.to_string(),
                     "gpu_rom" => gpu_rom = Some(value.to_string()),
+                    "hide_kvm" => hide_kvm = Some(value == "true"),
                     _ => {}
                 },
                 _ => {}
@@ -531,6 +546,9 @@ pub fn load_config(vm_path: &Path) -> Option<SingleGpuConfig> {
         other => DisplayManager::Unknown(other.to_string()),
     };
 
+    // Configs written before #71 lack the key; fall back to the vendor default.
+    let hide_kvm = hide_kvm.unwrap_or_else(|| default_hide_kvm(&gpu));
+
     Some(SingleGpuConfig {
         gpu,
         audio,
@@ -538,6 +556,7 @@ pub fn load_config(vm_path: &Path) -> Option<SingleGpuConfig> {
         original_driver,
         display_manager,
         gpu_rom,
+        hide_kvm,
     })
 }
 

--- a/src/hardware/tests/single_gpu.rs
+++ b/src/hardware/tests/single_gpu.rs
@@ -41,6 +41,7 @@ fn gpu_rom_round_trips_through_config_file() {
         original_driver: GpuDriver::Amdgpu,
         display_manager: DisplayManager::Gdm,
         gpu_rom: Some("/home/user/vbios.rom".to_string()),
+        hide_kvm: true,
     };
 
     // A set ROM round-trips.
@@ -57,6 +58,97 @@ fn gpu_rom_round_trips_through_config_file() {
     save_config(&dir, &config_none).unwrap();
     let loaded_none = load_config(&dir).expect("config should load");
     assert_eq!(loaded_none.gpu_rom, None);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Issue #71: hide_kvm must round-trip through the config file — in particular
+/// an explicit `false` must survive, since the AMD/NVIDIA default is `true`.
+#[test]
+fn hide_kvm_round_trips_through_config_file() {
+    use crate::hardware::PciDevice;
+
+    let dir = std::env::temp_dir().join(format!(
+        "vmcurator_sgpu_hidekvm_test_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let gpu = PciDevice {
+        address: "0000:03:00.0".to_string(),
+        vendor_id: 0x1002,
+        device_id: 0x7550,
+        vendor_name: "AMD/ATI".to_string(),
+        device_name: "Radeon RX 9070 XT".to_string(),
+        class_code: 0x030000,
+        driver: Some("amdgpu".to_string()),
+        iommu_group: Some(12),
+        is_boot_vga: true,
+        subsystem_vendor_id: 0,
+        subsystem_device_id: 0,
+    };
+    let config = SingleGpuConfig {
+        gpu,
+        audio: None,
+        iommu_group_devices: Vec::new(),
+        original_driver: GpuDriver::Amdgpu,
+        display_manager: DisplayManager::Sddm,
+        gpu_rom: None,
+        hide_kvm: false,
+    };
+
+    save_config(&dir, &config).unwrap();
+    let loaded = load_config(&dir).expect("config should load");
+    assert!(!loaded.hide_kvm, "explicit hide_kvm=false must round-trip");
+
+    let config_on = SingleGpuConfig {
+        hide_kvm: true,
+        ..config
+    };
+    save_config(&dir, &config_on).unwrap();
+    let loaded_on = load_config(&dir).expect("config should load");
+    assert!(loaded_on.hide_kvm);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Configs written before #71 have no hide_kvm key; loading one must fall back
+/// to the vendor default (on for AMD/NVIDIA GPUs).
+#[test]
+fn hide_kvm_defaults_on_when_missing_from_config_file() {
+    let dir = std::env::temp_dir().join(format!(
+        "vmcurator_sgpu_hidekvm_compat_test_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    // A pre-#71 config file: [settings] has no hide_kvm key.
+    std::fs::write(
+        dir.join("single-gpu-config.toml"),
+        r#"[gpu]
+address = "0000:03:00.0"
+vendor_id = "0x1002"
+device_id = "0x7550"
+vendor_name = "AMD/ATI"
+device_name = "Radeon RX 9070 XT"
+class_code = "0x030000"
+driver = "amdgpu"
+is_boot_vga = true
+
+[settings]
+original_driver = "amdgpu"
+display_manager = "sddm"
+"#,
+    )
+    .unwrap();
+
+    let loaded = load_config(&dir).expect("config should load");
+    assert!(
+        loaded.hide_kvm,
+        "AMD GPU without the key must default to on"
+    );
 
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/src/ui/screens/single_gpu_setup.rs
+++ b/src/ui/screens/single_gpu_setup.rs
@@ -227,6 +227,18 @@ fn render_gpu_info(app: &App, frame: &mut Frame, area: Rect) {
             Span::styled(rom_text, Style::default().fg(rom_color)),
         ]));
 
+        // Hide KVM (#71) — kvm=off + hv_vendor_id so NVIDIA/AMD Windows drivers
+        // don't refuse to run inside a visible hypervisor
+        let (kvm_text, kvm_color) = if config.hide_kvm {
+            ("On — kvm=off,hv_vendor_id ([h] to toggle)", Color::Green)
+        } else {
+            ("Off ([h] to toggle)", Color::DarkGray)
+        };
+        lines.push(Line::from(vec![
+            Span::styled("Hide KVM: ", Style::default().fg(Color::White)),
+            Span::styled(kvm_text, Style::default().fg(kvm_color)),
+        ]));
+
         // Integrated GPUs (APUs) are the riskiest case: unbinding them can hang
         // or power off the host, and guest video needs a vBIOS from the
         // machine's own BIOS image (#61).
@@ -326,7 +338,7 @@ fn render_scripts_info(app: &App, frame: &mut Frame, area: Rect) {
 /// Render help text
 fn render_help(_app: &App, frame: &mut Frame, area: Rect) {
     let help =
-        Paragraph::new("[g] Generate  [d] Delete  [r] Set vBIOS ROM  [R] Clear ROM  [Esc] Back")
+        Paragraph::new("[g] Generate  [d] Delete  [r/R] Set/Clear vBIOS  [h] Hide KVM  [Esc] Back")
             .style(Style::default().fg(Color::DarkGray))
             .alignment(Alignment::Center);
     frame.render_widget(help, area);
@@ -443,6 +455,29 @@ pub fn handle_key(app: &mut App, key: KeyEvent) -> anyhow::Result<()> {
             if app.single_gpu_config.is_some() {
                 app.load_file_browser(crate::app::FileBrowserMode::SingleGpuRom);
                 app.push_screen(Screen::FileBrowser);
+            } else {
+                app.set_status("No GPU configured for passthrough");
+            }
+        }
+        KeyCode::Char('h') | KeyCode::Char('H') => {
+            // Toggle hiding the hypervisor from the guest (#71)
+            let toggled = if let Some(ref mut config) = app.single_gpu_config {
+                config.hide_kvm = !config.hide_kvm;
+                Some(config.hide_kvm)
+            } else {
+                None
+            };
+            if let Some(enabled) = toggled {
+                if let (Some(vm), Some(config)) =
+                    (app.selected_vm(), app.single_gpu_config.as_ref())
+                {
+                    let _ = crate::hardware::save_config(&vm.path, config);
+                }
+                app.set_status(if enabled {
+                    "Hide KVM on — regenerate scripts ([g]) to apply"
+                } else {
+                    "Hide KVM off — regenerate scripts ([g]) to apply"
+                });
             } else {
                 app.set_status("No GPU configured for passthrough");
             }
@@ -582,11 +617,13 @@ pub fn init_single_gpu_config(app: &mut App) {
 
     if let Some(gpu) = gpu {
         let mut config = SingleGpuConfig::new(gpu, &app.pci_devices);
-        // Carry over a previously-saved vBIOS ROM path (#44) so it survives
-        // re-entry; the rest of the config is re-detected from live hardware.
+        // Carry over previously-saved user choices (#44 vBIOS ROM, #71 hide-KVM)
+        // so they survive re-entry; the rest of the config is re-detected from
+        // live hardware.
         if let Some(vm) = app.selected_vm() {
             if let Some(saved) = crate::hardware::load_config(&vm.path) {
                 config.gpu_rom = saved.gpu_rom;
+                config.hide_kvm = saved.hide_kvm;
             }
         }
         app.single_gpu_config = Some(config);

--- a/src/vm/single_gpu_scripts.rs
+++ b/src/vm/single_gpu_scripts.rs
@@ -84,6 +84,12 @@ use crate::hardware::SingleGpuConfig;
 use crate::vm::lifecycle::{load_pci_passthrough, load_usb_passthrough};
 use crate::vm::DiscoveredVm;
 
+/// CPU flags that hide the hypervisor from the guest (#71). `kvm=off` masks the
+/// KVM CPUID signature and `hv_vendor_id` replaces the Hyper-V vendor string
+/// (the value is arbitrary); the hv_* enlightenments keep Windows responsive.
+const HIDE_KVM_CPU_FLAGS: &str =
+    "host,kvm=off,hv_vendor_id=AuthenticAMD,hv_relaxed,hv_spinlocks=0x1fff,hv_vapic,hv_time";
+
 /// Generated scripts for single GPU passthrough
 #[derive(Debug)]
 pub struct GeneratedScripts {
@@ -1318,10 +1324,11 @@ fn extract_qemu_command_for_passthrough(
         passthrough_args.push(pci_arg.clone());
     }
 
-    // Add NVIDIA CPU flags if NVIDIA GPU
-    let nvidia_cpu_flags = if config.gpu.is_nvidia() {
-        // These flags help with NVIDIA driver compatibility
-        Some("-cpu host,kvm=off,hv_vendor_id=AuthenticAMD,hv_relaxed,hv_spinlocks=0x1fff,hv_vapic,hv_time".to_string())
+    // Hide the hypervisor from the guest if configured (#71): NVIDIA drivers
+    // historically refused to run in a VM without this, and modern AMD (RDNA3/4)
+    // Windows drivers black-screen or Code 43 without it too.
+    let hide_kvm_cpu_flags = if config.hide_kvm {
+        Some(format!("-cpu {}", HIDE_KVM_CPU_FLAGS))
     } else {
         None
     };
@@ -1330,8 +1337,8 @@ fn extract_qemu_command_for_passthrough(
     let passthrough_str = passthrough_args.join(" \\\n    ");
     qemu_cmd = append_passthrough_args(&qemu_cmd, &passthrough_str);
 
-    // Replace -cpu host with NVIDIA flags if needed
-    if let Some(flags) = nvidia_cpu_flags {
+    // Replace -cpu host with hypervisor-hiding flags if needed
+    if let Some(flags) = hide_kvm_cpu_flags {
         if RE_CPU_HOST.is_match(&qemu_cmd) {
             qemu_cmd = RE_CPU_HOST.replace(&qemu_cmd, flags.as_str()).to_string();
         }
@@ -1384,9 +1391,9 @@ fn generate_basic_qemu_command(
     let memory = vm.config.memory_mb;
     let cpu_cores = vm.config.cpu_cores;
 
-    // Use NVIDIA CPU flags if NVIDIA GPU
-    let cpu_flags = if config.gpu.is_nvidia() {
-        "host,kvm=off,hv_vendor_id=AuthenticAMD,hv_relaxed,hv_spinlocks=0x1fff,hv_vapic,hv_time"
+    // Hide the hypervisor from the guest if configured (#71)
+    let cpu_flags = if config.hide_kvm {
+        HIDE_KVM_CPU_FLAGS
     } else {
         "host"
     };
@@ -1675,6 +1682,7 @@ mod tests {
             original_driver: GpuDriver::Amdgpu,
             display_manager: DisplayManager::Gdm,
             gpu_rom,
+            hide_kvm: true,
         }
     }
 
@@ -1695,6 +1703,57 @@ mod tests {
             gpu_passthrough_device(&amd_gpu_config(Some(String::new()))),
             expected
         );
+    }
+
+    /// Issue #71: with hide_kvm on, `-cpu host` in the parsed launch.sh must be
+    /// replaced with the hypervisor-hiding flags — for AMD GPUs too, not just
+    /// NVIDIA (modern AMD Windows drivers also refuse to run in a visible VM).
+    #[test]
+    fn hide_kvm_replaces_cpu_host_for_amd_gpu() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vm = test_vm_with_cpu_host(tmp.path());
+        let script = generate_start_script(&vm, &amd_gpu_config(None)).unwrap();
+
+        assert!(script.contains("kvm=off"), "kvm=off missing:\n{script}");
+        assert!(script.contains("hv_vendor_id="), "hv_vendor_id missing");
+        assert!(
+            !script.contains("-cpu host \\"),
+            "-cpu host left unreplaced"
+        );
+    }
+
+    /// With hide_kvm off, the guest CPU config must be left untouched.
+    #[test]
+    fn hide_kvm_off_leaves_cpu_host_untouched() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vm = test_vm_with_cpu_host(tmp.path());
+        let mut config = amd_gpu_config(None);
+        config.hide_kvm = false;
+        let script = generate_start_script(&vm, &config).unwrap();
+
+        assert!(!script.contains("kvm=off"));
+        assert!(!script.contains("hv_vendor_id="));
+        assert!(script.contains("-cpu host"));
+    }
+
+    /// Like test_vm, but the launch.sh sets `-cpu host` so the hide-KVM
+    /// replacement path is exercised.
+    fn test_vm_with_cpu_host(dir: &Path) -> DiscoveredVm {
+        let launch = dir.join("launch.sh");
+        fs::write(
+            &launch,
+            "#!/bin/bash\nqemu-system-x86_64 \\\n    -machine q35,accel=kvm \\\n    -cpu host \\\n    -m 4096 \\\n    -display sdl,gl=on \\\n    -device virtio-net-pci,netdev=net0\n",
+        )
+        .unwrap();
+        DiscoveredVm {
+            id: "test-vm".to_string(),
+            path: dir.to_path_buf(),
+            launch_script: launch,
+            config: Default::default(),
+            custom_name: None,
+            os_profile: None,
+            notes: None,
+        }
     }
 
     /// Build a minimal VM directory with a parseable launch.sh


### PR DESCRIPTION
Fixes #71 (continuation of #60).

## Problem
The reporter's RX 9070 XT Windows 11 guest showed Code 43 / black screen even with a vBIOS romfile. They proved via libvirt that adding `<kvm><hidden state="on"/></kvm>` and a Hyper-V `vendor_id` makes the AMD driver work — in raw QEMU terms, `-cpu host,kvm=off,hv_vendor_id=<anything>`.

vm-curator already emits exactly these flags in the generated single-GPU scripts, but only when the GPU is NVIDIA. That gating reflects old folklore that only NVIDIA drivers punish VM detection; modern AMD (RDNA3/4) Windows drivers misbehave too.

## Changes
- **`SingleGpuConfig.hide_kvm`** (new field): hides the hypervisor from the guest. Defaults to **on for both NVIDIA and AMD** GPUs, off otherwise. Persisted in `single-gpu-config.toml`; files written before this change lack the key and fall back to the vendor default on load.
- **Script generation** (`single_gpu_scripts.rs`): both the parsed-launch.sh path and the fallback path now key off `config.hide_kvm` instead of `gpu.is_nvidia()`. Flag string unchanged (`kvm=off,hv_vendor_id=AuthenticAMD,hv_relaxed,hv_spinlocks=0x1fff,hv_vapic,hv_time` — the vendor id value is arbitrary) and hoisted into a shared `HIDE_KVM_CPU_FLAGS` const.
- **Single GPU Setup screen**: new "Hide KVM" status line, `[h]` toggles it (saved immediately, same pattern as the `[r]`/`[R]` vBIOS handling), survives screen re-entry.

## Notes
- Defaulting AMD to **on** fixes the reported setup out of the box. For AMD *Linux* guests the only cost is losing KVM paravirt niceties (kvmclock etc.) — the guest still runs KVM-accelerated — and `[h]` turns it off for anyone who prefers that.
- Pre-existing limitation (unchanged): in the parsed-launch.sh path the flags are injected by replacing `-cpu host`, so a launch.sh with a different CPU model won't get them. Already true for NVIDIA today.

## Testing
- New tests: flag injection on AMD with the toggle on/off, config round-trip incl. explicit `false`, and pre-#71 config files defaulting to on.
- `cargo test`: 198 passed, 0 failed. Clippy clean, rustfmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)