### PR TITLE
fix: scope disk parsing to the default boot invocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ scripts/
 result
 result-*
 *.nix-tmp
+
+# AI stuff
+.claude/worktrees

--- a/src/vm/launch_parser.rs
+++ b/src/vm/launch_parser.rs
@@ -368,14 +368,74 @@ fn expand_variables(s: &str, vars: &HashMap<String, String>, vm_dir: &Path) -> S
     result
 }
 
+/// Extract the primary `qemu-system-*` invocation from the script, including
+/// its backslash-continuation lines.
+///
+/// vm-curator's own generated launch.sh files wrap several invocations (one
+/// per boot mode: `--install`, `--cdrom`, `--recovery`, `--floppy`, and the
+/// default normal boot) in a `case "$1" in ... esac`. The default/no-args
+/// branch - the configuration vm-curator treats as canonical - is always the
+/// last invocation emitted, right before the catch-all `*)` branch. Scoping
+/// per-invocation parsing (like disks) to that last block, rather than the
+/// whole file, avoids mixing in install/cdrom/recovery drives (e.g. `-drive
+/// file="$2"`) that belong to other branches.
+fn extract_primary_command_block(content: &str) -> &str {
+    let emulators = [
+        "qemu-system-x86_64",
+        "qemu-system-i386",
+        "qemu-system-ppc",
+        "qemu-system-m68k",
+        "qemu-system-arm",
+        "qemu-system-aarch64",
+    ];
+
+    // Byte ranges of each line (newline included) so the block can be sliced
+    // back out of `content` without reconstructing the text.
+    let mut lines = Vec::new();
+    let mut offset = 0usize;
+    for line in content.split_inclusive('\n') {
+        lines.push((offset, offset + line.len()));
+        offset += line.len();
+    }
+
+    let mut start_idx = None;
+    for (i, &(s, e)) in lines.iter().enumerate() {
+        let trimmed = content[s..e].trim_start();
+        if trimmed.starts_with('#') {
+            continue;
+        }
+        if emulators.iter().any(|em| trimmed.starts_with(em)) {
+            start_idx = Some(i);
+        }
+    }
+
+    let Some(start_idx) = start_idx else {
+        return content;
+    };
+
+    let mut end_idx = start_idx;
+    while content[lines[end_idx].0..lines[end_idx].1]
+        .trim_end()
+        .ends_with('\\')
+        && end_idx + 1 < lines.len()
+    {
+        end_idx += 1;
+    }
+
+    &content[lines[start_idx].0..lines[end_idx].1]
+}
+
 /// Extract disk configurations
 fn extract_disks(content: &str, vm_dir: &Path) -> Vec<DiskConfig> {
     let mut disks = Vec::new();
 
-    // First, parse all variable assignments
+    // Parse variable assignments from the whole script - DISK/ISO/etc. are
+    // typically assigned once near the top, outside any invocation block.
     let vars = extract_shell_variables(content, vm_dir);
 
-    for line in content.lines() {
+    let block = extract_primary_command_block(content);
+
+    for line in block.lines() {
         if line.trim_start().starts_with('#') {
             continue;
         }

--- a/src/vm/tests/launch_parser.rs
+++ b/src/vm/tests/launch_parser.rs
@@ -265,3 +265,44 @@ fn test_physical_device_path_not_resolved_relative() {
         PathBuf::from("/dev/nvme0n1")
     );
 }
+
+#[test]
+fn test_disks_scoped_to_default_boot_branch() {
+    // vm-curator-generated scripts wrap several qemu-system invocations (one
+    // per boot mode) in a `case "$1" in ... esac`, with the default no-args
+    // boot branch emitted last. Disk extraction must only look at that final
+    // invocation, not merge drives from --cdrom/--floppy branches that
+    // reference positional parameters like "$2".
+    let vm_dir = Path::new("/home/user/vms/openwrt");
+    let script_path = vm_dir.join("launch.sh");
+    let content = r#"#!/bin/bash
+VM_DIR="$(dirname "$(readlink -f "$0")")"
+DISK="$VM_DIR/openwrt.raw"
+OVMF_VARS="$VM_DIR/OVMF_VARS.fd"
+
+case "$1" in
+    --cdrom)
+        qemu-system-x86_64 \
+        -drive if=pflash,format=raw,file="$OVMF_VARS" \
+        -drive file="$DISK",format=raw,if=virtio,index=0,media=disk \
+        -drive file="$2",media=cdrom,index=1
+        ;;
+    "")
+        qemu-system-x86_64 \
+        -drive if=pflash,format=raw,readonly=on,file=/usr/share/edk2/x64/OVMF_CODE.4m.fd \
+        -drive if=pflash,format=raw,file="$OVMF_VARS" \
+        -drive file="$DISK",format=raw,if=virtio,index=0,media=disk
+        ;;
+esac
+"#;
+    let config = parse_launch_script(&script_path, content).unwrap();
+
+    assert_eq!(config.disks.len(), 3);
+    let paths: Vec<String> = config
+        .disks
+        .iter()
+        .map(|d| d.path.to_string_lossy().to_string())
+        .collect();
+    assert!(!paths.iter().any(|p| p.contains('$')));
+    assert!(paths.iter().any(|p| p.ends_with("openwrt.raw")));
+}


### PR DESCRIPTION
## Summary
- `extract_disks()` scanned the entire `launch.sh` for `-drive`/`-hd*` lines, so on vm-curator-generated scripts (which wrap `--install`/`--cdrom`/`--recovery`/`--floppy`/default boot modes in a `case` statement) it merged drives from every branch into one VM's disk list.
- This produced duplicated disk entries and, for branches referencing positional parameters like `-drive file="$2"`, a literal unresolved `$2` path — reproduced via `vm-curator info openwrt` on a VM with an OVMF+bridge-network launch script.
- Disk extraction is now scoped to the last `qemu-system-*` invocation in the script, which is always the default no-args boot branch vm-curator generates (the config actually launched by default).

## Test plan
- [x] `cargo test` (269 passed) — added `test_disks_scoped_to_default_boot_branch` covering a case-statement script with `--cdrom` and default branches
- [x] Manually verified `vm-curator info openwrt` now shows exactly 3 disks (OVMF code, OVMF vars, system disk) instead of 18 duplicated/garbled entries