### PR TITLE
fix: exclude vm-curator's bridges and taps from NetworkManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ scripts/
 result
 result-*
 *.nix-tmp
+
+# AI stuff
+.claude/worktrees

--- a/src/tests/vnet.rs
+++ b/src/tests/vnet.rs
@@ -161,6 +161,18 @@ fn down_script_reverses_everything() {
     assert!(script.contains(rule), "down script missing: {rule}");
 }
 
+#[test]
+fn up_script_marks_bridge_and_taps_unmanaged_by_networkmanager() {
+    // NetworkManager can silently deactivate a tap it doesn't know is
+    // supposed to stay bridged, detaching it from the bridge with no error
+    // anywhere. The bridge and any tap* device must be excluded up front.
+    let script = generate_up_script(&lab_nat());
+    assert!(script.contains("unmanaged-devices=interface-name:vmc-*;interface-name:tap*"));
+    assert!(script.contains("nmcli device set \"$BRIDGE\" managed no"));
+    // Idempotent: don't clobber the shared conf file on every network's up
+    assert!(script.contains("if [[ ! -f \"$NM_CONF\" ]]"));
+}
+
 /// Scripts come out of format! templates; have bash verify the syntax.
 #[test]
 fn generated_scripts_are_valid_bash() {

--- a/src/vnet.rs
+++ b/src/vnet.rs
@@ -336,6 +336,25 @@ ip link set "$BRIDGE" up
 mkdir -p /etc/qemu
 touch /etc/qemu/bridge.conf
 grep -qxF "allow $BRIDGE" /etc/qemu/bridge.conf || echo "allow $BRIDGE" >> /etc/qemu/bridge.conf
+
+# NetworkManager doesn't know this bridge or the per-VM taps QEMU attaches
+# to it later, and can "helpfully" deactivate one — silently detaching it
+# from the bridge with no error anywhere, breaking VM-to-VM connectivity.
+# Tell it to leave vm-curator's bridges and taps alone, system-wide.
+if command -v nmcli >/dev/null 2>&1; then
+    mkdir -p /etc/NetworkManager/conf.d
+    NM_CONF=/etc/NetworkManager/conf.d/vm-curator-unmanaged.conf
+    if [[ ! -f "$NM_CONF" ]]; then
+        cat > "$NM_CONF" <<'NMEOF'
+# Written by vm-curator: never manage its virtual-network bridges or the
+# per-VM tap devices QEMU attaches to them.
+[keyfile]
+unmanaged-devices=interface-name:vmc-*;interface-name:tap*
+NMEOF
+        nmcli general reload conf 2>/dev/null || systemctl reload NetworkManager 2>/dev/null || true
+    fi
+    nmcli device set "$BRIDGE" managed no 2>/dev/null || true
+fi
 "#,
         name = net.name,
         kind = net.kind.label(),


### PR DESCRIPTION
## Summary
- Root-caused a "VMs on the same managed network can't reach each other" issue: NetworkManager doesn't know about vm-curator's bridges or the per-VM tap devices QEMU's bridge-helper attaches to them at launch time. It can deactivate a tap it thinks is unconfigured, which silently detaches it from the bridge - no error anywhere, the VM just goes unreachable to its bridge-mates. Confirmed via kernel log (`port 1(tapN) entered disabled state` / left promiscuous+allmulticast mode) and `nmcli device status` showing the tap as `disconnected` while NetworkManager left a sibling tap alone as `connected (externally)`.
- `net-up.sh` now drops `/etc/NetworkManager/conf.d/vm-curator-unmanaged.conf` (an `unmanaged-devices` glob for `vmc-*` and `tap*`) on first run, reloads NetworkManager's config, and marks the bridge itself unmanaged immediately via `nmcli`. Guarded by `command -v nmcli` so it's a no-op on systems without NetworkManager. Idempotent - only writes the conf file if it doesn't already exist, so multiple networks' up-scripts don't clobber each other.
- Confirmed fix on a live system: applying the generated conf.d file + reattaching a detached tap restored connectivity between two VMs sharing an isolated managed network.

## Test plan
- [x] `cargo test` (269 passed) - added `up_script_marks_bridge_and_taps_unmanaged_by_networkmanager`, and the existing `generated_scripts_are_valid_bash` check covers the new heredoc block's bash syntax
- [x] Manually verified on a live host: NetworkManager had silently detached a VM's tap from its managed bridge; applying the generated `/etc/NetworkManager/conf.d/vm-curator-unmanaged.conf` and reattaching the tap restored VM-to-VM connectivity